### PR TITLE
Fix memory leaks in bstr and stdpkt ring buffer reallocation

### DIFF
--- a/amifuse/fuse_fs.py
+++ b/amifuse/fuse_fs.py
@@ -982,7 +982,10 @@ class HandlerBridge:
         self._bstr_index = (idx + 1) % self._bstr_ring_size
         mem_obj = self._bstr_ring[idx]
         if mem_obj is None or len(data) > self._bstr_sizes[idx]:
-            mem_obj = self.vh.alloc.alloc_memory(len(data), label=f"FUSE_BSTR_{idx}")
+            new_mem = self.vh.alloc.alloc_memory(len(data), label=f"FUSE_BSTR_{idx}")
+            if mem_obj is not None:
+                self.vh.alloc.free_memory(mem_obj)
+            mem_obj = new_mem
             self._bstr_ring[idx] = mem_obj
             self._bstr_sizes[idx] = len(data)
         self.mem.w_block(mem_obj.addr, data)

--- a/amifuse/startup_runner.py
+++ b/amifuse/startup_runner.py
@@ -545,7 +545,10 @@ class HandlerLauncher:
         self._stdpkt_index = (idx + 1) % self._stdpkt_ring_size
         sp_mem = self._stdpkt_ring[idx]
         if sp_mem is None or total > self._stdpkt_sizes[idx]:
-            sp_mem = self.alloc.alloc_memory(total, label=f"stdpkt_scratch_{idx}")
+            new_mem = self.alloc.alloc_memory(total, label=f"stdpkt_scratch_{idx}")
+            if sp_mem is not None:
+                self.alloc.free_memory(sp_mem)
+            sp_mem = new_mem
             self._stdpkt_ring[idx] = sp_mem
             self._stdpkt_sizes[idx] = total
         sp_addr = sp_mem.addr

--- a/tests/unit/test_fuse_fs.py
+++ b/tests/unit/test_fuse_fs.py
@@ -1024,6 +1024,73 @@ class TestHandlerBridgeReadBuf:
         mem.w_block.assert_not_called()
 
 
+class TestHandlerBridgeBstrRing:
+    """Verify bstr ring buffer frees old allocation on growth."""
+
+    def test_alloc_bstr_reuses_existing_slot(self, fuse_mock):
+        from amifuse.fuse_fs import HandlerBridge
+
+        existing_mem = SimpleNamespace(addr=0x3000, size=16)
+        alloc = MagicMock()
+        mem = MagicMock()
+        bridge = HandlerBridge.__new__(HandlerBridge)
+        bridge.vh = SimpleNamespace(alloc=alloc)
+        bridge.mem = mem
+        bridge._bstr_ring = [existing_mem] + [None] * 7
+        bridge._bstr_sizes = [16] + [0] * 7
+        bridge._bstr_ring_size = 8
+        bridge._bstr_index = 0
+
+        bridge._alloc_bstr("hi")
+
+        alloc.alloc_memory.assert_not_called()
+        alloc.free_memory.assert_not_called()
+
+    def test_alloc_bstr_grows_and_frees_old_slot(self, fuse_mock):
+        from amifuse.fuse_fs import HandlerBridge
+
+        old_mem = SimpleNamespace(addr=0x3000, size=4)
+        new_mem = SimpleNamespace(addr=0x4000, size=64)
+        alloc = MagicMock()
+        alloc.alloc_memory.return_value = new_mem
+        mem = MagicMock()
+        bridge = HandlerBridge.__new__(HandlerBridge)
+        bridge.vh = SimpleNamespace(alloc=alloc)
+        bridge.mem = mem
+        bridge._bstr_ring = [old_mem] + [None] * 7
+        bridge._bstr_sizes = [4] + [0] * 7
+        bridge._bstr_ring_size = 8
+        bridge._bstr_index = 0
+
+        bridge._alloc_bstr("a" * 50)
+
+        alloc.alloc_memory.assert_called_once()
+        alloc.free_memory.assert_called_once_with(old_mem)
+        assert bridge._bstr_ring[0] is new_mem
+
+    def test_alloc_bstr_failed_growth_keeps_old_slot(self, fuse_mock):
+        from amifuse.fuse_fs import HandlerBridge
+
+        old_mem = SimpleNamespace(addr=0x3000, size=4)
+        alloc = MagicMock()
+        alloc.alloc_memory.side_effect = RuntimeError("oom")
+        mem = MagicMock()
+        bridge = HandlerBridge.__new__(HandlerBridge)
+        bridge.vh = SimpleNamespace(alloc=alloc)
+        bridge.mem = mem
+        bridge._bstr_ring = [old_mem] + [None] * 7
+        bridge._bstr_sizes = [4] + [0] * 7
+        bridge._bstr_ring_size = 8
+        bridge._bstr_index = 0
+
+        with pytest.raises(RuntimeError, match="oom"):
+            bridge._alloc_bstr("a" * 50)
+
+        assert bridge._bstr_ring[0] is old_mem
+        assert bridge._bstr_sizes[0] == 4
+        alloc.free_memory.assert_not_called()
+
+
 class TestCommandMatchesMountpoint:
     """Direct tests for _command_matches_mountpoint() token matching."""
 

--- a/tests/unit/test_startup_runner.py
+++ b/tests/unit/test_startup_runner.py
@@ -1,6 +1,9 @@
 """Unit tests for amifuse.startup_runner module."""
 
 import inspect
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
 import pytest
 
 
