### PR TITLE
ci: enable Windows integration and tools-smoke CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,11 +44,6 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        exclude:
-          # Windows excluded: machine68k segfaults due to opcode table
-          # over-read (cnvogelg/machine68k#8) and JMP/CAS collision (#9).
-          # Remove this exclude block once upstream fixes land.
-          - os: windows-latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -66,6 +61,14 @@ jobs:
         run: |
           git clone --depth 1 https://github.com/reinauer/AmiFUSE-testing.git ../AmiFUSE-testing
         continue-on-error: true
+
+      - name: Install machine68k-amifuse (Windows)
+        # Upstream machine68k lacks Windows fixes (cnvogelg/machine68k#8,
+        # #9). The machine68k-amifuse fork includes all fixes with
+        # pre-built Windows wheels.
+        # Remove this step once upstream machine68k merges the fixes.
+        if: runner.os == 'Windows'
+        run: pip install "machine68k-amifuse>=0.4.1.post1"
 
       - name: Install dependencies
         run: |
@@ -93,11 +96,6 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        exclude:
-          # Windows excluded: machine68k segfaults due to opcode table
-          # over-read (cnvogelg/machine68k#8) and JMP/CAS collision (#9).
-          # Remove this exclude block once upstream fixes land.
-          - os: windows-latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -115,6 +113,14 @@ jobs:
         run: |
           git clone --depth 1 https://github.com/reinauer/AmiFUSE-testing.git ../AmiFUSE-testing
         continue-on-error: true
+
+      - name: Install machine68k-amifuse (Windows)
+        # Upstream machine68k lacks Windows fixes (cnvogelg/machine68k#8,
+        # #9). The machine68k-amifuse fork includes all fixes with
+        # pre-built Windows wheels.
+        # Remove this step once upstream machine68k merges the fixes.
+        if: runner.os == 'Windows'
+        run: pip install "machine68k-amifuse>=0.4.1.post1"
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Why

The `machine68k-amifuse` PyPI package now ships pre-built Windows
wheels with all three upstream fixes (#7, #8, #9) baked in. Since
`pip install amifuse` already resolves to `machine68k-amifuse` for
end users, the public Windows experience works today — but CI
doesn't validate it.

## How

A conditional pre-install step (`if: runner.os == 'Windows'`) pins
`machine68k-amifuse>=0.4.1.post1` before the editable submodule
install. When pip later sees the `machine68k >= 0.4.0` requirement
from amitools, it's already satisfied — no source compilation, no
segfaults. Linux and macOS are unchanged.

The step is clearly marked as a workaround with a note to remove it
once upstream `machine68k` merges the fixes.