### PR TITLE
Add ls and verify commands for FUSE-free filesystem inspection

### DIFF
--- a/amifuse/fuse_fs.py
+++ b/amifuse/fuse_fs.py
@@ -2717,6 +2717,11 @@ def _cleanup_bridge(bridge, temp_driver=None):
             backend = getattr(bridge, "backend", None)
             if backend is not None:
                 backend.sync()
+        except Exception:
+            pass
+        try:
+            backend = getattr(bridge, "backend", None)
+            if backend is not None:
                 backend.close()
         except Exception:
             pass

--- a/amifuse/fuse_fs.py
+++ b/amifuse/fuse_fs.py
@@ -2667,6 +2667,377 @@ def _inspect_rdisk(rdisk, full=False):
             print(f"  {w}")
 
 
+def _json_error(command: str, code: str, message: str, details: dict = None) -> dict:
+    """Build a JSON error envelope."""
+    result = {
+        "status": "error",
+        "command": command,
+        "version": __version__,
+        "error": {
+            "code": code,
+            "message": message,
+        },
+    }
+    if details:
+        result["error"]["details"] = details
+    return result
+
+
+def _json_result(command: str, **kwargs) -> dict:
+    """Build a JSON success envelope."""
+    result = {
+        "status": "ok",
+        "command": command,
+        "version": __version__,
+    }
+    result.update(kwargs)
+    return result
+
+
+def _cleanup_bridge(bridge, temp_driver=None):
+    """Shut down a HandlerBridge and release all resources.
+
+    Mirrors the cleanup pattern from destroy() -- each step is independent
+    so failures don't cascade.
+
+    Args:
+        bridge: HandlerBridge instance (or None, in which case only
+            temp_driver cleanup is attempted).
+        temp_driver: Optional Path to a temp driver file created by
+            extract_embedded_driver(). Deleted after bridge shutdown.
+    """
+    if bridge is not None:
+        try:
+            shutdown = getattr(getattr(bridge, "vh", None), "shutdown", None)
+            if shutdown is not None:
+                shutdown()
+        except Exception:
+            pass
+        try:
+            backend = getattr(bridge, "backend", None)
+            if backend is not None:
+                backend.sync()
+                backend.close()
+        except Exception:
+            pass
+    if temp_driver is not None:
+        try:
+            temp_driver.unlink(missing_ok=True)
+        except Exception:
+            pass
+
+
+def _create_bridge_from_args(args, command: str):
+    """Create a HandlerBridge from CLI arguments.
+
+    Handles driver resolution (RDB extraction or explicit --driver),
+    ADF/ISO detection, and JSON error reporting.
+
+    Args:
+        args: Parsed argparse namespace. Must have: image, partition, driver,
+              block_size, debug. May have: json.
+        command: Command name for error envelopes.
+
+    Returns:
+        Tuple of (HandlerBridge, temp_driver_path_or_None). The caller must
+        call _cleanup_bridge(bridge, temp_driver) when done.
+
+    Raises:
+        SystemExit on error (with JSON error if args.json is True).
+    """
+    import json as _json
+    from .rdb_inspect import detect_adf, detect_iso
+
+    use_json = getattr(args, "json", False)
+    image = args.image
+
+    # Validate image exists
+    if not image.exists():
+        if use_json:
+            print(_json.dumps(_json_error(command, "IMAGE_NOT_FOUND",
+                f"Image file not found: {image}")))
+            sys.exit(1)
+        raise SystemExit(f"Error: image file not found: {image}")
+
+    # Detect image type
+    adf_info = detect_adf(image)
+    iso_info = None
+    driver = getattr(args, "driver", None)
+    partition = getattr(args, "partition", None)
+    block_size = getattr(args, "block_size", None)
+    debug = getattr(args, "debug", False)
+    temp_driver = None
+
+    if adf_info is not None:
+        if driver is None:
+            msg = ("ADF floppy image detected. Floppy images don't contain "
+                   "embedded filesystem drivers. Use --driver to specify one.")
+            if use_json:
+                print(_json.dumps(_json_error(command, "DRIVER_NOT_FOUND", msg)))
+                sys.exit(1)
+            raise SystemExit(msg)
+    else:
+        iso_info = detect_iso(image)
+        if iso_info is not None:
+            if driver is None:
+                msg = ("ISO 9660 image detected. ISO images don't contain "
+                       "embedded filesystem drivers. Use --driver to specify one.")
+                if use_json:
+                    print(_json.dumps(_json_error(command, "DRIVER_NOT_FOUND", msg)))
+                    sys.exit(1)
+                raise SystemExit(msg)
+        else:
+            # RDB image -- extract embedded driver if not specified
+            if driver is None:
+                try:
+                    result = extract_embedded_driver(image, block_size, partition)
+                except IOError as e:
+                    if use_json:
+                        print(_json.dumps(_json_error(command, "IMAGE_INVALID", str(e))))
+                        sys.exit(1)
+                    raise SystemExit(f"Error: {e}")
+                if result is None:
+                    msg = ("No embedded filesystem driver found. "
+                           "Use --driver to specify one.")
+                    if use_json:
+                        print(_json.dumps(_json_error(command, "DRIVER_NOT_FOUND", msg)))
+                        sys.exit(1)
+                    raise SystemExit(msg)
+                temp_driver, _, _ = result
+                driver = temp_driver
+
+    # Create the bridge
+    try:
+        bridge = HandlerBridge(
+            image,
+            driver,
+            block_size=block_size,
+            read_only=True,
+            debug=debug,
+            partition=partition,
+            adf_info=adf_info,
+            iso_info=iso_info,
+        )
+    except SystemExit as e:
+        if temp_driver is not None:
+            try:
+                temp_driver.unlink(missing_ok=True)
+            except Exception:
+                pass
+        if use_json:
+            print(_json.dumps(_json_error(command, "HANDLER_ERROR", str(e))))
+            sys.exit(1)
+        raise
+    except Exception as e:
+        if temp_driver is not None:
+            try:
+                temp_driver.unlink(missing_ok=True)
+            except Exception:
+                pass
+        if use_json:
+            print(_json.dumps(_json_error(command, "HANDLER_ERROR",
+                f"Failed to initialize filesystem handler: {e}")))
+            sys.exit(1)
+        raise SystemExit(f"Error initializing handler: {e}")
+
+    return bridge, temp_driver
+
+
+def _format_protection(prot_bits: int) -> str:
+    """Format Amiga protection bits as a human-readable string."""
+    prot = DosProtection(prot_bits)
+    return str(prot)
+
+
+def _ls_recursive(bridge, root_path: str) -> list:
+    """Recursively list all entries under root_path."""
+    entries = []
+    stack = [root_path]
+    while stack:
+        current = stack.pop()
+        raw = bridge.list_dir_path(current)
+        dir_children = []
+        for ent in raw:
+            is_dir = ent.get("dir_type", 0) > 0
+            child = "/" + ent["name"] if current == "/" else current + "/" + ent["name"]
+            prot_bits = ent.get("protection", 0)
+            prot_str = _format_protection(prot_bits)
+            entries.append({
+                "name": ent["name"],
+                "path": child,
+                "type": "dir" if is_dir else "file",
+                "size": ent.get("size", 0),
+                "protection": prot_str,
+                "protection_bits": prot_bits,
+            })
+            if is_dir:
+                dir_children.append(child)
+        # Traverse in sorted order for deterministic output
+        stack.extend(reversed(sorted(dir_children)))
+    return entries
+
+
+def cmd_ls(args):
+    """Handle the 'ls' subcommand."""
+    import json
+
+    use_json = getattr(args, "json", False)
+    path = getattr(args, "path", "/")
+    recursive = getattr(args, "recursive", False)
+
+    # Normalize path (strip trailing slash, ensure leading slash)
+    path = "/" + path.strip("/")
+    if path != "/" and path.endswith("/"):
+        path = path.rstrip("/")
+
+    bridge, temp_driver = _create_bridge_from_args(args, "ls")
+    try:
+        if recursive:
+            entries = _ls_recursive(bridge, path)
+        else:
+            raw = bridge.list_dir_path(path)
+            if not raw and path != "/":
+                # Path might not exist -- try stat to distinguish
+                stat = bridge.stat_path(path)
+                if stat is None:
+                    if use_json:
+                        print(json.dumps(_json_error("ls", "FILE_NOT_FOUND",
+                            f"Path not found: {path}")))
+                        sys.exit(1)
+                    raise SystemExit(f"Error: path not found: {path}")
+            entries = []
+            for ent in raw:
+                is_dir = ent.get("dir_type", 0) > 0
+                child = "/" + ent["name"] if path == "/" else path + "/" + ent["name"]
+                prot_bits = ent.get("protection", 0)
+                prot_str = _format_protection(prot_bits)
+                entries.append({
+                    "name": ent["name"],
+                    "path": child,
+                    "type": "dir" if is_dir else "file",
+                    "size": ent.get("size", 0),
+                    "protection": prot_str,
+                    "protection_bits": prot_bits,
+                })
+
+        if use_json:
+            result = _json_result("ls",
+                target=str(args.image),
+                path=path,
+                entries=entries,
+            )
+            print(json.dumps(result, indent=2))
+        else:
+            for ent in entries:
+                if ent["type"] == "dir":
+                    print(f"  {ent['name']:30s}  <dir>     {ent['protection']}")
+                else:
+                    print(f"  {ent['name']:30s}  {ent['size']:>10d}  {ent['protection']}")
+    except SystemExit:
+        raise
+    except Exception as e:
+        if use_json:
+            print(json.dumps(_json_error("ls", "HANDLER_ERROR",
+                f"Directory listing failed: {e}")))
+            sys.exit(1)
+        raise SystemExit(f"Error during directory listing: {e}")
+    finally:
+        _cleanup_bridge(bridge, temp_driver)
+
+
+def cmd_verify(args):
+    """Handle the 'verify' subcommand."""
+    import json
+
+    use_json = getattr(args, "json", False)
+    file_path = getattr(args, "file", None)
+    expect_size = getattr(args, "expect_size", None)
+
+    # Warn if --expect-size used without --file (it has no meaning alone)
+    if expect_size is not None and file_path is None:
+        if use_json:
+            print(json.dumps(_json_error("verify", "INVALID_ARGUMENT",
+                "--expect-size requires --file")))
+            sys.exit(1)
+        raise SystemExit("Error: --expect-size requires --file")
+
+    bridge, temp_driver = _create_bridge_from_args(args, "verify")
+    try:
+        if file_path:
+            # Verify a specific file
+            normalized = "/" + file_path.lstrip("/")
+            stat = bridge.stat_path(normalized)
+            if stat is None:
+                if use_json:
+                    print(json.dumps(_json_error("verify", "FILE_NOT_FOUND",
+                        f"File not found: {file_path}")))
+                    sys.exit(1)
+                raise SystemExit(f"Error: file not found: {file_path}")
+
+            result_data = {
+                "target": str(args.image),
+                "file": file_path,
+                "exists": True,
+                "size": stat.get("size", 0),
+                "type": "dir" if stat.get("dir_type", 0) > 0 else "file",
+            }
+            if expect_size is not None:
+                result_data["expected_size"] = expect_size
+                result_data["size_matches"] = stat.get("size", 0) == expect_size
+
+            if use_json:
+                print(json.dumps(_json_result("verify", **result_data), indent=2))
+            else:
+                print(f"File: {file_path}")
+                print(f"  Exists: yes")
+                print(f"  Type: {result_data['type']}")
+                print(f"  Size: {stat.get('size', 0)}")
+                if expect_size is not None:
+                    match = "yes" if result_data["size_matches"] else "NO"
+                    print(f"  Expected size: {expect_size} ({match})")
+        else:
+            # Verify volume -- count files and dirs
+            total_files = 0
+            total_dirs = 0
+            total_size = 0
+            entries = _ls_recursive(bridge, "/")
+            for ent in entries:
+                if ent["type"] == "dir":
+                    total_dirs += 1
+                else:
+                    total_files += 1
+                    total_size += ent.get("size", 0)
+
+            volname = bridge.volume_name()
+            result_data = {
+                "target": str(args.image),
+                "volume": volname,
+                "total_dirs": total_dirs,
+                "total_files": total_files,
+                "total_size_bytes": total_size,
+                "filesystem_responsive": True,
+            }
+
+            if use_json:
+                print(json.dumps(_json_result("verify", **result_data), indent=2))
+            else:
+                print(f"Volume: {volname}")
+                print(f"  Directories: {total_dirs}")
+                print(f"  Files: {total_files}")
+                print(f"  Total size: {total_size:,} bytes")
+                print(f"  Filesystem responsive: yes")
+    except SystemExit:
+        raise
+    except Exception as e:
+        if use_json:
+            print(json.dumps(_json_error("verify", "HANDLER_ERROR",
+                f"Verification failed: {e}")))
+            sys.exit(1)
+        raise SystemExit(f"Error during verification: {e}")
+    finally:
+        _cleanup_bridge(bridge, temp_driver)
+
+
 def cmd_inspect(args):
     """Handle the 'inspect' subcommand."""
     import amitools.fs.DosType as DosType
