### PR TITLE
Add disabled Windows CI entries and CONTRIBUTING.md

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,9 +43,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Windows excluded: machine68k segfaults due to opcode table
-        # over-read (cnvogelg/machine68k#8) and JMP/CAS collision (#9).
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        exclude:
+          # Windows excluded: machine68k segfaults due to opcode table
+          # over-read (cnvogelg/machine68k#8) and JMP/CAS collision (#9).
+          # Remove this exclude block once upstream fixes land.
+          - os: windows-latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -89,7 +92,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        exclude:
+          # Windows excluded: machine68k segfaults due to opcode table
+          # over-read (cnvogelg/machine68k#8) and JMP/CAS collision (#9).
+          # Remove this exclude block once upstream fixes land.
+          - os: windows-latest
     steps:
       - uses: actions/checkout@v4
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,87 @@
+# Contributing
+
+Thanks for your interest in AmiFUSE. This guide covers the minimum
+needed to clone, build, test, and submit changes.
+
+## Prerequisites
+
+- **Python 3.11+** for development (`pyproject.toml` declares `>=3.9`
+  for runtime compatibility, but CI tests 3.11 through 3.13)
+- **Git** with submodule support
+- Optional: [macFUSE](https://osxfuse.github.io/) /
+  [FUSE for Linux](https://github.com/libfuse/libfuse) /
+  [WinFSP](https://winfsp.dev/) (only needed for live mount testing)
+
+## Clone and Setup
+
+```sh
+git clone --recurse-submodules https://github.com/reinauer/AmiFUSE.git
+cd AmiFUSE
+python3 -m venv .venv
+source .venv/bin/activate   # Windows: .venv\Scripts\activate
+pip install -e "./amitools[vamos]"
+pip install "pytest>=7.0" "pytest-cov>=4.0" "pytest-timeout>=2.0"
+pip install -e "." --no-deps
+```
+
+## Running Tests
+
+```sh
+# Quick check (all platforms, no fixtures needed)
+pytest tests/unit/ -v --timeout=30
+```
+
+See [TESTING.md](TESTING.md) for integration tests, tools smoke, and
+the full test matrix.
+
+## Test Fixtures
+
+Integration tests resolve the fixture directory through a cascade:
+
+| Priority | Source | How |
+|----------|--------|-----|
+| 1 | `AMIFUSE_FIXTURE_ROOT` env var | Point at any directory with `drivers/` and `fixtures/readonly/` |
+| 2 | `../AmiFUSE-testing` sibling checkout | Clone [AmiFUSE-testing](https://github.com/reinauer/AmiFUSE-testing) next to AmiFUSE |
+| 3 | `~/AmigaOS/AmiFuse` | Default local path |
+| -- | None found | Integration tests skip gracefully |
+
+The fixture directory should contain:
+
+```
+<fixture-root>/
+├── drivers/
+│   ├── pfs3aio
+│   ├── SmartFilesystem
+│   ├── FastFileSystem
+│   ├── BFFSFilesystem
+│   └── ...
+└── fixtures/
+    └── readonly/
+        ├── pfs.hdf
+        ├── sfs.hdf
+        ├── ofs.adf
+        └── ...
+```
+
+## How CI Works
+
+The workflow (`.github/workflows/ci.yml`) has three layers:
+
+- **Unit tests** -- All platforms (Linux, macOS, Windows) x Python
+  3.11--3.13. No external dependencies.
+- **Integration tests** -- Linux + macOS only. Clones AmiFUSE-testing
+  for fixtures. Exercises the full m68k emulation stack.
+- **Tools smoke** -- Linux + macOS only. Same fixtures. Runs
+  `amifuse_matrix.py` and `image_format_smoke.py` as CI-visible smoke
+  checks.
+
+Windows is excluded from integration and smoke jobs pending upstream
+machine68k fixes
+([cnvogelg/machine68k#8](https://github.com/cnvogelg/machine68k/issues/8),
+[cnvogelg/machine68k#9](https://github.com/cnvogelg/machine68k/issues/9)).
+
+## Pull Requests
+
+- One logical change per PR
+- All CI checks should pass (or failures should be pre-existing)
+- Keep the scope focused -- small, reviewable diffs are easier to merge

--- a/TESTING.md
+++ b/TESTING.md
@@ -8,6 +8,9 @@ This repo currently has two testing layers:
 `PERFORMANCE.md` records timing policy and current benchmark tables.
 It is not the main "how do I run the tests?" document. This file is.
 
+New to the project? See [CONTRIBUTING.md](CONTRIBUTING.md) for clone,
+setup, and fixture resolution instructions.
+
 ## Fixtures
 
 Top-level AmiFuse tests use images and drivers from:


### PR DESCRIPTION
## Why

PR #41 established CI with integration tests and tools smoke on Linux and macOS, but left Windows out entirely because machine68k segfaults on Windows runners (cnvogelg/machine68k#8, #9). That's the right call for now, but it means enabling Windows CI later requires someone to remember the exact matrix syntax, figure out which jobs need it, and write the upstream issue references from scratch. Meanwhile, new contributors have no onboarding path — TESTING.md documents the test matrix in depth but assumes you already have a working checkout with fixtures resolved.

## How

### Windows CI readiness

Rather than leaving Windows as an implicit omission (just not listed in the `os` array), both `integration-tests` and `tools-smoke` now declare `windows-latest` in their matrix and immediately exclude it via `exclude` blocks. The exclude blocks carry the upstream issue references as comments, so the context travels with the code. When machine68k #8 and #9 land, enabling Windows is a four-line deletion — remove the `exclude` block — with no other changes needed.

This approach was chosen over YAML comments (not schema-validated, easy to overlook) and conditional `if` expressions (noisier, runtime complexity for a static decision).

### Contributor onboarding

CONTRIBUTING.md covers the minimum path from clone to passing tests: prerequisites, venv setup, and a single `pytest tests/unit/` command. Everything else links to TESTING.md rather than duplicating it. The fixture resolution cascade (env var → sibling checkout → default path → skip) gets its own section because it's the main stumbling block for new contributors — integration tests silently skip without fixtures, and the three-tier fallback isn't obvious from the code alone.

TESTING.md gets a reciprocal pointer so the two documents form a coherent pair: CONTRIBUTING.md answers "how do I get started?" and TESTING.md answers "what tests exist and how do I run them?"

## Test plan

- [x] CI passes — unit-tests (9/9), integration-tests (2/2), tools-smoke (2/2)
- [x] Windows jobs are excluded (not failing) in integration-tests and tools-smoke
- [x] Removing both `exclude` blocks is the only change needed to enable Windows
- [x] CONTRIBUTING.md clone-to-test instructions are accurate
- [x] TESTING.md → CONTRIBUTING.md cross-reference works