### PR TITLE
Remove obsolete fake FUSE shims from tools scripts

### DIFF
--- a/tools/amifuse_matrix.py
+++ b/tools/amifuse_matrix.py
@@ -13,7 +13,6 @@ import subprocess
 import sys
 import time
 import traceback
-import types
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional
@@ -414,30 +413,8 @@ def _ensure_import_path():
         sys.path.insert(0, str(REPO_ROOT))
 
 
-def _install_fake_fuse():
-    if "fuse" in sys.modules:
-        return
-    fake_fuse = types.ModuleType("fuse")
-
-    class _DummyOperations:
-        pass
-
-    class _DummyLoggingMixIn:
-        pass
-
-    class _DummyFuseError(RuntimeError):
-        pass
-
-    fake_fuse.FUSE = object
-    fake_fuse.FuseOSError = _DummyFuseError
-    fake_fuse.LoggingMixIn = _DummyLoggingMixIn
-    fake_fuse.Operations = _DummyOperations
-    sys.modules["fuse"] = fake_fuse
-
-
 def _load_runtime():
     _ensure_import_path()
-    _install_fake_fuse()
     logging.getLogger().setLevel(logging.CRITICAL)
     from amifuse.fuse_fs import HandlerBridge, format_volume
     from amifuse.rdb_inspect import detect_adf, detect_iso, open_rdisk

--- a/tools/image_format_smoke.py
+++ b/tools/image_format_smoke.py
@@ -5,13 +5,11 @@ from __future__ import annotations
 
 import argparse
 import contextlib
-import importlib
 import json
 import os
 import subprocess
 import sys
 import traceback
-import types
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional
@@ -126,36 +124,12 @@ def _ensure_import_path():
         sys.path.insert(0, str(AMITOOLS_ROOT))
 
 
-def _install_fake_fuse():
-    if "fuse" in sys.modules:
-        del sys.modules["fuse"]
-
-    fake_fuse = types.ModuleType("fuse")
-
-    class _DummyOperations:
-        pass
-
-    class _DummyLoggingMixIn:
-        pass
-
-    class _DummyFuseError(RuntimeError):
-        pass
-
-    fake_fuse.FuseOSError = _DummyFuseError
-    fake_fuse.LoggingMixIn = _DummyLoggingMixIn
-    fake_fuse.Operations = _DummyOperations
-    sys.modules["fuse"] = fake_fuse
-    return fake_fuse
-
-
 def _load_runtime():
     _ensure_import_path()
-    fake_fuse = _install_fake_fuse()
     from amifuse.rdb_inspect import detect_adf, detect_iso, open_rdisk
     import amifuse.fuse_fs as fuse_fs
 
-    fuse_fs = importlib.reload(fuse_fs)
-    return fake_fuse, fuse_fs, detect_adf, detect_iso, open_rdisk
+    return fuse_fs, detect_adf, detect_iso, open_rdisk
 
 
 def _inspect_case(case: FormatCase, detect_adf, detect_iso, open_rdisk):
@@ -209,16 +183,7 @@ def _inspect_case(case: FormatCase, detect_adf, detect_iso, open_rdisk):
             blkdev.close()
 
 
-def _cleanup_bridge(bridge):
-    shutdown = getattr(getattr(bridge, "vh", None), "shutdown", None)
-    if shutdown is not None:
-        shutdown()
-    backend = getattr(bridge, "backend", None)
-    if backend is not None:
-        backend.close()
-
-
-def _mount_case(case: FormatCase, fake_fuse, fuse_fs):
+def _mount_case(case: FormatCase, fuse_fs):
     invocation: Dict[str, object] = {}
 
     def _fake_mount(fs, mountpoint, **kwargs):
@@ -237,9 +202,8 @@ def _mount_case(case: FormatCase, fake_fuse, fuse_fs):
                 "read_bytes": len(data),
             }
         )
-        _cleanup_bridge(fs.bridge)
+        fs.bridge.close()
 
-    fake_fuse.FUSE = _fake_mount
     fuse_fs.FUSE = _fake_mount
     mountpoint = REPO_ROOT / "run" / "image-format-smoke" / case.key
     mountpoint.parent.mkdir(parents=True, exist_ok=True)
@@ -263,9 +227,9 @@ def _run_case(case: FormatCase) -> FormatResult:
     try:
         if case.download_url:
             ensure_downloaded_fixture(case.image, case.download_url, case.label)
-        fake_fuse, fuse_fs, detect_adf, detect_iso, open_rdisk = _load_runtime()
+        fuse_fs, detect_adf, detect_iso, open_rdisk = _load_runtime()
         inspect_info = _inspect_case(case, detect_adf, detect_iso, open_rdisk)