@@ -2963,6 +3334,24 @@ commands:
     --driver PATH             Filesystem binary (default: extract from RDB).
     --block-size N            Override block size (defaults to auto/512).
     --debug                   Enable debug logging.
+
+  ls <image> [path]         List files in an Amiga filesystem image.
+    --path PATH               Directory path to list (default: /).
+    --partition NAME          Partition name (e.g. DH0) or index.
+    --driver PATH             Filesystem binary (default: extract from RDB).
+    --block-size N            Override block size (defaults to auto/512).
+    --recursive               List all entries recursively.
+    --json                    Output results as JSON.
+    --debug                   Enable debug logging.
+
+  verify <image>            Verify an Amiga filesystem image.
+    --file PATH               Verify a specific file.
+    --expect-size N           Expected file size in bytes (with --file).
+    --partition NAME          Partition name (e.g. DH0) or index.
+    --driver PATH             Filesystem binary (default: extract from RDB).
+    --block-size N            Override block size (defaults to auto/512).
+    --json                    Output results as JSON.
+    --debug                   Enable debug logging.
 """,
     )
     parser.add_argument(
@@ -3059,6 +3448,76 @@ commands:
         "--debug", action="store_true", help="Enable debug logging."
     )
     format_parser.set_defaults(func=cmd_format)
+
+    # ls subcommand
+    ls_parser = subparsers.add_parser(
+        "ls", help="List files in an Amiga filesystem image (no FUSE needed)."
+    )
+    ls_parser.add_argument("image", type=Path, help="Disk image file")
+    ls_parser.add_argument(
+        "--path", type=str, default="/",
+        help="Directory path to list (default: root).",
+    )
+    ls_parser.add_argument(
+        "--partition", type=str,
+        help="Partition name (e.g. DH0) or index (defaults to first).",
+    )
+    ls_parser.add_argument(
+        "--driver", type=Path,
+        help="Filesystem binary (default: extract from RDB if available).",
+    )
+    ls_parser.add_argument(
+        "--block-size", type=int,
+        help="Override block size (defaults to auto/512).",
+    )
+    ls_parser.add_argument(
+        "--recursive", action="store_true",
+        help="List all entries recursively.",
+    )
+    ls_parser.add_argument(
+        "--json", action="store_true",
+        help="Output results as JSON.",
+    )
+    ls_parser.add_argument(
+        "--debug", action="store_true",
+        help="Enable debug logging.",
+    )
+    ls_parser.set_defaults(func=cmd_ls)
+
+    # verify subcommand
+    verify_parser = subparsers.add_parser(
+        "verify", help="Verify an Amiga filesystem image (no FUSE needed)."
+    )
+    verify_parser.add_argument("image", type=Path, help="Disk image file")
+    verify_parser.add_argument(
+        "--file", type=str, dest="file",
+        help="Verify a specific file exists and get its metadata.",
+    )
+    verify_parser.add_argument(
+        "--expect-size", type=int, dest="expect_size",
+        help="Expected file size in bytes (requires --file).",
+    )
+    verify_parser.add_argument(
+        "--partition", type=str,
+        help="Partition name (e.g. DH0) or index (defaults to first).",
+    )
+    verify_parser.add_argument(
+        "--driver", type=Path,
+        help="Filesystem binary (default: extract from RDB if available).",
+    )
+    verify_parser.add_argument(
+        "--block-size", type=int,
+        help="Override block size (defaults to auto/512).",
+    )
+    verify_parser.add_argument(
+        "--json", action="store_true",
+        help="Output results as JSON.",
+    )
+    verify_parser.add_argument(
+        "--debug", action="store_true",
+        help="Enable debug logging.",
+    )
+    verify_parser.set_defaults(func=cmd_verify)
 
     args = parser.parse_args(argv)
     try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,9 +69,18 @@ def fuse_mock(monkeypatch):
         FileHandleStruct=dummy_cls,
         DosPacketStruct=dummy_cls,
     )
+    # DosProtection needs to be callable with an int arg and str-able
+    # so _format_protection(prot_bits) works in tests.
+    class _FakeDosProtection:
+        def __init__(self, bits=0):
+            self._bits = bits
+
+        def __str__(self):
+            return f"----rwed" if self._bits == 0 else f"p={self._bits}"
+
     _stub_module("amitools.vamos.lib")
     _stub_module("amitools.vamos.lib.dos")
-    _stub_module("amitools.vamos.lib.dos.DosProtection", DosProtection=dummy_cls)
+    _stub_module("amitools.vamos.lib.dos.DosProtection", DosProtection=_FakeDosProtection)
 
 
 @pytest.fixture

--- a/tests/unit/test_fuse_fs.py
+++ b/tests/unit/test_fuse_fs.py
@@ -779,6 +779,15 @@ class TestCleanupBridge:
         mock_bridge.backend.sync.assert_called_once()
         mock_bridge.backend.close.assert_called_once()
 
+    def test_cleanup_bridge_sync_failure_still_closes(self, fuse_mock):
+        """If backend.sync() raises, backend.close() must still be called."""
+        from amifuse.fuse_fs import _cleanup_bridge
+
+        mock_bridge = MagicMock()
+        mock_bridge.backend.sync.side_effect = OSError("disk error")
+        _cleanup_bridge(mock_bridge)
+        mock_bridge.backend.close.assert_called_once()
+
 
 # ---------------------------------------------------------------------------
 # TestCreateBridgeFromArgs -- bridge creation helper tests
@@ -903,6 +912,97 @@ class TestCreateBridgeFromArgs:
             fuse_fs_mod._create_bridge_from_args(args, "test")
         # Temp driver should be cleaned up
         assert not temp_driver.exists()
+
+    def test_bridge_adf_no_driver_json_error(
+        self, fuse_mock, monkeypatch, tmp_path, capsys,
+    ):
+        """ADF without --driver: verify JSON body."""
+        import amifuse.fuse_fs as fuse_fs_mod
+
+        image = tmp_path / "test.adf"
+        image.write_bytes(b"\x00" * 1024)
+
+        fake_rdb = MagicMock()
+        fake_rdb.detect_adf.return_value = MagicMock()
+        monkeypatch.setitem(sys.modules, "amifuse.rdb_inspect", fake_rdb)
+
+        args = argparse.Namespace(
+            image=image,
+            json=True,
+            partition=None,
+            driver=None,
+            block_size=None,
+            debug=False,
+        )
+        with pytest.raises(SystemExit):
+            fuse_fs_mod._create_bridge_from_args(args, "test")
+        output = capsys.readouterr().out
+        data = json.loads(output)
+        assert data["error"]["code"] == "DRIVER_NOT_FOUND"
+        assert "ADF" in data["error"]["message"]
+        assert "--driver" in data["error"]["message"]
+
+    def test_bridge_iso_no_driver_json_error(
+        self, fuse_mock, monkeypatch, tmp_path, capsys,
+    ):
+        """ISO image without --driver should emit DRIVER_NOT_FOUND JSON error."""
+        import amifuse.fuse_fs as fuse_fs_mod
+
+        image = tmp_path / "test.iso"
+        image.write_bytes(b"\x00" * 1024)
+
+        fake_rdb = MagicMock()
+        fake_rdb.detect_adf.return_value = None
+        fake_rdb.detect_iso.return_value = MagicMock()  # valid ISOInfo
+        monkeypatch.setitem(sys.modules, "amifuse.rdb_inspect", fake_rdb)
+
+        args = argparse.Namespace(
+            image=image,
+            json=True,
+            partition=None,
+            driver=None,
+            block_size=None,
+            debug=False,
+        )
+        with pytest.raises(SystemExit):
+            fuse_fs_mod._create_bridge_from_args(args, "test")
+        output = capsys.readouterr().out
+        data = json.loads(output)
+        assert data["error"]["code"] == "DRIVER_NOT_FOUND"
+        assert "ISO" in data["error"]["message"]
+        assert "--driver" in data["error"]["message"]
+
+    def test_bridge_rdb_no_embedded_driver_json_error(
+        self, fuse_mock, monkeypatch, tmp_path, capsys,
+    ):
+        """RDB image with no embedded driver should emit DRIVER_NOT_FOUND."""
+        import amifuse.fuse_fs as fuse_fs_mod
+
+        image = tmp_path / "test.hdf"
+        image.write_bytes(b"\x00" * 1024)
+
+        fake_rdb = MagicMock()
+        fake_rdb.detect_adf.return_value = None
+        fake_rdb.detect_iso.return_value = None
+        monkeypatch.setitem(sys.modules, "amifuse.rdb_inspect", fake_rdb)
+
+        monkeypatch.setattr(
+            fuse_fs_mod, "extract_embedded_driver", lambda *a, **kw: None,
+        )
+
+        args = argparse.Namespace(
+            image=image,
+            json=True,
+            partition=None,
+            driver=None,
+            block_size=None,
+            debug=False,
+        )
+        with pytest.raises(SystemExit):
+            fuse_fs_mod._create_bridge_from_args(args, "test")
+        output = capsys.readouterr().out
+        data = json.loads(output)
+        assert data["error"]["code"] == "DRIVER_NOT_FOUND"
 
 
 # ---------------------------------------------------------------------------
@@ -1065,6 +1165,28 @@ class TestCmdLs:
         assert len(lines) == 1
         parts = lines[0].split()
         assert len(parts) >= 3  # name, <dir>, protection
+
+    def test_ls_handler_exception_json(self, mock_bridge_for_ls, capsys):
+        """Exception in list_dir_path should produce HANDLER_ERROR JSON."""
+        mock_bridge, fuse_fs_mod = mock_bridge_for_ls
+        mock_bridge.list_dir_path.side_effect = RuntimeError("handler crashed")
+
+        args = argparse.Namespace(
+            image=Path("/fake/test.hdf"),
+            json=True,
+            path="/",
+            recursive=False,
+            partition=None,
+            driver=None,
+            block_size=None,
+            debug=False,
+        )
+        with pytest.raises(SystemExit):
+            fuse_fs_mod.cmd_ls(args)
+        output = capsys.readouterr().out
+        data = json.loads(output)
+        assert data["error"]["code"] == "HANDLER_ERROR"
+        assert "handler crashed" in data["error"]["message"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_fuse_fs.py
+++ b/tests/unit/test_fuse_fs.py
@@ -6,6 +6,7 @@ installed.
 """
 
 import argparse
