### PR TITLE
Fix BPTR conversion in send_disk_info, add fixture root env override

### DIFF
--- a/amifuse/startup_runner.py
+++ b/amifuse/startup_runner.py
@@ -1004,8 +1004,8 @@ class HandlerLauncher:
         return run_state
 
     def send_disk_info(self, state: HandlerLaunchState, info_buf_addr: int):
-        # Arg1 = InfoData* (APTR)
-        return self.send_packet(state, ACTION_DISK_INFO, [info_buf_addr])
+        # Arg1 = InfoData* (BPTR)
+        return self.send_packet(state, ACTION_DISK_INFO, [info_buf_addr >> 2])
 
     def send_read(self, state: HandlerLaunchState, buf_addr: int, offset_bytes: int, length_bytes: int):
         # Arg1 = window (not used), Arg2 = offset (block), Arg3 = buf, Arg4 = length

--- a/tools/fixture_paths.py
+++ b/tools/fixture_paths.py
@@ -14,7 +14,8 @@ from pathlib import Path
 from urllib.parse import parse_qs, urlencode, urljoin, urlparse
 
 
-FIXTURE_ROOT = Path.home() / "AmigaOS" / "AmiFuse"
+_env_root = os.environ.get("AMIFUSE_FIXTURE_ROOT")
+FIXTURE_ROOT = Path(_env_root) if _env_root else Path.home() / "AmigaOS" / "AmiFuse"
 DRIVERS_DIR = FIXTURE_ROOT / "drivers"
 FIXTURES_DIR = FIXTURE_ROOT / "fixtures"
 READONLY_DIR = FIXTURES_DIR / "readonly"


### PR DESCRIPTION
## Summary

Two independent fixes in separate commits:

**BPTR conversion (`startup_runner.py`):** `send_disk_info` was passing `info_buf_addr` as a raw APTR to `ACTION_DISK_INFO`, but the AmigaDOS packet protocol expects a BPTR (address >> 2) — the same convention used by `send_examine`, `send_findinput`, and every other `send_*` method in the class. Without the shift, the handler receives a pointer 4x too large, which could corrupt the InfoData result or crash on handlers that validate pointer alignment.

**Fixture path override (`fixture_paths.py`):** `FIXTURE_ROOT` was hardcoded to `~/AmigaOS/AmiFuse`, which works for local development but blocks CI runners and contributors who clone AmiFUSE-testing to a different location. Adding `AMIFUSE_FIXTURE_ROOT` env var support lets CI point fixture resolution at its clone path without modifying the default local workflow. When unset (or empty), behavior is unchanged.

## Test plan

- [x] `>> 2` pattern matches all peer `send_*` methods — confirmed: `send_examine` (L1064), `send_examine_next` (L1068), `send_findinput` (L1086), `send_findupdate` (L1105), `send_findoutput` (L1124) all use `>> 2`
- [x] `fixture_paths.py` defaults unchanged when env var unset — confirmed: `os.environ.get()` returns `None`, falsy branch takes `Path.home() / "AmigaOS" / "AmiFuse"`
- [x] Empty `AMIFUSE_FIXTURE_ROOT=""` falls back to default, not CWD — confirmed: empty string is falsy, two-line conditional avoids `Path("")`
- [x] Existing test suite passes — 285/285 in 0.76s