-        mount_info = _mount_case(case, fake_fuse, fuse_fs)
+        mount_info = _mount_case(case, fuse_fs)
         detail = (
             f"kind={inspect_info['kind']}"
             f", read={mount_info['read_path']} ({mount_info['read_bytes']} bytes)"

--- a/tools/pfs_benchmark.py
+++ b/tools/pfs_benchmark.py
@@ -9,7 +9,6 @@ import statistics
 import subprocess
 import sys
 import time
-import types
 from pathlib import Path
 
 
@@ -45,23 +44,6 @@ def _run_worker(image: str, driver: str, read_size: int, read_count: int):
         sys.path.insert(0, str(amitools_root))
     if str(repo_root) not in sys.path:
         sys.path.insert(0, str(repo_root))
-    if "fuse" not in sys.modules:
-        fake_fuse = types.ModuleType("fuse")
-
-        class _DummyOperations:
-            pass
-
-        class _DummyLoggingMixIn:
-            pass
-
-        class _DummyFuseError(RuntimeError):
-            pass
-
-        fake_fuse.FUSE = object
-        fake_fuse.FuseOSError = _DummyFuseError
-        fake_fuse.LoggingMixIn = _DummyLoggingMixIn
-        fake_fuse.Operations = _DummyOperations
-        sys.modules["fuse"] = fake_fuse
     from amifuse.fuse_fs import HandlerBridge
 
     start = time.perf_counter()

--- a/tools/readme_smoke.py
+++ b/tools/readme_smoke.py
@@ -13,7 +13,6 @@ import subprocess
 import sys
 import tempfile
 import traceback
-import types
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Dict, Iterable, List, Optional
@@ -67,49 +66,16 @@ def _cli_example(name: str, command: List[str], expect: Callable[[subprocess.Com
     return ExampleResult(name=name, mode="cli", status="ok", command=" ".join(command), details=details)
 
 
-def _install_fake_fuse():
-    if "fuse" in sys.modules:
-        del sys.modules["fuse"]
-
-    fake_fuse = types.ModuleType("fuse")
-
-    class _DummyOperations:
-        pass
-
-    class _DummyLoggingMixIn:
-        pass
-
-    class _DummyFuseError(RuntimeError):
-        pass
-
-    fake_fuse.FuseOSError = _DummyFuseError
-    fake_fuse.LoggingMixIn = _DummyLoggingMixIn
-    fake_fuse.Operations = _DummyOperations
-    sys.modules["fuse"] = fake_fuse
-    return fake_fuse
-
-
-def _cleanup_bridge(bridge):
-    shutdown = getattr(getattr(bridge, "vh", None), "shutdown", None)
-    if shutdown is not None:
-        shutdown()
-    backend = getattr(bridge, "backend", None)
-    if backend is not None:
-        backend.close()
-
-
 def _load_mount_runtime():
     if str(REPO_ROOT) not in sys.path:
         sys.path.insert(0, str(REPO_ROOT))
-    fake_fuse = _install_fake_fuse()
     module = importlib.import_module("amifuse.fuse_fs")
-    module = importlib.reload(module)
-    return fake_fuse, module
+    return module
 
 
 def _mount_example_runner() -> Callable:
     invocations: List[Dict[str, object]] = []
-    fake_fuse, module = _load_mount_runtime()
+    module = _load_mount_runtime()
 
     def _fake_fuse(fs, mountpoint, **kwargs):
         root_names = [entry["name"] for entry in fs.bridge.list_dir_path("/")]
@@ -121,10 +87,9 @@ def _mount_example_runner() -> Callable:
             "icons_enabled": getattr(fs, "_icons_enabled", False),
         }
         invocations.append(invocation)
-        _cleanup_bridge(fs.bridge)
+        fs.bridge.close()
         return invocation
 
-    fake_fuse.FUSE = _fake_fuse
     module.FUSE = _fake_fuse
 
     def run(name: str, command: str, check: Callable[[Dict[str, object], object], str], **kwargs) -> ExampleResult:


### PR DESCRIPTION
## Summary

Since upstream commit 8b3803e, FUSE imports are guarded with try/except in fuse_fs.py — the module loads cleanly without fusepy installed. The `_install_fake_fuse()` workaround in each tools/ script is now dead code. Similarly, the manual `_cleanup_bridge()` helpers duplicated `HandlerBridge.close()` logic that became idempotent in the same commit.

## Details

Removes `_install_fake_fuse()` and `_cleanup_bridge()` from all four tools/ scripts (`amifuse_matrix.py`, `pfs_benchmark.py`, `image_format_smoke.py`, `readme_smoke.py`). Drops the now-unused `types` and `importlib` imports, and removes the `importlib.reload()` calls that were only needed to pick up the injected fake module.

For `image_format_smoke.py` and `readme_smoke.py`, the `fuse_fs.FUSE = _fake_mount` assignment for mount-path interception is preserved — only the module-injection workaround is removed. Bridge teardown calls switch from the removed `_cleanup_bridge(fs.bridge)` to the existing `fs.bridge.close()`.

`tests/conftest.py`'s `fuse_mock` fixture is intentionally untouched — it stubs amitools/startup_runner dependencies for unit tests, not just FUSE.

## Testing

Verified that all four tools/ scripts still import and run correctly without fusepy installed. Existing unit tests pass unchanged.