+import json
 import signal
 import sys
 from pathlib import Path
@@ -693,3 +694,565 @@ class TestDirectoryListingCap:
         source = inspect.getsource(HandlerBridge.list_dir)
         assert "for iter_num in range(" in source
         assert "while True" not in source
+
+
+# ---------------------------------------------------------------------------
+# TestJsonHelpers -- JSON envelope helper tests
+# ---------------------------------------------------------------------------
+
+
+class TestJsonHelpers:
+    """Tests for _json_error() and _json_result() envelope helpers."""
+
+    def test_json_error_structure(self, fuse_mock):
+        from amifuse.fuse_fs import _json_error
+
+        result = _json_error("test", "TEST_ERROR", "something went wrong")
+        assert result["status"] == "error"
+        assert result["command"] == "test"
+        assert "version" in result
+        assert result["error"]["code"] == "TEST_ERROR"
+        assert result["error"]["message"] == "something went wrong"
+        assert "details" not in result["error"]
+
+    def test_json_error_with_details(self, fuse_mock):
+        from amifuse.fuse_fs import _json_error
+
+        result = _json_error("test", "TEST_ERROR", "msg", details={"key": "val"})
+        assert result["error"]["details"]["key"] == "val"
+
+    def test_json_result_structure(self, fuse_mock):
+        from amifuse.fuse_fs import _json_result
+
+        result = _json_result("test", foo="bar")
+        assert result["status"] == "ok"
+        assert result["command"] == "test"
+        assert "version" in result
+        assert result["foo"] == "bar"
+
+
+# ---------------------------------------------------------------------------
+# TestCleanupBridge -- bridge cleanup helper tests
+# ---------------------------------------------------------------------------
+
+
+class TestCleanupBridge:
+    """Tests for _cleanup_bridge() resource cleanup."""
+
+    def test_cleanup_bridge_deletes_temp_driver(self, fuse_mock, tmp_path):
+        from amifuse.fuse_fs import _cleanup_bridge
+
+        temp_file = tmp_path / "test.handler"
+        temp_file.write_text("fake driver")
+        assert temp_file.exists()
+
+        mock_bridge = MagicMock()
+        _cleanup_bridge(mock_bridge, temp_file)
+        assert not temp_file.exists()
+
+    def test_cleanup_bridge_none_bridge_still_deletes_temp(self, fuse_mock, tmp_path):
+        from amifuse.fuse_fs import _cleanup_bridge
+
+        temp_file = tmp_path / "test.handler"
+        temp_file.write_text("fake driver")
+        assert temp_file.exists()
+
+        _cleanup_bridge(None, temp_file)
+        assert not temp_file.exists()
+
+    def test_cleanup_bridge_calls_shutdown_and_close(self, fuse_mock):
+        from amifuse.fuse_fs import _cleanup_bridge
+
+        mock_bridge = MagicMock()
+        _cleanup_bridge(mock_bridge)
+        mock_bridge.vh.shutdown.assert_called_once()
+        mock_bridge.backend.sync.assert_called_once()
+        mock_bridge.backend.close.assert_called_once()
+
+    def test_cleanup_bridge_handles_shutdown_failure(self, fuse_mock):
+        from amifuse.fuse_fs import _cleanup_bridge
+
+        mock_bridge = MagicMock()
+        mock_bridge.vh.shutdown.side_effect = RuntimeError("boom")
+        # Should not raise
+        _cleanup_bridge(mock_bridge)
+        mock_bridge.backend.sync.assert_called_once()
+        mock_bridge.backend.close.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# TestCreateBridgeFromArgs -- bridge creation helper tests
+# ---------------------------------------------------------------------------
+
+
+class TestCreateBridgeFromArgs:
+    """Tests for _create_bridge_from_args() error handling."""
+
+    def test_bridge_image_not_found_json(self, fuse_mock, tmp_path, capsys, monkeypatch):
+        # Mock rdb_inspect so the local import in _create_bridge_from_args works
+        fake_rdb = MagicMock()
+        monkeypatch.setitem(sys.modules, "amifuse.rdb_inspect", fake_rdb)
+
+        from amifuse.fuse_fs import _create_bridge_from_args
+
+        args = argparse.Namespace(
+            image=tmp_path / "nonexistent.hdf",
+            json=True,
+            partition=None,
+            driver=None,
+            block_size=None,
+            debug=False,
+        )
+        with pytest.raises(SystemExit):
+            _create_bridge_from_args(args, "test")
+        output = capsys.readouterr().out
+        data = json.loads(output)
+        assert data["error"]["code"] == "IMAGE_NOT_FOUND"
+
+    def test_bridge_image_not_found_human(self, fuse_mock, tmp_path, monkeypatch):
+        fake_rdb = MagicMock()
+        monkeypatch.setitem(sys.modules, "amifuse.rdb_inspect", fake_rdb)
+
+        from amifuse.fuse_fs import _create_bridge_from_args
+
+        args = argparse.Namespace(
+            image=tmp_path / "nonexistent.hdf",
+            json=False,
+            partition=None,
+            driver=None,
+            block_size=None,
+            debug=False,
+        )
+        with pytest.raises(SystemExit, match="image file not found"):
+            _create_bridge_from_args(args, "test")
+
+    def test_bridge_returns_tuple(self, fuse_mock, monkeypatch, tmp_path):
+        import amifuse.fuse_fs as fuse_fs_mod
+
+        # Create a real image file so exists() passes
+        image = tmp_path / "test.hdf"
+        image.write_bytes(b"\x00" * 1024)
+
+        # Mock detect_adf/detect_iso to return None (treat as RDB)
+        fake_rdb = MagicMock()
+        fake_rdb.detect_adf.return_value = None
+        fake_rdb.detect_iso.return_value = None
+        monkeypatch.setitem(sys.modules, "amifuse.rdb_inspect", fake_rdb)
+
+        # Mock extract_embedded_driver to return a temp path
+        temp_driver = tmp_path / "temp.handler"
+        temp_driver.write_text("fake")
+        monkeypatch.setattr(
+            fuse_fs_mod, "extract_embedded_driver",
+            lambda *a, **kw: (temp_driver, "DOS3", 0x444F5303),
+        )
+
+        # Mock HandlerBridge
+        mock_bridge = MagicMock()
+        monkeypatch.setattr(fuse_fs_mod, "HandlerBridge", lambda *a, **kw: mock_bridge)
+
+        args = argparse.Namespace(
+            image=image,
+            json=False,
+            partition=None,
+            driver=None,
+            block_size=None,
+            debug=False,
+        )
+        result = fuse_fs_mod._create_bridge_from_args(args, "test")
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+        bridge, td = result
+        assert bridge is mock_bridge
+        assert td == temp_driver
+
+    def test_bridge_cleans_temp_driver_on_failure(self, fuse_mock, monkeypatch, tmp_path):
+        import amifuse.fuse_fs as fuse_fs_mod
+
+        image = tmp_path / "test.hdf"
+        image.write_bytes(b"\x00" * 1024)
+
+        # Mock detect_adf/detect_iso
+        fake_rdb = MagicMock()
+        fake_rdb.detect_adf.return_value = None
+        fake_rdb.detect_iso.return_value = None
+        monkeypatch.setitem(sys.modules, "amifuse.rdb_inspect", fake_rdb)
+
+        # Create a real temp file
+        temp_driver = tmp_path / "temp.handler"
+        temp_driver.write_text("fake driver content")
+        monkeypatch.setattr(
+            fuse_fs_mod, "extract_embedded_driver",
+            lambda *a, **kw: (temp_driver, "DOS3", 0x444F5303),
+        )
+
+        # Mock HandlerBridge to raise
+        def fail_init(*a, **kw):
+            raise RuntimeError("init failed")
+        monkeypatch.setattr(fuse_fs_mod, "HandlerBridge", fail_init)
+
+        args = argparse.Namespace(
+            image=image,
+            json=False,
+            partition=None,
+            driver=None,
+            block_size=None,
+            debug=False,
+        )
+        with pytest.raises(SystemExit):
+            fuse_fs_mod._create_bridge_from_args(args, "test")
+        # Temp driver should be cleaned up
+        assert not temp_driver.exists()
+
+
+# ---------------------------------------------------------------------------
+# TestCmdLs -- ls command tests
+# ---------------------------------------------------------------------------
+
+
+class TestCmdLs:
+    """Tests for cmd_ls() subcommand."""
+
+    @pytest.fixture
+    def mock_bridge_for_ls(self, fuse_mock, monkeypatch):
+        """Set up mocked bridge for ls tests."""
+        import amifuse.fuse_fs as fuse_fs_mod
+
+        mock_bridge = MagicMock()
+        monkeypatch.setattr(
+            fuse_fs_mod, "_create_bridge_from_args",
+            lambda args, cmd: (mock_bridge, None),
+        )
+        return mock_bridge, fuse_fs_mod
+
+    def test_ls_json_output_structure(self, mock_bridge_for_ls, capsys):
+        mock_bridge, fuse_fs_mod = mock_bridge_for_ls
+        mock_bridge.list_dir_path.return_value = [
+            {"name": "file1.txt", "dir_type": 0, "size": 100, "protection": 0},
+            {"name": "Devs", "dir_type": 2, "size": 0, "protection": 0},
+        ]
+
+        args = argparse.Namespace(
+            image=Path("/fake/test.hdf"),
+            json=True,
+            path="/",
+            recursive=False,
+            partition=None,
+            driver=None,
+            block_size=None,
+            debug=False,
+        )
+        fuse_fs_mod.cmd_ls(args)
+        output = capsys.readouterr().out
+        data = json.loads(output)
+
+        assert data["status"] == "ok"
+        assert data["command"] == "ls"
+        assert "version" in data
+        assert data["path"] == "/"
+        assert len(data["entries"]) == 2
+        assert data["entries"][0]["name"] == "file1.txt"
+        assert data["entries"][0]["type"] == "file"
+        assert data["entries"][0]["size"] == 100
+        assert data["entries"][1]["name"] == "Devs"
+        assert data["entries"][1]["type"] == "dir"
+
+    def test_ls_recursive_json(self, mock_bridge_for_ls, capsys):
+        mock_bridge, fuse_fs_mod = mock_bridge_for_ls
+
+        def fake_list_dir(path):
+            if path == "/":
+                return [
+                    {"name": "S", "dir_type": 2, "size": 0, "protection": 0},
+                    {"name": "readme.txt", "dir_type": 0, "size": 50, "protection": 0},
+                ]
+            elif path == "/S":
+                return [
+                    {"name": "Startup-Sequence", "dir_type": 0, "size": 200, "protection": 0},
+                ]
+            return []
+
+        mock_bridge.list_dir_path.side_effect = fake_list_dir
+
+        args = argparse.Namespace(
+            image=Path("/fake/test.hdf"),
+            json=True,
+            path="/",
+            recursive=True,
+            partition=None,
+            driver=None,
+            block_size=None,
+            debug=False,
+        )
+        fuse_fs_mod.cmd_ls(args)
+        output = capsys.readouterr().out
+        data = json.loads(output)
+
+        assert data["status"] == "ok"
+        entries = data["entries"]
+        assert len(entries) == 3
+        names = [e["name"] for e in entries]
+        assert "S" in names
+        assert "readme.txt" in names
+        assert "Startup-Sequence" in names
+        ss_entry = next(e for e in entries if e["name"] == "Startup-Sequence")
+        assert ss_entry["path"] == "/S/Startup-Sequence"
+
+    def test_ls_path_not_found_json(self, mock_bridge_for_ls, capsys):
+        mock_bridge, fuse_fs_mod = mock_bridge_for_ls
+        mock_bridge.list_dir_path.return_value = []
+        mock_bridge.stat_path.return_value = None
+
+        args = argparse.Namespace(
+            image=Path("/fake/test.hdf"),
+            json=True,
+            path="/nonexistent",
+            recursive=False,
+            partition=None,
+            driver=None,
+            block_size=None,
+            debug=False,
+        )
+        with pytest.raises(SystemExit):
+            fuse_fs_mod.cmd_ls(args)
+        output = capsys.readouterr().out
+        data = json.loads(output)
+        assert data["error"]["code"] == "FILE_NOT_FOUND"
+
+    def test_ls_normalizes_path(self, mock_bridge_for_ls, capsys):
+        mock_bridge, fuse_fs_mod = mock_bridge_for_ls
+        mock_bridge.list_dir_path.return_value = [
+            {"name": "Startup-Sequence", "dir_type": 0, "size": 100, "protection": 0},
+        ]
+
+        # Test with path "S/" (no leading slash, trailing slash)
+        args = argparse.Namespace(
+            image=Path("/fake/test.hdf"),
+            json=True,
+            path="S/",
+            recursive=False,
+            partition=None,
+            driver=None,
+            block_size=None,
+            debug=False,
+        )
+        fuse_fs_mod.cmd_ls(args)
+
+        # Verify list_dir_path was called with normalized "/S"
+        mock_bridge.list_dir_path.assert_called_with("/S")
+
+    def test_ls_human_shows_protection_for_dirs(self, mock_bridge_for_ls, capsys):
+        mock_bridge, fuse_fs_mod = mock_bridge_for_ls
+        mock_bridge.list_dir_path.return_value = [
+            {"name": "Devs", "dir_type": 2, "size": 0, "protection": 15},
+        ]
+
+        args = argparse.Namespace(
+            image=Path("/fake/test.hdf"),
+            json=False,
+            path="/",
+            recursive=False,
+            partition=None,
+            driver=None,
+            block_size=None,
+            debug=False,
+        )
+        fuse_fs_mod.cmd_ls(args)
+        output = capsys.readouterr().out
+        assert "Devs" in output
+        assert "<dir>" in output
+        lines = output.strip().split("\n")
+        assert len(lines) == 1
+        parts = lines[0].split()
+        assert len(parts) >= 3  # name, <dir>, protection
+
+
+# ---------------------------------------------------------------------------
+# TestCmdVerify -- verify command tests
+# ---------------------------------------------------------------------------
+
+
+class TestCmdVerify:
+    """Tests for cmd_verify() subcommand."""
+
+    @pytest.fixture
+    def mock_bridge_for_verify(self, fuse_mock, monkeypatch):
+        """Set up mocked bridge for verify tests."""
+        import amifuse.fuse_fs as fuse_fs_mod
+
+        mock_bridge = MagicMock()
+        monkeypatch.setattr(
+            fuse_fs_mod, "_create_bridge_from_args",
+            lambda args, cmd: (mock_bridge, None),
+        )
+        return mock_bridge, fuse_fs_mod
+
+    def test_verify_file_json(self, mock_bridge_for_verify, capsys):
+        mock_bridge, fuse_fs_mod = mock_bridge_for_verify
+        mock_bridge.stat_path.return_value = {
+            "dir_type": 0, "size": 1234, "name": "test.txt", "protection": 0,
+        }
+
+        args = argparse.Namespace(
+            image=Path("/fake/test.hdf"),
+            json=True,
+            file="test.txt",
+            expect_size=None,
+            partition=None,
+            driver=None,
+            block_size=None,
+            debug=False,
+        )
+        fuse_fs_mod.cmd_verify(args)
+        output = capsys.readouterr().out
+        data = json.loads(output)
+
+        assert data["status"] == "ok"
+        assert data["command"] == "verify"
+        assert data["exists"] is True
+        assert data["size"] == 1234
+        assert data["type"] == "file"
+
+    def test_verify_file_size_match(self, mock_bridge_for_verify, capsys):
+        mock_bridge, fuse_fs_mod = mock_bridge_for_verify
+        mock_bridge.stat_path.return_value = {
+            "dir_type": 0, "size": 1234, "name": "test.txt", "protection": 0,
+        }
+
+        args = argparse.Namespace(
+            image=Path("/fake/test.hdf"),
+            json=True,
+            file="test.txt",
+            expect_size=1234,
+            partition=None,
+            driver=None,
+            block_size=None,
+            debug=False,
+        )
+        fuse_fs_mod.cmd_verify(args)
+        output = capsys.readouterr().out
+        data = json.loads(output)
+
+        assert data["size_matches"] is True
+        assert data["expected_size"] == 1234
+
+    def test_verify_file_size_mismatch(self, mock_bridge_for_verify, capsys):
+        mock_bridge, fuse_fs_mod = mock_bridge_for_verify
+        mock_bridge.stat_path.return_value = {
+            "dir_type": 0, "size": 1234, "name": "test.txt", "protection": 0,
+        }
+
+        args = argparse.Namespace(
+            image=Path("/fake/test.hdf"),
+            json=True,
+            file="test.txt",
+            expect_size=9999,
+            partition=None,
+            driver=None,
+            block_size=None,
+            debug=False,
+        )
+        fuse_fs_mod.cmd_verify(args)
+        output = capsys.readouterr().out
+        data = json.loads(output)
+
+        assert data["size_matches"] is False
+        assert data["expected_size"] == 9999
+
+    def test_verify_file_not_found_json(self, mock_bridge_for_verify, capsys):
+        mock_bridge, fuse_fs_mod = mock_bridge_for_verify
+        mock_bridge.stat_path.return_value = None
+
+        args = argparse.Namespace(
+            image=Path("/fake/test.hdf"),
+            json=True,
+            file="missing.txt",
+            expect_size=None,
+            partition=None,
+            driver=None,
+            block_size=None,
+            debug=False,
+        )
+        with pytest.raises(SystemExit):
+            fuse_fs_mod.cmd_verify(args)
+        output = capsys.readouterr().out
+        data = json.loads(output)
+        assert data["error"]["code"] == "FILE_NOT_FOUND"
+
+    def test_verify_volume_json(self, mock_bridge_for_verify, monkeypatch, capsys):
+        import amifuse.fuse_fs as fuse_fs_mod
+
+        mock_bridge, _ = mock_bridge_for_verify
+        mock_bridge.volume_name.return_value = "Workbench3.1"
+
+        def fake_list_dir(path):
+            if path == "/":
+                return [
+                    {"name": "S", "dir_type": 2, "size": 0, "protection": 0},
+                    {"name": "readme.txt", "dir_type": 0, "size": 50, "protection": 0},
+                    {"name": "data.bin", "dir_type": 0, "size": 200, "protection": 0},
+                ]
+            elif path == "/S":
+                return [
+                    {"name": "Startup-Sequence", "dir_type": 0, "size": 100, "protection": 0},
+                ]
+            return []
+
+        mock_bridge.list_dir_path.side_effect = fake_list_dir
+
+        args = argparse.Namespace(
+            image=Path("/fake/test.hdf"),
+            json=True,
+            file=None,
+            expect_size=None,
+            partition=None,
+            driver=None,
+            block_size=None,
+            debug=False,
+        )
+        fuse_fs_mod.cmd_verify(args)
+        output = capsys.readouterr().out
+        data = json.loads(output)
+
+        assert data["status"] == "ok"
+        assert data["command"] == "verify"
+        assert data["volume"] == "Workbench3.1"
+        assert data["total_dirs"] == 1
+        assert data["total_files"] == 3
+        assert data["total_size_bytes"] == 350
+        assert data["filesystem_responsive"] is True
+
+    def test_verify_expect_size_without_file_json(self, fuse_mock, capsys):
+        import amifuse.fuse_fs as fuse_fs_mod
+
+        args = argparse.Namespace(
+            image=Path("/fake/test.hdf"),
+            json=True,
+            file=None,
+            expect_size=100,
+            partition=None,
+            driver=None,
+            block_size=None,
+            debug=False,
+        )
+        with pytest.raises(SystemExit):
+            fuse_fs_mod.cmd_verify(args)
+        output = capsys.readouterr().out
+        data = json.loads(output)
+        assert data["error"]["code"] == "INVALID_ARGUMENT"
+
+    def test_verify_expect_size_without_file_human(self, fuse_mock):
+        import amifuse.fuse_fs as fuse_fs_mod
+
+        args = argparse.Namespace(
+            image=Path("/fake/test.hdf"),
+            json=False,
+            file=None,
+            expect_size=100,
+            partition=None,
+            driver=None,
+            block_size=None,
+            debug=False,
+        )
+        with pytest.raises(SystemExit, match="--expect-size requires --file"):
+            fuse_fs_mod.cmd_verify(args)