@@ -126,3 +129,86 @@ def test_run_burst_reseeds_execbase_when_restarting_at_main_loop_with_null_a6():
 
     assert "state.pc == state.main_loop_pc" in source
     assert "state.regs[REG_A6] == 0" in source
+
+
+class TestStdpktRingBuffer:
+    """Verify stdpkt ring buffer frees old allocation on growth."""
+
+    def _make_launcher(self):
+        from amifuse.startup_runner import HandlerLauncher
+
+        launcher = HandlerLauncher.__new__(HandlerLauncher)
+        launcher.alloc = MagicMock()
+        launcher.mem = MagicMock()
+        launcher._stdpkt_ring = []
+        launcher._stdpkt_sizes = []
+        launcher._stdpkt_ring_size = 8
+        launcher._stdpkt_index = 0
+        # Minimal field offsets (actual values don't matter for allocation tests)
+        launcher._msg_size = 20
+        launcher._pkt_size = 48
+        launcher._msg_ln_type_offset = 0
+        launcher._msg_ln_succ_offset = 4
+        launcher._msg_ln_pred_offset = 8
+        launcher._mn_replyport_offset = 12
+        launcher._mn_length_offset = 16
+        launcher._msg_ln_name_offset = 18
+        launcher._dp_link_offset = 0
+        launcher._dp_port_offset = 4
+        launcher._dp_type_offset = 8
+        launcher._dp_arg1_offset = 12
+        launcher._debug = False
+        launcher.exec_impl = MagicMock()
+        # Stub out _link_msg_to_port — we're only testing allocation behavior
+        launcher._link_msg_to_port = lambda *args, **kwargs: None
+        return launcher
+
+    def test_stdpkt_first_alloc(self):
+        launcher = self._make_launcher()
+        new_mem = SimpleNamespace(addr=0x5000, size=68)
+        launcher.alloc.alloc_memory.return_value = new_mem
+
+        launcher._build_std_packet(0x1000, 0x2000, 1, [])
+
+        launcher.alloc.alloc_memory.assert_called_once()
+        launcher.alloc.free_memory.assert_not_called()
+        assert launcher._stdpkt_ring[0] is new_mem
+
+    def test_stdpkt_reuses_existing_slot(self):
+        launcher = self._make_launcher()
+        existing = SimpleNamespace(addr=0x5000, size=68)
+        launcher._stdpkt_ring = [existing] + [None] * 7
+        launcher._stdpkt_sizes = [68] + [0] * 7
+
+        launcher._build_std_packet(0x1000, 0x2000, 1, [])
+
+        launcher.alloc.alloc_memory.assert_not_called()
+        launcher.alloc.free_memory.assert_not_called()
+
+    def test_stdpkt_grows_and_frees_old_slot(self):
+        launcher = self._make_launcher()
+        old_mem = SimpleNamespace(addr=0x5000, size=32)
+        new_mem = SimpleNamespace(addr=0x6000, size=68)
+        launcher._stdpkt_ring = [old_mem] + [None] * 7
+        launcher._stdpkt_sizes = [32] + [0] * 7
+        launcher.alloc.alloc_memory.return_value = new_mem
+
+        launcher._build_std_packet(0x1000, 0x2000, 1, [])
+
+        launcher.alloc.alloc_memory.assert_called_once()
+        launcher.alloc.free_memory.assert_called_once_with(old_mem)
+        assert launcher._stdpkt_ring[0] is new_mem
+
+    def test_stdpkt_failed_growth_keeps_old_slot(self):
+        launcher = self._make_launcher()
+        old_mem = SimpleNamespace(addr=0x5000, size=32)
+        launcher._stdpkt_ring = [old_mem] + [None] * 7
+        launcher._stdpkt_sizes = [32] + [0] * 7
+        launcher.alloc.alloc_memory.side_effect = RuntimeError("oom")
+
+        with pytest.raises(RuntimeError, match="oom"):
+            launcher._build_std_packet(0x1000, 0x2000, 1, [])
+
+        assert launcher._stdpkt_ring[0] is old_mem
+        assert launcher._stdpkt_sizes[0] == 32
+        launcher.alloc.free_memory.assert_not_called()


### PR DESCRIPTION
When a bstr or stdpkt ring buffer slot needs to grow (incoming data exceeds the current allocation), the old emulated Amiga memory is silently replaced — the reference is overwritten without freeing it first. In the constrained emulated address space, these leaked allocations accumulate with no reclaim path and no garbage collector to recover them.

Both ring buffers now follow an allocate-new-then-free-old pattern so that a failed allocation leaves the previous slot intact rather than corrupting ring state. This is the same pattern already used by `_alloc_read_buf` (commit ea7979a).

For bstr the leak is bounded (8 slots × ~257 bytes per slot), but over long-running mounts with varied path lengths the fragmentation is real — each growth event permanently consumes emulated memory. The stdpkt ring has the same structural issue; in practice its slot size is constant after the first request, so the grow path rarely executes, but the correctness fix costs nothing to apply.

## Test plan

- [x] 292 tests pass (285 existing + 7 new)
- [x] bstr ring: reuse (no alloc/free), grow-with-free (old freed, new stored), failed-growth-rollback (old slot preserved)
- [x] stdpkt ring: first alloc, reuse, grow-with-free, failed-growth-rollback