### PR TITLE
rdb: support multiple 0x76 partitions on Emu68-style MBR images

### DIFF
--- a/amifuse/bootstrap.py
+++ b/amifuse/bootstrap.py
@@ -50,7 +50,7 @@ class SyntheticPartition:
 
 
 class BootstrapAllocator:
-    def __init__(self, vh, image_path: Path, block_size=512, partition=None, adf_info: Optional[ADFInfo] = None):
+    def __init__(self, vh, image_path: Path, block_size=512, partition=None, adf_info: Optional[ADFInfo] = None, mbr_partition_index=None):
         self.vh = vh
         self.alloc = vh.alloc
         self.mem = vh.alloc.get_mem()
@@ -58,11 +58,15 @@ class BootstrapAllocator:
         self.block_size = block_size
         self.partition = partition  # name, index, or None for first
         self.adf_info = adf_info  # Pre-detected ADF info, if any
+        self.mbr_partition_index = mbr_partition_index  # For MBR disks with multiple 0x76 partitions
 
     def _read_partition_env(self):
         from .rdb_inspect import open_rdisk
 
-        blk, rd, mbr_ctx = open_rdisk(self.image_path, block_size=self.block_size)
+        blk, rd, mbr_ctx = open_rdisk(
+            self.image_path, block_size=self.block_size,
+            mbr_partition_index=self.mbr_partition_index,
+        )
         if self.partition is None:
             part = rd.get_partition(0)
         else:


### PR DESCRIPTION
When an Emu68-style MBR image contains more than one partition of type
0x76 (Amiga RDB), only the first one is examined.  Both open_rdisk()
and BlockDeviceBackend.open() iterate over 0x76 entries but return as
soon as the first valid RDB is found, making all Amiga partitions in
subsequent 0x76 slots invisible to inspect and unmountable.

Add find_partition_mbr_index() which searches every 0x76 MBR partition
for a named Amiga partition and returns its index.  Use it in
get_partition_info(), extract_embedded_driver(), HandlerBridge and
BootstrapAllocator so that mounting a partition like ADH0 that lives
in the second 0x76 slot works transparently.

Update cmd_inspect() and the standalone rdb_inspect main() to iterate
over all 0x76 partitions, printing the MBR table once followed by a
section for each RDB with its partitions and filesystem drivers.  JSON
output returns an array when multiple RDBs are present.

Closes: #4