### PR DESCRIPTION
## Summary

AmiFUSE has a useful architectural property: `HandlerBridge` runs the full m68k filesystem handler stack — driver loading, DOS packet protocol, block I/O — without needing FUSE. The benchmark tool already exploits this for performance measurement. These two commands expose that same capability through the CLI, making roughly 80% of filesystem verification possible on any platform with just Python and amitools, no kernel module required.

**Why this matters:** On Windows, installing WinFSP requires admin privileges and sometimes a reboot. On macOS, macFUSE needs a kernel extension approval. In CI, FUSE backends add complexity to every runner. By operating directly through `HandlerBridge`, `ls` and `verify` bypass all of that — the same binary that can list files on a developer's laptop also works in a headless CI container.

The shared infrastructure (`_create_bridge_from_args`, `_cleanup_bridge`, `_json_error`/`_json_result`) encapsulates three concerns that would otherwise be duplicated across every FUSE-free command:

1. **Driver resolution** — the ADF→ISO→RDB detection cascade and embedded driver extraction from `mount_fuse()`, including temp file lifecycle management for extracted drivers.
2. **Resource cleanup** — mirroring the `destroy()` teardown pattern (shutdown m68k runtime → sync → close backend → delete temp driver), with each step in its own try/except to prevent cascading failures.
3. **Structured error reporting** — a universal JSON envelope with typed error codes (`IMAGE_NOT_FOUND`, `FILE_NOT_FOUND`, `HANDLER_ERROR`, etc.) so callers can branch on failure type rather than parsing messages.

Both commands support `--json` for machine-readable output and default to human-readable text. The `verify` command operates in two modes: whole-volume integrity scan (recursive traversal reporting file/dir counts and total size) and single-file verification (with optional `--expect-size` for content assertions).

## Test plan

- [x] `python -m pytest tests/unit/ -v` — 168 passed, 0 new failures (3 pre-existing upstream unmount failures on Windows)
- [x] **JSON helpers** — `_json_error` structure with/without details, `_json_result` structure with kwargs (3 tests)
- [x] **Bridge cleanup** — temp driver deletion, None bridge handling, shutdown+sync+close calls, shutdown failure isolation, sync failure still calls close (5 tests)
- [x] **Bridge creation error paths** — image not found (JSON + human), ADF without `--driver`, ISO without `--driver`, RDB without embedded driver, returns (bridge, temp_driver) tuple, temp driver cleaned on init failure (7 tests)
- [x] **`ls` command** — JSON output structure, recursive traversal with nested dirs, path not found error, path normalization (`S/` → `/S`), protection bits shown for dirs, handler exception produces JSON error (6 tests)
- [x] **`verify` command** — file mode JSON output, size match/mismatch, file not found, volume mode with recursive counts, `--expect-size` without `--file` rejection in JSON + human modes (7 tests)
- [x] **conftest** — `DosProtection` stub updated to support `_format_protection()` (callable with int, str-able)
- [x] **Bug fix validated** — `_cleanup_bridge` sync/close split into independent try blocks; test confirms `close()` is called even when `sync()` raises