### PR TITLE
Add amifuse status command for mount discovery

### DIFF
--- a/amifuse/fuse_fs.py
+++ b/amifuse/fuse_fs.py
@@ -3780,21 +3780,42 @@ def cmd_unmount(args):
         raise SystemExit(f"Mountpoint {mountpoint} is not currently mounted.")
 
     cmd = plat.get_unmount_command(mountpoint)
-    if not cmd:
-        raise SystemExit(
-            "This platform does not provide a standalone unmount command yet. "
-            "Stop the amifuse process that owns the mount instead."
-        )
-
-    result = subprocess.run(cmd, check=False)
-    if result.returncode != 0:
+    if cmd:
+        result = subprocess.run(cmd, check=False)
+        if result.returncode != 0:
+            killed_pids = _kill_mount_owner_processes(mountpoint)
+            if killed_pids:
+                result = subprocess.run(cmd, check=False)
+        if result.returncode != 0:
+            raise SystemExit(
+                f"Unmount failed with exit code {result.returncode}: "
+                f"{' '.join(cmd)}"
+            )
+    else:
+        # No platform unmount command (e.g. Windows/WinFSP) -- go straight
+        # to process termination.
         killed_pids = _kill_mount_owner_processes(mountpoint)
-        if killed_pids:
-            result = subprocess.run(cmd, check=False)
-    if result.returncode != 0:
-        raise SystemExit(
-            f"Unmount failed with exit code {result.returncode}: {' '.join(cmd)}"
-        )
+        if not killed_pids:
+            raise SystemExit(
+                f"No amifuse process found for mountpoint {mountpoint}."
+            )
+        print(f"Unmounted {mountpoint} (terminated "
+              f"{'processes' if len(killed_pids) > 1 else 'process'}"
+              f" {', '.join(str(p) for p in killed_pids)}).")
+
+
+def _truncate_left(s, max_width):
+    """Truncate a string from the left, preserving the rightmost characters.
+
+    The filename at the end of a path is more useful than the directory prefix,
+    so we trim from the left and prepend an ellipsis when truncation occurs.
+
+    >>> _truncate_left("C:/very/long/path/to/file.hdf", 20)
+    '..path/to/file.hdf'
+    """
+    if len(s) <= max_width:
+        return s
+    return ".." + s[-(max_width - 2):]
 
 
 def cmd_status(args):
@@ -3837,7 +3858,7 @@ def cmd_status(args):
                     uptime_str = f"{hrs}h {mins}m {secs}s"
                 else:
                     uptime_str = "N/A"
-                image = m.get("image") or "N/A"
+                image = _truncate_left(m.get("image") or "N/A", 40)
                 mountpoint = m.get("mountpoint") or "N/A"
                 print(f"{m['pid']:<8} {mountpoint:<20} {image:<40} {uptime_str}")
 

--- a/amifuse/fuse_fs.py
+++ b/amifuse/fuse_fs.py
@@ -3797,6 +3797,51 @@ def cmd_unmount(args):
         )
 
 
+def cmd_status(args):
+    """Handle the 'status' subcommand."""
+    import json
+    from . import platform as plat
+
+    try:
+        mounts = plat.find_amifuse_mounts()
+    except OSError as exc:
+        if getattr(args, "json", False):
+            print(json.dumps({
+                "status": "error",
+                "command": "status",
+                "error": f"Process discovery failed: {exc}",
+                "mounts": [],
+            }, indent=2))
+        else:
+            print(f"Error: Process discovery failed: {exc}")
+        sys.exit(1)
+
+    if getattr(args, "json", False):
+        print(json.dumps({
+            "status": "ok",
+            "command": "status",
+            "mounts": mounts,
+        }, indent=2))
+    else:
+        if not mounts:
+            print("No active AmiFUSE mounts.")
+        else:
+            # Tabular output
+            print(f"{'PID':<8} {'Mountpoint':<20} {'Image':<40} {'Uptime'}")
+            print("-" * 80)
+            for m in mounts:
+                uptime = m.get("uptime_seconds")
+                if uptime is not None:
+                    mins, secs = divmod(uptime, 60)
+                    hrs, mins = divmod(mins, 60)
+                    uptime_str = f"{hrs}h {mins}m {secs}s"
+                else:
+                    uptime_str = "N/A"
+                image = m.get("image") or "N/A"
+                mountpoint = m.get("mountpoint") or "N/A"
+                print(f"{m['pid']:<8} {mountpoint:<20} {image:<40} {uptime_str}")
+
+
 def cmd_doctor(args):
     """Handle the 'doctor' subcommand."""
     import json
@@ -3946,136 +3991,35 @@ def _kill_mount_owner_processes(mountpoint: Path) -> List[int]:
 def _find_mount_owner_pids(mountpoint: Path) -> List[int]:
     """Find PIDs of amifuse processes that own the given mountpoint.
 
-    Dispatches to platform-specific discovery: ``ps`` on Unix,
-    ``wmic`` on Windows.
+    Uses platform.find_amifuse_mounts() for process discovery, then
+    filters to those matching the given mountpoint.
     """
-    if sys.platform.startswith("win"):
-        return _find_mount_owner_pids_windows(mountpoint)
-    return _find_mount_owner_pids_unix(mountpoint)
+    from . import platform as plat
 
-
-def _find_mount_owner_pids_windows(mountpoint: Path) -> List[int]:
-    """Find amifuse PIDs on Windows using wmic."""
-    try:
-        result = subprocess.run(
-            ["wmic", "process", "where",
-             "name like '%python%'",
-             "get", "ProcessId,CommandLine",
-             "/FORMAT:LIST"],
-            check=False,
-            capture_output=True,
-            text=True,
-        )
-    except OSError:
-        return []
-    if result.returncode != 0:
-        return []
-
-    current_pid = os.getpid()
     raw_mountpoint = str(mountpoint)
     abs_mountpoint = str(mountpoint.resolve(strict=False))
-    pids = []
 
-    # wmic /FORMAT:LIST outputs key=value pairs separated by blank lines
-    current_cmdline = None
-    current_pid_val = None
-    for line in result.stdout.splitlines():
-        line = line.strip()
-        if not line:
-            # End of a record -- evaluate what we have
-            if current_cmdline is not None and current_pid_val is not None:
-                pid = current_pid_val
-                command = current_cmdline
-                if pid != current_pid and "amifuse" in command:
-                    try:
-                        tokens = shlex.split(command, posix=False)
-                    except ValueError:
-                        tokens = command.split()
-                    if _command_matches_mountpoint(tokens, raw_mountpoint, abs_mountpoint):
-                        pids.append(pid)
-            current_cmdline = None
-            current_pid_val = None
-            continue
-        if line.startswith("CommandLine="):
-            current_cmdline = line[len("CommandLine="):]
-        elif line.startswith("ProcessId="):
-            try:
-                current_pid_val = int(line[len("ProcessId="):])
-            except ValueError:
-                current_pid_val = None
-
-    # Handle last record if no trailing blank line
-    if current_cmdline is not None and current_pid_val is not None:
-        pid = current_pid_val
-        command = current_cmdline
-        if pid != current_pid and "amifuse" in command:
-            try:
-                tokens = shlex.split(command, posix=False)
-            except ValueError:
-                tokens = command.split()
-            if _command_matches_mountpoint(tokens, raw_mountpoint, abs_mountpoint):
-                pids.append(pid)
-
-    return pids
-
-
-def _find_mount_owner_pids_unix(mountpoint: Path) -> List[int]:
-    """Find amifuse PIDs on Unix using ps."""
     try:
-        result = subprocess.run(
-            ["ps", "-axo", "pid=,command="],
-            check=False,
-            capture_output=True,
-            text=True,
-        )
+        all_mounts = plat.find_amifuse_mounts()
     except OSError:
         return []
-    if result.returncode != 0:
-        return []
 
-    current_pid = os.getpid()
-    raw_mountpoint = str(mountpoint)
-    abs_mountpoint = str(mountpoint.resolve(strict=False))
     pids = []
-
-    for line in result.stdout.splitlines():
-        line = line.strip()
-        if not line:
+    for mount in all_mounts:
+        mp = mount.get("mountpoint")
+        if mp is None:
+            continue
+        if mp == raw_mountpoint or mp == abs_mountpoint:
+            pids.append(mount["pid"])
             continue
         try:
-            pid_str, command = line.split(None, 1)
-            pid = int(pid_str)
-        except ValueError:
-            continue
-        if pid == current_pid or "amifuse" not in command:
-            continue
-        try:
-            tokens = shlex.split(command)
-        except ValueError:
-            continue
-        if not _command_matches_mountpoint(tokens, raw_mountpoint, abs_mountpoint):
-            continue
-        pids.append(pid)
-
-    return pids
-
-
-def _command_matches_mountpoint(tokens: List[str], raw_mountpoint: str, abs_mountpoint: str) -> bool:
-    for idx, token in enumerate(tokens):
-        if token != "--mountpoint":
-            continue
-        if idx + 1 >= len(tokens):
-            return False
-        mount_arg = tokens[idx + 1]
-        if mount_arg == raw_mountpoint or mount_arg == abs_mountpoint:
-            return True
-        try:
-            resolved = str(Path(mount_arg).expanduser().resolve(strict=False))
+            resolved = str(Path(mp).expanduser().resolve(strict=False))
         except OSError:
             continue
         if resolved == abs_mountpoint:
-            return True
-    return False
+            pids.append(mount["pid"])
+
+    return pids
 
 
 def _pid_exists(pid: int) -> bool:
@@ -4129,6 +4073,9 @@ commands:
     --profile                 Enable profiling and write stats to profile.txt.
 
   unmount <mountpoint>      Unmount an existing AmiFUSE mount.
+
+  status                    Show active AmiFUSE mounts on this system.
+    --json                    Output results as JSON.
 
   doctor                    Check prerequisites and environment readiness.
     --json                    Output results as JSON.
@@ -4267,6 +4214,16 @@ commands:
     )
     unmount_parser.add_argument("mountpoint", type=Path, help="Mounted filesystem path")
     unmount_parser.set_defaults(func=cmd_unmount)
+
+    # status subcommand
+    status_parser = subparsers.add_parser(
+        "status", help="Show active AmiFUSE mounts on this system."
+    )
+    status_parser.add_argument(
+        "--json", action="store_true",
+        help="Output results as JSON.",
+    )
+    status_parser.set_defaults(func=cmd_status)
 
     # doctor subcommand
     doctor_parser = subparsers.add_parser(

--- a/amifuse/platform.py
+++ b/amifuse/platform.py
@@ -11,9 +11,13 @@ Platform-specific implementations:
 """
 
 import errno
+import logging
 import os
+import shlex
 import shutil
+import subprocess
 import sys
+import time
 from pathlib import Path
 from typing import List, Optional, TYPE_CHECKING
 
@@ -392,3 +396,282 @@ def pre_generate_volume_icon(bridge, debug: bool = False) -> Optional[Path]:
         print(f"[amifuse] Generated volume icon: {temp_path} ({len(icns_data)} bytes)", flush=True)
 
     return Path(temp_path)
+
+
+# ---------------------------------------------------------------------------
+# Mount discovery
+# ---------------------------------------------------------------------------
+
+logger = logging.getLogger(__name__)
+
+
+def find_amifuse_mounts():
+    """Discover all active amifuse mount processes on the system.
+
+    Returns a list of dicts, each with keys:
+        - mountpoint (str)
+        - image (str or None)
+        - pid (int)
+        - uptime_seconds (int or None)
+        - filesystem_type (None -- reserved for future use)
+
+    Raises OSError if the process discovery command fails unexpectedly.
+    Returns an empty list if the discovery tool is unavailable.
+    """
+    if sys.platform.startswith("win"):
+        return _find_amifuse_mounts_windows()
+    return _find_amifuse_mounts_unix()
+
+
+def _parse_mount_tokens(tokens):
+    """Extract image path and --mountpoint value from amifuse command tokens.
+
+    The image is the first positional arg after the 'mount' subcommand.
+    Handles both 'python -m amifuse mount <image> ...' and
+    'amifuse mount <image> ...' invocation forms.
+
+    Returns (image, mountpoint) where either may be None if not found.
+    """
+    # Find the index of 'mount' subcommand
+    mount_idx = None
+    for i, tok in enumerate(tokens):
+        if tok == "mount":
+            mount_idx = i
+            break
+    if mount_idx is None:
+        return None, None
+
+    # Image is the first positional arg after 'mount' (not starting with '-')
+    image = None
+    mountpoint = None
+    i = mount_idx + 1
+    while i < len(tokens):
+        tok = tokens[i]
+        if tok == "--mountpoint" and i + 1 < len(tokens):
+            mountpoint = tokens[i + 1]
+            i += 2
+            continue
+        if tok.startswith("-"):
+            # Skip flags; if flag takes a value, skip next token too
+            # Known value-taking flags in mount subcommand
+            value_flags = {"--driver", "--partition", "--block-size", "--volname"}
+            if tok in value_flags and i + 1 < len(tokens):
+                i += 2
+            else:
+                i += 1
+            continue
+        if image is None:
+            image = tok
+        i += 1
+
+    return image, mountpoint
+
+
+def _find_amifuse_mounts_unix():
+    """Discover amifuse mounts on macOS/Linux using ps."""
+    is_mac = sys.platform.startswith("darwin")
+
+    # macOS: lstart gives absolute start time; Linux: etimes gives elapsed seconds
+    if is_mac:
+        ps_cmd = ["ps", "-axo", "pid=,lstart=,command="]
+    else:
+        ps_cmd = ["ps", "-axo", "pid=,etimes=,command="]
+
+    try:
+        result = subprocess.run(
+            ps_cmd, check=False, capture_output=True, text=True,
+        )
+    except OSError:
+        logger.debug("ps not available, cannot discover mounts")
+        return []
+    if result.returncode != 0:
+        logger.debug("ps exited with code %d", result.returncode)
+        return []
+
+    current_pid = os.getpid()
+    mounts = []
+
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        if "amifuse" not in line or "mount" not in line:
+            continue
+
+        try:
+            if is_mac:
+                # Format: "  PID  DAY MON DD HH:MM:SS YYYY COMMAND..."
+                # lstart is 5 tokens: e.g. "Sat Apr 19 10:30:00 2026"
+                parts = line.split(None, 6)
+                if len(parts) < 7:
+                    continue
+                pid = int(parts[0])
+                lstart_str = " ".join(parts[1:6])
+                command = parts[6]
+                # Parse lstart to compute uptime
+                uptime = _parse_lstart_uptime(lstart_str)
+            else:
+                # Format: "  PID ETIMES COMMAND..."
+                parts = line.split(None, 2)
+                if len(parts) < 3:
+                    continue
+                pid = int(parts[0])
+                command = parts[2]
+                try:
+                    uptime = int(parts[1])
+                except ValueError:
+                    uptime = None
+        except ValueError:
+            logger.debug("Skipping unparseable ps line: %s", line)
+            continue
+
+        if pid == current_pid:
+            continue
+
+        # Must contain "mount" as a subcommand, not just in a path
+        try:
+            tokens = shlex.split(command)
+        except ValueError:
+            logger.debug("Skipping line with unparseable command: %s", line)
+            continue
+
+        if "mount" not in tokens:
+            continue
+
+        image, mountpoint = _parse_mount_tokens(tokens)
+
+        mounts.append({
+            "mountpoint": mountpoint,
+            "image": image,
+            "pid": pid,
+            "uptime_seconds": uptime,
+            "filesystem_type": None,
+        })
+
+    return mounts
+
+
+def _parse_lstart_uptime(lstart_str):
+    """Parse macOS ps lstart string and return uptime in seconds."""
+    import calendar
+
+    try:
+        # lstart format: "Sat Apr 19 10:30:00 2026"
+        # Parse with time.strptime (locale-independent for English month/day names)
+        t = time.strptime(lstart_str, "%a %b %d %H:%M:%S %Y")
+        start_epoch = calendar.timegm(t)
+        return max(0, int(time.time() - start_epoch))
+    except (ValueError, OverflowError):
+        return None
+
+
+def _find_amifuse_mounts_windows():
+    """Discover amifuse mounts on Windows using wmic.
+
+    Note: wmic is deprecated on Windows 11. Future fallback: use
+    Get-CimInstance Win32_Process via PowerShell if wmic is unavailable.
+    """
+    try:
+        result = subprocess.run(
+            ["wmic", "process", "where",
+             "name like '%python%'",
+             "get", "ProcessId,CommandLine,CreationDate",
+             "/FORMAT:LIST"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError:
+        # wmic not available (e.g., removed on newer Windows 11 builds)
+        logger.debug("wmic not available, cannot discover mounts")
+        return []
+    if result.returncode != 0:
+        logger.debug("wmic exited with code %d", result.returncode)
+        return []
+
+    current_pid = os.getpid()
+    mounts = []
+
+    # wmic /FORMAT:LIST outputs key=value pairs separated by blank lines
+    current_cmdline = None
+    current_pid_val = None
+    current_creation = None
+
+    def _process_record():
+        if current_cmdline is None or current_pid_val is None:
+            return
+        if current_pid_val == current_pid:
+            return
+        if "amifuse" not in current_cmdline:
+            return
+
+        try:
+            tokens = shlex.split(current_cmdline, posix=False)
+        except ValueError:
+            tokens = current_cmdline.split()
+
+        if "mount" not in tokens:
+            return
+
+        image, mountpoint = _parse_mount_tokens(tokens)
+
+        uptime = _parse_wmic_creation_date_uptime(current_creation)
+
+        mounts.append({
+            "mountpoint": mountpoint,
+            "image": image,
+            "pid": current_pid_val,
+            "uptime_seconds": uptime,
+            "filesystem_type": None,
+        })
+
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        if not line:
+            # wmic uses \r\r\n which creates spurious empty lines between
+            # fields within a record.  Only finalise when we have a complete
+            # record (both CommandLine and ProcessId collected).
+            if current_cmdline is not None and current_pid_val is not None:
+                _process_record()
+                current_cmdline = None
+                current_pid_val = None
+                current_creation = None
+            continue
+        if line.startswith("CommandLine="):
+            current_cmdline = line[len("CommandLine="):]
+        elif line.startswith("ProcessId="):
+            try:
+                current_pid_val = int(line[len("ProcessId="):])
+            except ValueError:
+                current_pid_val = None
+        elif line.startswith("CreationDate="):
+            current_creation = line[len("CreationDate="):]
+
+    # Handle last record if no trailing blank line
+    _process_record()
+
+    return mounts
+
+
+def _parse_wmic_creation_date_uptime(creation_str):
+    """Parse wmic CreationDate (yyyymmddHHMMSS.ffffff+ZZZ) to uptime seconds."""
+    if not creation_str:
+        return None
+    try:
+        # Format: 20260419103000.123456+060
+        # Take first 14 chars: yyyymmddHHMMSS
+        dt_str = creation_str[:14]
+        t = time.strptime(dt_str, "%Y%m%d%H%M%S")
+        import calendar
+        start_epoch = calendar.timegm(t)
+        # Adjust for timezone offset in wmic output (+/- minutes)
+        if len(creation_str) > 21:
+            tz_str = creation_str[21:]
+            try:
+                tz_minutes = int(tz_str)
+                start_epoch -= tz_minutes * 60
+            except ValueError:
+                pass
+        return max(0, int(time.time() - start_epoch))
+    except (ValueError, OverflowError):
+        return None

--- a/amifuse/platform.py
+++ b/amifuse/platform.py
@@ -130,14 +130,11 @@ def _get_winfsp_install_dir() -> Optional[str]:
 def _get_windows_unmount_command(mountpoint: Path) -> List[str]:
     """Build a Windows unmount command for the given mountpoint.
 
-    WinFSP drive-letter mounts (e.g. ``Z:``) can be detached with
-    ``net use Z: /delete``.  Non-drive-letter mounts have no standalone
-    unmount CLI -- callers handle the empty-list case by falling back to
-    process termination.
+    WinFSP mounts are not network drives, so ``net use /delete`` does not
+    work for them.  Return an empty list so that ``cmd_unmount`` falls
+    through to process-termination, which is the reliable approach on
+    Windows.
     """
-    mp_str = str(mountpoint)
-    if len(mp_str) == 2 and mp_str[1] == ":":
-        return ["net", "use", mp_str, "/delete"]
     return []
 
 
@@ -419,8 +416,12 @@ def find_amifuse_mounts():
     Returns an empty list if the discovery tool is unavailable.
     """
     if sys.platform.startswith("win"):
-        return _find_amifuse_mounts_windows()
-    return _find_amifuse_mounts_unix()
+        mounts = _find_amifuse_mounts_windows()
+    else:
+        mounts = _find_amifuse_mounts_unix()
+
+    _enrich_null_mountpoints(mounts)
+    return mounts
 
 
 def _parse_mount_tokens(tokens):
@@ -651,6 +652,110 @@ def _find_amifuse_mounts_windows():
     _process_record()
 
     return mounts
+
+
+# ---------------------------------------------------------------------------
+# Mountpoint enrichment for auto-assigned mounts
+# ---------------------------------------------------------------------------
+
+
+def _enrich_null_mountpoints(mounts):
+    """Post-process mounts to fill in mountpoint=None entries.
+
+    When users mount without --mountpoint, the CLI args don't contain
+    the mountpoint, so process scanning yields None.  We heuristically
+    detect the actual mountpoint via OS-specific APIs.
+
+    Limitation: when multiple auto-assigned mounts exist, the pairing
+    of process-to-mountpoint is non-deterministic (we lack PID-to-handle
+    mapping without admin privileges).  For the common single-mount case,
+    the 1:1 match is reliable.
+    """
+    null_mounts = [m for m in mounts if m.get("mountpoint") is None]
+    if not null_mounts:
+        return
+
+    if sys.platform.startswith("win"):
+        _enrich_mountpoints_windows(null_mounts, mounts)
+    elif sys.platform.startswith("darwin"):
+        _enrich_mountpoints_macos(null_mounts, mounts)
+    # Linux requires explicit --mountpoint; no enrichment needed.
+
+
+def _enrich_mountpoints_windows(null_mounts, all_mounts):
+    """Scan drive letters for WinFSP/AmiFUSE volumes and assign to null mounts.
+
+    Uses GetVolumeInformationW to check the filesystem name on each drive.
+    Drives with fs name starting with 'FUSE-AmiFUSE' are amifuse mounts.
+    """
+    try:
+        import ctypes
+    except ImportError:
+        return
+
+    # Collect mountpoints already known (claimed by explicit --mountpoint)
+    claimed = {m["mountpoint"] for m in all_mounts if m.get("mountpoint")}
+
+    amifuse_drives = []
+    fs_name_buf = ctypes.create_unicode_buffer(256)
+    vol_name_buf = ctypes.create_unicode_buffer(256)
+
+    for letter in "DEFGHIJKLMNOPQRSTUVWXYZ":
+        drive = f"{letter}:\\"
+        try:
+            ok = ctypes.windll.kernel32.GetVolumeInformationW(
+                drive,
+                vol_name_buf, 256,
+                None, None, None,
+                fs_name_buf, 256,
+            )
+        except Exception:
+            continue
+        if not ok:
+            continue
+        fs_name = fs_name_buf.value
+        if fs_name.startswith("FUSE-AmiFUSE"):
+            drive_mp = f"{letter}:"
+            if drive_mp not in claimed:
+                amifuse_drives.append(drive_mp)
+
+    # Match null-mountpoint processes to discovered drives.
+    # Non-deterministic for multiple mounts -- best-effort pairing.
+    for mount, drive in zip(null_mounts, amifuse_drives):
+        mount["mountpoint"] = drive
+
+
+def _enrich_mountpoints_macos(null_mounts, all_mounts):
+    """Scan /Volumes/ for amifuse mount points and assign to null mounts.
+
+    Checks entries in /Volumes/ that are actual mount points.
+    """
+    volumes_dir = "/Volumes"
+    if not os.path.isdir(volumes_dir):
+        return
+
+    claimed = {m["mountpoint"] for m in all_mounts if m.get("mountpoint")}
+
+    amifuse_volumes = []
+    try:
+        entries = os.listdir(volumes_dir)
+    except OSError:
+        return
+
+    for entry in sorted(entries):
+        vol_path = volumes_dir + "/" + entry
+        if vol_path in claimed:
+            continue
+        try:
+            if os.path.ismount(vol_path):
+                amifuse_volumes.append(vol_path)
+        except OSError:
+            continue
+
+    # Match null-mountpoint processes to discovered volumes.
+    # Non-deterministic for multiple mounts -- best-effort pairing.
+    for mount, vol in zip(null_mounts, amifuse_volumes):
+        mount["mountpoint"] = vol
 
 
 def _parse_wmic_creation_date_uptime(creation_str):

--- a/tests/integration/test_status_cli.py
+++ b/tests/integration/test_status_cli.py
@@ -1,0 +1,54 @@
+"""Integration test for `amifuse status --json` CLI output.
+
+Runs amifuse as a subprocess and validates the JSON envelope.
+"""
+
+import json
+import subprocess
+import sys
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+def _run_amifuse(*args, timeout=30.0):
+    return subprocess.run(
+        [sys.executable, "-m", "amifuse", *args],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+class TestStatusCli:
+    """Validate amifuse status --json subprocess output."""
+
+    def test_status_json_exit_code(self):
+        proc = _run_amifuse("status", "--json")
+        assert proc.returncode == 0, (
+            f"Exit code {proc.returncode}\nstderr: {proc.stderr}")
+
+    def test_status_json_valid_output(self):
+        proc = _run_amifuse("status", "--json")
+        data = json.loads(proc.stdout)
+        assert data["status"] == "ok"
+        assert data["command"] == "status"
+        assert isinstance(data["mounts"], list)
+
+    def test_status_json_mount_schema(self):
+        """If any mounts are present, validate field presence."""
+        proc = _run_amifuse("status", "--json")
+        data = json.loads(proc.stdout)
+        required_keys = {"mountpoint", "image", "pid",
+                         "uptime_seconds", "filesystem_type"}
+        for mount in data["mounts"]:
+            assert required_keys.issubset(mount.keys()), (
+                f"Missing keys in mount entry: "
+                f"{required_keys - mount.keys()}")
+
+    def test_status_text_mode(self):
+        """Text mode (no --json) should also exit 0."""
+        proc = _run_amifuse("status")
+        assert proc.returncode == 0

--- a/tests/integration/test_status_cli.py
+++ b/tests/integration/test_status_cli.py
@@ -52,3 +52,20 @@ class TestStatusCli:
         """Text mode (no --json) should also exit 0."""
         proc = _run_amifuse("status")
         assert proc.returncode == 0
+
+    def test_status_text_zero_mounts(self):
+        """Text mode with no active mounts shows informative message."""
+        proc = _run_amifuse("status")
+        assert proc.returncode == 0
+        assert "No active AmiFUSE mounts" in proc.stdout
+
+    def test_status_json_mount_field_types(self):
+        """If any mounts present, validate field types (not just presence)."""
+        proc = _run_amifuse("status", "--json")
+        data = json.loads(proc.stdout)
+        for mount in data["mounts"]:
+            assert isinstance(mount["mountpoint"], str)
+            assert isinstance(mount["image"], str)
+            assert isinstance(mount["pid"], int)
+            assert isinstance(mount["uptime_seconds"], (int, float))
+            assert isinstance(mount["filesystem_type"], str)

--- a/tests/integration/test_unmount_cli.py
+++ b/tests/integration/test_unmount_cli.py
@@ -1,0 +1,60 @@
+"""Integration tests for `amifuse unmount` CLI error paths.
+
+These tests exercise argument validation and error messaging without
+requiring FUSE or real mounts -- they run on all platforms.
+"""
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+def _run_amifuse(*args, timeout=30.0):
+    return subprocess.run(
+        [sys.executable, "-m", "amifuse", *args],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+class TestUnmountCli:
+    """Validate amifuse unmount error paths."""
+
+    def test_unmount_no_arguments(self):
+        """unmount with no args should fail with usage/argument error."""
+        proc = _run_amifuse("unmount")
+        assert proc.returncode != 0
+        # argparse prints usage to stderr
+        assert "mountpoint" in proc.stderr.lower() or "usage" in proc.stderr.lower(), (
+            f"Expected usage/argument error, got:\n"
+            f"stdout: {proc.stdout!r}\nstderr: {proc.stderr!r}"
+        )
+
+    def test_unmount_nonexistent_path(self):
+        """unmount on a path that doesn't exist should fail cleanly."""
+        proc = _run_amifuse("unmount", "/nonexistent/path/nowhere")
+        assert proc.returncode != 0
+        combined = proc.stdout + proc.stderr
+        # Should not be a raw traceback -- look for a clean error message
+        assert "Traceback" not in combined, (
+            f"Got a raw traceback instead of a clean error:\n{combined}"
+        )
+        assert len(combined.strip()) > 0, "Expected an error message, got nothing"
+
+    def test_unmount_non_mounted_path(self):
+        """unmount on an existing but non-mounted directory should fail cleanly."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            proc = _run_amifuse("unmount", tmpdir)
+            assert proc.returncode != 0
+            combined = proc.stdout + proc.stderr
+            assert "Traceback" not in combined, (
+                f"Got a raw traceback instead of a clean error:\n{combined}"
+            )
+            assert len(combined.strip()) > 0, "Expected an error message, got nothing"

--- a/tests/unit/test_fuse_fs.py
+++ b/tests/unit/test_fuse_fs.py
@@ -510,166 +510,74 @@ class TestPidExists:
 
 
 class TestWindowsProcessDiscovery:
-    """Tests for _find_mount_owner_pids_windows() wmic-based discovery."""
+    """Tests for _find_mount_owner_pids() wrapper around platform.find_amifuse_mounts().
+
+    The raw wmic/ps parsing has moved to platform.py and is tested in
+    test_status.py. These tests verify the refactored wrapper in fuse_fs.py
+    correctly filters by mountpoint and handles errors.
+    """
 
     def test_finds_amifuse_pid_from_wmic_output(self, fuse_mock, monkeypatch):
         import amifuse.fuse_fs as fuse_fs_mod
+        import amifuse.platform as plat_mod
 
-        wmic_output = (
-            "\r\n"
-            "CommandLine=python -m amifuse mount disk.hdf --mountpoint Z:\r\n"
-            "ProcessId=4567\r\n"
-            "\r\n"
-        )
+        monkeypatch.setattr(plat_mod, "find_amifuse_mounts", lambda: [
+            {"mountpoint": "Z:", "image": "disk.hdf", "pid": 4567,
+             "uptime_seconds": None, "filesystem_type": None},
+        ])
 
-        def fake_run(cmd, **kwargs):
-            return argparse.Namespace(returncode=0, stdout=wmic_output)
-
-        monkeypatch.setattr(fuse_fs_mod.subprocess, "run", fake_run)
-        monkeypatch.setattr(fuse_fs_mod.os, "getpid", lambda: 999)
-
-        pids = fuse_fs_mod._find_mount_owner_pids_windows(Path("Z:"))
+        pids = fuse_fs_mod._find_mount_owner_pids(Path("Z:"))
         assert 4567 in pids
 
-    def test_excludes_own_pid(self, fuse_mock, monkeypatch):
+    def test_excludes_non_matching_mountpoint(self, fuse_mock, monkeypatch):
         import amifuse.fuse_fs as fuse_fs_mod
+        import amifuse.platform as plat_mod
 
-        wmic_output = (
-            "CommandLine=python -m amifuse mount disk.hdf --mountpoint Z:\r\n"
-            "ProcessId=999\r\n"
-            "\r\n"
-        )
+        monkeypatch.setattr(plat_mod, "find_amifuse_mounts", lambda: [
+            {"mountpoint": "Z:", "image": "disk.hdf", "pid": 999,
+             "uptime_seconds": None, "filesystem_type": None},
+        ])
 
-        def fake_run(cmd, **kwargs):
-            return argparse.Namespace(returncode=0, stdout=wmic_output)
-
-        monkeypatch.setattr(fuse_fs_mod.subprocess, "run", fake_run)
-        monkeypatch.setattr(fuse_fs_mod.os, "getpid", lambda: 999)
-
-        pids = fuse_fs_mod._find_mount_owner_pids_windows(Path("Z:"))
+        pids = fuse_fs_mod._find_mount_owner_pids(Path("Y:"))
         assert pids == []
 
-    def test_returns_empty_on_wmic_failure(self, fuse_mock, monkeypatch):
+    def test_returns_empty_on_discovery_failure(self, fuse_mock, monkeypatch):
         import amifuse.fuse_fs as fuse_fs_mod
+        import amifuse.platform as plat_mod
 
-        def fake_run(cmd, **kwargs):
-            return argparse.Namespace(returncode=1, stdout="")
-
-        monkeypatch.setattr(fuse_fs_mod.subprocess, "run", fake_run)
-
-        pids = fuse_fs_mod._find_mount_owner_pids_windows(Path("Z:"))
-        assert pids == []
-
-    def test_returns_empty_on_wmic_not_found(self, fuse_mock, monkeypatch):
-        import amifuse.fuse_fs as fuse_fs_mod
-
-        def fake_run(cmd, **kwargs):
+        def _raise():
             raise OSError("wmic not found")
+        monkeypatch.setattr(plat_mod, "find_amifuse_mounts", _raise)
 
-        monkeypatch.setattr(fuse_fs_mod.subprocess, "run", fake_run)
-
-        pids = fuse_fs_mod._find_mount_owner_pids_windows(Path("Z:"))
+        pids = fuse_fs_mod._find_mount_owner_pids(Path("Z:"))
         assert pids == []
 
-    def test_dispatcher_routes_to_windows(self, fuse_mock, monkeypatch):
+    def test_returns_empty_on_oserror(self, fuse_mock, monkeypatch):
         import amifuse.fuse_fs as fuse_fs_mod
+        import amifuse.platform as plat_mod
 
-        monkeypatch.setattr("sys.platform", "win32")
-        called = {"windows": False}
+        def _raise():
+            raise OSError("ps not found")
+        monkeypatch.setattr(plat_mod, "find_amifuse_mounts", _raise)
 
-        def fake_windows(mp):
-            called["windows"] = True
-            return []
+        pids = fuse_fs_mod._find_mount_owner_pids(Path("Z:"))
+        assert pids == []
 
-        monkeypatch.setattr(fuse_fs_mod, "_find_mount_owner_pids_windows", fake_windows)
-
-        fuse_fs_mod._find_mount_owner_pids(Path("Z:"))
-        assert called["windows"] is True
-
-    def test_dispatcher_routes_to_unix(self, fuse_mock, monkeypatch):
+    def test_filters_multiple_mounts(self, fuse_mock, monkeypatch):
         import amifuse.fuse_fs as fuse_fs_mod
+        import amifuse.platform as plat_mod
 
-        monkeypatch.setattr("sys.platform", "linux")
-        called = {"unix": False}
+        monkeypatch.setattr(plat_mod, "find_amifuse_mounts", lambda: [
+            {"mountpoint": "Z:", "image": "a.hdf", "pid": 100,
+             "uptime_seconds": None, "filesystem_type": None},
+            {"mountpoint": "Y:", "image": "b.hdf", "pid": 200,
+             "uptime_seconds": None, "filesystem_type": None},
+            {"mountpoint": "Z:", "image": "c.hdf", "pid": 300,
+             "uptime_seconds": None, "filesystem_type": None},
+        ])
 
-        def fake_unix(mp):
-            called["unix"] = True
-            return []
-
-        monkeypatch.setattr(fuse_fs_mod, "_find_mount_owner_pids_unix", fake_unix)
-
-        fuse_fs_mod._find_mount_owner_pids(Path("/mnt/amiga"))
-        assert called["unix"] is True
-
-    def test_backslash_mountpoint_preserved_with_posix_false(self, fuse_mock, monkeypatch):
-        r"""Backslash paths like C:\mnt\amiga are preserved by posix=False.
-
-        shlex.split in POSIX mode would interpret \m and \a as escape
-        sequences, mangling the path. This test verifies that the
-        non-POSIX split keeps Windows paths intact.
-        """
-        import amifuse.fuse_fs as fuse_fs_mod
-
-        wmic_output = (
-            "\r\n"
-            "CommandLine=python -m amifuse mount disk.hdf --mountpoint C:\\mnt\\amiga\r\n"
-            "ProcessId=5678\r\n"
-            "\r\n"
-        )
-
-        def fake_run(cmd, **kwargs):
-            return argparse.Namespace(returncode=0, stdout=wmic_output)
-
-        monkeypatch.setattr(fuse_fs_mod.subprocess, "run", fake_run)
-        monkeypatch.setattr(fuse_fs_mod.os, "getpid", lambda: 999)
-
-        pids = fuse_fs_mod._find_mount_owner_pids_windows(Path(r"C:\mnt\amiga"))
-        assert 5678 in pids
-
-    def test_last_record_without_trailing_blank_line(self, fuse_mock, monkeypatch):
-        """Parser flushes the final record even without a trailing blank line."""
-        import amifuse.fuse_fs as fuse_fs_mod
-
-        # No trailing \r\n after ProcessId — output ends abruptly
-        wmic_output = (
-            "\r\n"
-            "CommandLine=python -m amifuse mount disk.hdf --mountpoint Z:\r\n"
-            "ProcessId=7890"
-        )
-
-        def fake_run(cmd, **kwargs):
-            return argparse.Namespace(returncode=0, stdout=wmic_output)
-
-        monkeypatch.setattr(fuse_fs_mod.subprocess, "run", fake_run)
-        monkeypatch.setattr(fuse_fs_mod.os, "getpid", lambda: 999)
-
-        pids = fuse_fs_mod._find_mount_owner_pids_windows(Path("Z:"))
-        assert 7890 in pids
-
-    def test_malformed_quoting_falls_back_to_split(self, fuse_mock, monkeypatch):
-        """Unmatched quotes in CommandLine trigger ValueError fallback to str.split()."""
-        import amifuse.fuse_fs as fuse_fs_mod
-
-        # Unmatched double quote after mount — shlex.split will raise ValueError
-        wmic_output = (
-            "\r\n"
-            'CommandLine=python -m amifuse "mount disk.hdf --mountpoint Z:\r\n'
-            "ProcessId=3456\r\n"
-            "\r\n"
-        )
-
-        def fake_run(cmd, **kwargs):
-            return argparse.Namespace(returncode=0, stdout=wmic_output)
-
-        monkeypatch.setattr(fuse_fs_mod.subprocess, "run", fake_run)
-        monkeypatch.setattr(fuse_fs_mod.os, "getpid", lambda: 999)
-
-        # Should not raise — falls back to command.split()
-        pids = fuse_fs_mod._find_mount_owner_pids_windows(Path("Z:"))
-        # The fallback split will produce tokens that include the quote char,
-        # so --mountpoint matching may or may not succeed, but the function
-        # must not crash.
-        assert isinstance(pids, list)
+        pids = fuse_fs_mod._find_mount_owner_pids(Path("Z:"))
+        assert sorted(pids) == [100, 300]
 
 
 class TestDriverValidation:
@@ -1092,37 +1000,58 @@ class TestHandlerBridgeBstrRing:
 
 
 class TestCommandMatchesMountpoint:
-    """Direct tests for _command_matches_mountpoint() token matching."""
+    """Tests for mountpoint matching via _find_mount_owner_pids wrapper.
 
-    def test_matches_literal_mountpoint(self, fuse_mock):
-        """Matches when --mountpoint value equals the raw mountpoint string."""
-        from amifuse.fuse_fs import _command_matches_mountpoint
+    The _command_matches_mountpoint helper was removed during refactoring.
+    Mountpoint matching is now tested through the wrapper. Detailed token
+    parsing is covered in test_status.py::TestParseMountTokens.
+    """
 
-        tokens = ["python", "-m", "amifuse", "mount", "disk.hdf", "--mountpoint", "/mnt/amiga"]
-        assert _command_matches_mountpoint(tokens, "/mnt/amiga", "/mnt/amiga") is True
+    def test_matches_literal_mountpoint(self, fuse_mock, monkeypatch):
+        """Matches when mountpoint value equals the raw mountpoint string."""
+        import amifuse.fuse_fs as fuse_fs_mod
+        import amifuse.platform as plat_mod
+
+        monkeypatch.setattr(plat_mod, "find_amifuse_mounts", lambda: [
+            {"mountpoint": "/mnt/amiga", "image": "disk.hdf", "pid": 42,
+             "uptime_seconds": None, "filesystem_type": None},
+        ])
+        pids = fuse_fs_mod._find_mount_owner_pids(Path("/mnt/amiga"))
+        assert pids == [42]
+
+    def test_no_match_different_mountpoint(self, fuse_mock, monkeypatch):
+        """Does not match when the mountpoint value differs."""
+        import amifuse.fuse_fs as fuse_fs_mod
+        import amifuse.platform as plat_mod
+
+        monkeypatch.setattr(plat_mod, "find_amifuse_mounts", lambda: [
+            {"mountpoint": "/mnt/other", "image": "disk.hdf", "pid": 42,
+             "uptime_seconds": None, "filesystem_type": None},
+        ])
+        pids = fuse_fs_mod._find_mount_owner_pids(Path("/mnt/amiga"))
+        assert pids == []
+
+    def test_no_match_empty_mounts(self, fuse_mock, monkeypatch):
+        """Returns empty when no mounts are active."""
+        import amifuse.fuse_fs as fuse_fs_mod
+        import amifuse.platform as plat_mod
+
+        monkeypatch.setattr(plat_mod, "find_amifuse_mounts", lambda: [])
+        pids = fuse_fs_mod._find_mount_owner_pids(Path("/mnt/amiga"))
+        assert pids == []
 
     def test_matches_resolved_path(self, fuse_mock, monkeypatch, tmp_path):
         """Matches when the mountpoint arg resolves to the same absolute path."""
-        from amifuse.fuse_fs import _command_matches_mountpoint
+        import amifuse.fuse_fs as fuse_fs_mod
+        import amifuse.platform as plat_mod
 
-        # Use a relative-looking path that resolves to the abs_mountpoint
         abs_mp = str(tmp_path / "amiga")
-        tokens = ["python", "-m", "amifuse", "mount", "disk.hdf", "--mountpoint", str(tmp_path / "amiga")]
-        assert _command_matches_mountpoint(tokens, "./amiga", abs_mp) is True
-
-    def test_no_match_different_mountpoint(self, fuse_mock):
-        """Does not match when the mountpoint value differs."""
-        from amifuse.fuse_fs import _command_matches_mountpoint
-
-        tokens = ["python", "-m", "amifuse", "mount", "disk.hdf", "--mountpoint", "/mnt/other"]
-        assert _command_matches_mountpoint(tokens, "/mnt/amiga", "/mnt/amiga") is False
-
-    def test_no_match_without_mountpoint_flag(self, fuse_mock):
-        """Returns False when the command has no --mountpoint flag."""
-        from amifuse.fuse_fs import _command_matches_mountpoint
-
-        tokens = ["python", "-m", "amifuse", "mount", "disk.hdf"]
-        assert _command_matches_mountpoint(tokens, "/mnt/amiga", "/mnt/amiga") is False
+        monkeypatch.setattr(plat_mod, "find_amifuse_mounts", lambda: [
+            {"mountpoint": abs_mp, "image": "disk.hdf", "pid": 42,
+             "uptime_seconds": None, "filesystem_type": None},
+        ])
+        pids = fuse_fs_mod._find_mount_owner_pids(Path(abs_mp))
+        assert pids == [42]
 
 
 class TestKillEscalation:

--- a/tests/unit/test_fuse_fs.py
+++ b/tests/unit/test_fuse_fs.py
@@ -393,7 +393,8 @@ class TestUnmountCommand:
 
         assert "is not currently mounted" in str(exc_info.value)
 
-    def test_unmount_rejects_platforms_without_command(self, monkeypatch, fuse_mock):
+    def test_unmount_uses_process_kill_when_no_command(self, monkeypatch, fuse_mock):
+        """When platform returns no unmount command, go straight to process kill."""
         monkeypatch.setattr("os.path.ismount", lambda path: True)
         monkeypatch.setattr(
             "amifuse.platform.get_unmount_command",
@@ -401,10 +402,33 @@ class TestUnmountCommand:
         )
         import amifuse.fuse_fs as fuse_fs_mod
 
+        killed_pids = [42]
+        monkeypatch.setattr(
+            fuse_fs_mod, "_kill_mount_owner_processes",
+            lambda mp: killed_pids,
+        )
+
+        fuse_fs_mod.cmd_unmount(argparse.Namespace(mountpoint=Path("/mnt/amiga")))
+        # Should succeed (no SystemExit)
+
+    def test_unmount_no_command_no_process_found(self, monkeypatch, fuse_mock):
+        """When no unmount command and no process found, report error."""
+        monkeypatch.setattr("os.path.ismount", lambda path: True)
+        monkeypatch.setattr(
+            "amifuse.platform.get_unmount_command",
+            lambda mountpoint: [],
+        )
+        import amifuse.fuse_fs as fuse_fs_mod
+
+        monkeypatch.setattr(
+            fuse_fs_mod, "_kill_mount_owner_processes",
+            lambda mp: [],
+        )
+
         with pytest.raises(SystemExit) as exc_info:
             fuse_fs_mod.cmd_unmount(argparse.Namespace(mountpoint=Path("/mnt/amiga")))
 
-        assert "does not provide a standalone unmount command" in str(exc_info.value)
+        assert "No amifuse process found" in str(exc_info.value)
 
     def test_unmount_runs_for_stale_mountpoint(self, monkeypatch, fuse_mock):
         monkeypatch.setattr("os.path.ismount", lambda path: False)

--- a/tests/unit/test_platform.py
+++ b/tests/unit/test_platform.py
@@ -165,12 +165,12 @@ class TestGetUnmountCommand:
         assert result == ["umount", "-f", "/mnt/amiga"]
 
     def test_unmount_command_windows_drive_letter(self, monkeypatch):
-        """On Windows, drive-letter mounts use 'net use /delete'."""
+        """On Windows, drive-letter mounts return empty (process kill path)."""
         monkeypatch.setattr("sys.platform", "win32")
         from amifuse.platform import get_unmount_command
 
         result = get_unmount_command(Path("D:"))
-        assert result == ["net", "use", "D:", "/delete"]
+        assert result == []
 
     def test_unmount_command_windows_non_drive_returns_empty(self, monkeypatch):
         """On Windows, non-drive-letter mounts have no standalone unmount CLI."""
@@ -721,12 +721,12 @@ class TestMountRunsInForegroundByDefault:
 class TestWindowsUnmountCommand:
     """Tests for _get_windows_unmount_command() and get_unmount_command() on Windows."""
 
-    def test_drive_letter_returns_net_use_delete(self, monkeypatch):
+    def test_drive_letter_returns_empty(self, monkeypatch):
         monkeypatch.setattr("sys.platform", "win32")
         from amifuse.platform import _get_windows_unmount_command
 
         result = _get_windows_unmount_command(Path("Z:"))
-        assert result == ["net", "use", "Z:", "/delete"]
+        assert result == []
 
     def test_non_drive_letter_returns_empty(self, monkeypatch):
         monkeypatch.setattr("sys.platform", "win32")
@@ -740,4 +740,4 @@ class TestWindowsUnmountCommand:
         from amifuse.platform import get_unmount_command
 
         result = get_unmount_command(Path("Z:"))
-        assert result == ["net", "use", "Z:", "/delete"]
+        assert result == []

--- a/tests/unit/test_status.py
+++ b/tests/unit/test_status.py
@@ -466,3 +466,146 @@ class TestFindMountOwnerPidsRefactored:
             "amifuse.platform.find_amifuse_mounts", _raise)
         pids = _find_mount_owner_pids(Path("/mnt/a"))
         assert pids == []
+
+
+# ---------------------------------------------------------------------------
+# G. _truncate_left
+# ---------------------------------------------------------------------------
+
+
+class TestTruncateLeft:
+    """Tests for _truncate_left helper."""
+
+    def test_short_string_unchanged(self):
+        from amifuse.fuse_fs import _truncate_left
+
+        assert _truncate_left("short.hdf", 40) == "short.hdf"
+
+    def test_exact_length_unchanged(self):
+        from amifuse.fuse_fs import _truncate_left
+
+        s = "x" * 40
+        assert _truncate_left(s, 40) == s
+
+    def test_long_string_truncated_from_left(self):
+        from amifuse.fuse_fs import _truncate_left
+
+        s = "C:\\GitHub\\AmiFUSE-testing\\fixtures\\readonly\\pfs.hdf"
+        result = _truncate_left(s, 40)
+        assert len(result) == 40
+        assert result.startswith("..")
+        assert result.endswith("pfs.hdf")
+
+    def test_preserves_filename(self):
+        from amifuse.fuse_fs import _truncate_left
+
+        s = "/very/long/path/to/some/deeply/nested/file.hdf"
+        result = _truncate_left(s, 20)
+        assert result.endswith("file.hdf")
+        assert len(result) == 20
+
+    def test_empty_string(self):
+        from amifuse.fuse_fs import _truncate_left
+
+        assert _truncate_left("", 40) == ""
+
+
+# ---------------------------------------------------------------------------
+# H. Mountpoint enrichment
+# ---------------------------------------------------------------------------
+
+
+class TestEnrichNullMountpoints:
+    """Tests for _enrich_null_mountpoints and platform-specific helpers."""
+
+    def test_no_null_mountpoints_is_noop(self):
+        from amifuse.platform import _enrich_null_mountpoints
+
+        mounts = [{"mountpoint": "/mnt/a", "pid": 1}]
+        _enrich_null_mountpoints(mounts)
+        assert mounts[0]["mountpoint"] == "/mnt/a"
+
+    @pytest.mark.skipif(sys.platform != "win32", reason="Windows-only ctypes.windll")
+    def test_enrich_windows_single_mount(self, monkeypatch):
+        from amifuse.platform import _enrich_mountpoints_windows
+
+        # Mock ctypes.windll.kernel32.GetVolumeInformationW
+        mock_kernel32 = MagicMock()
+        call_count = [0]
+        drive_info = {
+            "D:\\": ("PFS3AIO Volume", "FUSE-AmiFUSE"),
+            "E:\\": ("SomeOther", "NTFS"),
+        }
+
+        def fake_get_vol_info(drive, vol_buf, vol_sz, *rest):
+            info = drive_info.get(drive)
+            if info is None:
+                return 0
+            import ctypes
+            # Write to the buffers
+            vol_name, fs_name = info
+            for i, c in enumerate(vol_name):
+                vol_buf[i] = c
+            vol_buf[len(vol_name)] = '\0'
+            # fs_name_buf is rest[-2]
+            fs_buf = rest[-2]
+            for i, c in enumerate(fs_name):
+                fs_buf[i] = c
+            fs_buf[len(fs_name)] = '\0'
+            return 1
+
+        import ctypes
+        monkeypatch.setattr(
+            "ctypes.windll.kernel32.GetVolumeInformationW",
+            fake_get_vol_info,
+        )
+
+        mounts = [{"mountpoint": None, "pid": 123}]
+        _enrich_mountpoints_windows(mounts, mounts)
+        assert mounts[0]["mountpoint"] == "D:"
+
+    def test_enrich_macos(self, monkeypatch):
+        from amifuse.platform import _enrich_mountpoints_macos
+
+        monkeypatch.setattr("os.path.isdir", lambda p: p == "/Volumes")
+        monkeypatch.setattr("os.listdir", lambda p: ["DH0", "Macintosh HD"])
+        monkeypatch.setattr("os.path.ismount", lambda p: True)
+
+        mounts = [{"mountpoint": None, "pid": 456}]
+        all_mounts = mounts[:]
+        _enrich_mountpoints_macos(mounts, all_mounts)
+        assert mounts[0]["mountpoint"] == "/Volumes/DH0"
+
+    def test_enrich_macos_skips_claimed(self, monkeypatch):
+        from amifuse.platform import _enrich_mountpoints_macos
+
+        monkeypatch.setattr("os.path.isdir", lambda p: p == "/Volumes")
+        monkeypatch.setattr("os.listdir", lambda p: ["DH0", "DH1"])
+        monkeypatch.setattr("os.path.ismount", lambda p: True)
+
+        null_mount = {"mountpoint": None, "pid": 456}
+        claimed_mount = {"mountpoint": "/Volumes/DH0", "pid": 789}
+        all_mounts = [claimed_mount, null_mount]
+        _enrich_mountpoints_macos([null_mount], all_mounts)
+        assert null_mount["mountpoint"] == "/Volumes/DH1"
+
+    def test_text_output_uses_truncation(self, monkeypatch, capsys):
+        from amifuse.fuse_fs import cmd_status
+
+        long_path = "C:\\GitHub\\AmiFUSE-testing\\fixtures\\readonly\\pfs.hdf"
+        mounts = [{
+            "mountpoint": "D:",
+            "image": long_path,
+            "pid": 999,
+            "uptime_seconds": 60,
+            "filesystem_type": None,
+        }]
+        monkeypatch.setattr(
+            "amifuse.platform.find_amifuse_mounts", lambda: mounts)
+        args = MagicMock()
+        args.json = False
+        cmd_status(args)
+        out = capsys.readouterr().out
+        # Should contain truncation marker, not the full path
+        assert ".." in out
+        assert "pfs.hdf" in out

--- a/tests/unit/test_status.py
+++ b/tests/unit/test_status.py
@@ -1,0 +1,468 @@
+"""Unit tests for mount discovery (platform.find_amifuse_mounts) and cmd_status.
+
+All subprocess calls are mocked -- no real processes needed.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import types
+from io import StringIO
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# A. _parse_mount_tokens
+# ---------------------------------------------------------------------------
+
+
+class TestParseMountTokens:
+    """Tests for platform._parse_mount_tokens helper."""
+
+    def test_standard_invocation(self):
+        from amifuse.platform import _parse_mount_tokens
+
+        tokens = ["python", "-m", "amifuse", "mount", "/images/test.hdf",
+                  "--mountpoint", "/Volumes/DH0"]
+        image, mp = _parse_mount_tokens(tokens)
+        assert image == "/images/test.hdf"
+        assert mp == "/Volumes/DH0"
+
+    def test_direct_invocation(self):
+        from amifuse.platform import _parse_mount_tokens
+
+        tokens = ["amifuse", "mount", "C:/images/test.hdf",
+                  "--mountpoint", "D:"]
+        image, mp = _parse_mount_tokens(tokens)
+        assert image == "C:/images/test.hdf"
+        assert mp == "D:"
+
+    def test_no_mount_subcommand(self):
+        from amifuse.platform import _parse_mount_tokens
+
+        tokens = ["amifuse", "doctor", "--json"]
+        image, mp = _parse_mount_tokens(tokens)
+        assert image is None
+        assert mp is None
+
+    def test_no_mountpoint_flag(self):
+        from amifuse.platform import _parse_mount_tokens
+
+        tokens = ["amifuse", "mount", "/images/test.hdf"]
+        image, mp = _parse_mount_tokens(tokens)
+        assert image == "/images/test.hdf"
+        assert mp is None  # auto-assigned mountpoints won't appear in CLI args
+
+    def test_image_path_with_spaces(self):
+        from amifuse.platform import _parse_mount_tokens
+
+        tokens = ["amifuse", "mount", "/my images/test file.hdf",
+                  "--mountpoint", "/Volumes/DH0"]
+        image, mp = _parse_mount_tokens(tokens)
+        assert image == "/my images/test file.hdf"
+        assert mp == "/Volumes/DH0"
+
+    def test_flags_before_image(self):
+        from amifuse.platform import _parse_mount_tokens
+
+        tokens = ["amifuse", "mount", "--driver", "/path/to/pfs3",
+                  "test.hdf", "--mountpoint", "/mnt/amiga"]
+        image, mp = _parse_mount_tokens(tokens)
+        assert image == "test.hdf"
+        assert mp == "/mnt/amiga"
+
+    def test_boolean_flags_skipped(self):
+        from amifuse.platform import _parse_mount_tokens
+
+        tokens = ["amifuse", "mount", "test.hdf", "--debug",
+                  "--mountpoint", "/mnt/amiga", "--interactive"]
+        image, mp = _parse_mount_tokens(tokens)
+        assert image == "test.hdf"
+        assert mp == "/mnt/amiga"
+
+
+# ---------------------------------------------------------------------------
+# B. find_amifuse_mounts -- Unix (mocked ps)
+# ---------------------------------------------------------------------------
+
+
+class TestFindAmifuseMountsUnix:
+    """Test _find_amifuse_mounts_unix with mocked subprocess output."""
+
+    @pytest.fixture(autouse=True)
+    def _force_unix(self, monkeypatch):
+        monkeypatch.setattr("sys.platform", "linux")
+
+    def _mock_ps(self, monkeypatch, stdout, returncode=0):
+        result = MagicMock()
+        result.stdout = stdout
+        result.returncode = returncode
+        monkeypatch.setattr(
+            "amifuse.platform.subprocess.run",
+            MagicMock(return_value=result),
+        )
+
+    def test_single_mount(self, monkeypatch):
+        from amifuse.platform import _find_amifuse_mounts_unix
+
+        # Simulate current PID != 12345
+        monkeypatch.setattr("amifuse.platform.os.getpid", lambda: 99999)
+        self._mock_ps(monkeypatch,
+            "12345   3600 python -m amifuse mount /images/test.hdf --mountpoint /mnt/amiga\n")
+
+        mounts = _find_amifuse_mounts_unix()
+        assert len(mounts) == 1
+        assert mounts[0]["pid"] == 12345
+        assert mounts[0]["image"] == "/images/test.hdf"
+        assert mounts[0]["mountpoint"] == "/mnt/amiga"
+        assert mounts[0]["uptime_seconds"] == 3600
+        assert mounts[0]["filesystem_type"] is None
+
+    def test_empty_process_list(self, monkeypatch):
+        from amifuse.platform import _find_amifuse_mounts_unix
+
+        self._mock_ps(monkeypatch, "")
+        mounts = _find_amifuse_mounts_unix()
+        assert mounts == []
+
+    def test_non_amifuse_processes_filtered(self, monkeypatch):
+        from amifuse.platform import _find_amifuse_mounts_unix
+
+        monkeypatch.setattr("amifuse.platform.os.getpid", lambda: 99999)
+        self._mock_ps(monkeypatch,
+            "111   100 python some_other_script.py\n"
+            "222   200 python -m amifuse doctor --json\n"
+            "333   300 python -m amifuse mount /img.hdf --mountpoint /mnt/x\n")
+
+        mounts = _find_amifuse_mounts_unix()
+        assert len(mounts) == 1
+        assert mounts[0]["pid"] == 333
+
+    def test_current_pid_excluded(self, monkeypatch):
+        from amifuse.platform import _find_amifuse_mounts_unix
+
+        monkeypatch.setattr("amifuse.platform.os.getpid", lambda: 12345)
+        self._mock_ps(monkeypatch,
+            "12345   100 python -m amifuse mount /img.hdf --mountpoint /mnt/x\n")
+
+        mounts = _find_amifuse_mounts_unix()
+        assert mounts == []
+
+    def test_multiple_mounts(self, monkeypatch):
+        from amifuse.platform import _find_amifuse_mounts_unix
+
+        monkeypatch.setattr("amifuse.platform.os.getpid", lambda: 99999)
+        self._mock_ps(monkeypatch,
+            "100   60 python -m amifuse mount /a.hdf --mountpoint /mnt/a\n"
+            "200   120 python -m amifuse mount /b.hdf --mountpoint /mnt/b\n")
+
+        mounts = _find_amifuse_mounts_unix()
+        assert len(mounts) == 2
+        assert {m["pid"] for m in mounts} == {100, 200}
+
+    def test_malformed_line_skipped(self, monkeypatch):
+        from amifuse.platform import _find_amifuse_mounts_unix
+
+        monkeypatch.setattr("amifuse.platform.os.getpid", lambda: 99999)
+        self._mock_ps(monkeypatch,
+            "not_a_pid amifuse mount something\n"
+            "100   60 python -m amifuse mount /a.hdf --mountpoint /mnt/a\n")
+
+        mounts = _find_amifuse_mounts_unix()
+        assert len(mounts) == 1
+
+    def test_ps_failure_returns_empty(self, monkeypatch):
+        from amifuse.platform import _find_amifuse_mounts_unix
+
+        self._mock_ps(monkeypatch, "", returncode=1)
+        mounts = _find_amifuse_mounts_unix()
+        assert mounts == []
+
+    def test_ps_not_found_returns_empty(self, monkeypatch):
+        from amifuse.platform import _find_amifuse_mounts_unix
+
+        monkeypatch.setattr(
+            "amifuse.platform.subprocess.run",
+            MagicMock(side_effect=OSError("No such file")),
+        )
+        mounts = _find_amifuse_mounts_unix()
+        assert mounts == []
+
+
+# ---------------------------------------------------------------------------
+# C. find_amifuse_mounts -- Windows (mocked wmic)
+# ---------------------------------------------------------------------------
+
+
+class TestFindAmifuseMountsWindows:
+    """Test _find_amifuse_mounts_windows with mocked subprocess output."""
+
+    @pytest.fixture(autouse=True)
+    def _force_windows(self, monkeypatch):
+        monkeypatch.setattr("sys.platform", "win32")
+
+    def _mock_wmic(self, monkeypatch, stdout, returncode=0):
+        result = MagicMock()
+        result.stdout = stdout
+        result.returncode = returncode
+        monkeypatch.setattr(
+            "amifuse.platform.subprocess.run",
+            MagicMock(return_value=result),
+        )
+
+    def test_single_mount(self, monkeypatch):
+        from amifuse.platform import _find_amifuse_mounts_windows
+
+        monkeypatch.setattr("amifuse.platform.os.getpid", lambda: 99999)
+        self._mock_wmic(monkeypatch,
+            "CommandLine=python -m amifuse mount C:/images/test.hdf --mountpoint D:\r\n"
+            "CreationDate=20260419103000.123456+000\r\n"
+            "ProcessId=12345\r\n"
+            "\r\n")
+
+        mounts = _find_amifuse_mounts_windows()
+        assert len(mounts) == 1
+        assert mounts[0]["pid"] == 12345
+        assert mounts[0]["image"] == "C:/images/test.hdf"
+        assert mounts[0]["mountpoint"] == "D:"
+        assert mounts[0]["filesystem_type"] is None
+
+    def test_empty_process_list(self, monkeypatch):
+        from amifuse.platform import _find_amifuse_mounts_windows
+
+        self._mock_wmic(monkeypatch, "")
+        mounts = _find_amifuse_mounts_windows()
+        assert mounts == []
+
+    def test_non_amifuse_filtered(self, monkeypatch):
+        from amifuse.platform import _find_amifuse_mounts_windows
+
+        monkeypatch.setattr("amifuse.platform.os.getpid", lambda: 99999)
+        self._mock_wmic(monkeypatch,
+            "CommandLine=python some_script.py\r\n"
+            "CreationDate=20260419100000.000000+000\r\n"
+            "ProcessId=111\r\n"
+            "\r\n"
+            "CommandLine=python -m amifuse mount C:/img.hdf --mountpoint E:\r\n"
+            "CreationDate=20260419100000.000000+000\r\n"
+            "ProcessId=222\r\n"
+            "\r\n")
+
+        mounts = _find_amifuse_mounts_windows()
+        assert len(mounts) == 1
+        assert mounts[0]["pid"] == 222
+
+    def test_wmic_failure_returns_empty(self, monkeypatch):
+        from amifuse.platform import _find_amifuse_mounts_windows
+
+        self._mock_wmic(monkeypatch, "", returncode=1)
+        mounts = _find_amifuse_mounts_windows()
+        assert mounts == []
+
+    def test_wmic_not_found_returns_empty(self, monkeypatch):
+        from amifuse.platform import _find_amifuse_mounts_windows
+
+        monkeypatch.setattr(
+            "amifuse.platform.subprocess.run",
+            MagicMock(side_effect=OSError("[WinError 2] The system cannot find the file specified")),
+        )
+        mounts = _find_amifuse_mounts_windows()
+        assert mounts == []
+
+    def test_multiple_mounts(self, monkeypatch):
+        from amifuse.platform import _find_amifuse_mounts_windows
+
+        monkeypatch.setattr("amifuse.platform.os.getpid", lambda: 99999)
+        self._mock_wmic(monkeypatch,
+            "CommandLine=python -m amifuse mount C:/a.hdf --mountpoint D:\r\n"
+            "CreationDate=20260419100000.000000+000\r\n"
+            "ProcessId=100\r\n"
+            "\r\n"
+            "CommandLine=python -m amifuse mount C:/b.hdf --mountpoint E:\r\n"
+            "CreationDate=20260419100000.000000+000\r\n"
+            "ProcessId=200\r\n"
+            "\r\n")
+
+        mounts = _find_amifuse_mounts_windows()
+        assert len(mounts) == 2
+
+
+# ---------------------------------------------------------------------------
+# D. find_amifuse_mounts (dispatch)
+# ---------------------------------------------------------------------------
+
+
+class TestFindAmifuseMountsDispatch:
+    """Test the top-level find_amifuse_mounts() dispatches correctly."""
+
+    def test_dispatches_to_unix(self, monkeypatch):
+        from amifuse import platform as plat
+
+        monkeypatch.setattr("sys.platform", "linux")
+        sentinel = [{"mountpoint": "/mnt/x", "pid": 1, "image": "a",
+                     "uptime_seconds": None, "filesystem_type": None}]
+        monkeypatch.setattr(plat, "_find_amifuse_mounts_unix", lambda: sentinel)
+        assert plat.find_amifuse_mounts() == sentinel
+
+    def test_dispatches_to_windows(self, monkeypatch):
+        from amifuse import platform as plat
+
+        monkeypatch.setattr("sys.platform", "win32")
+        sentinel = [{"mountpoint": "D:", "pid": 2, "image": "b",
+                     "uptime_seconds": None, "filesystem_type": None}]
+        monkeypatch.setattr(plat, "_find_amifuse_mounts_windows", lambda: sentinel)
+        assert plat.find_amifuse_mounts() == sentinel
+
+
+# ---------------------------------------------------------------------------
+# E. cmd_status
+# ---------------------------------------------------------------------------
+
+
+class TestCmdStatus:
+    """Test the cmd_status handler in fuse_fs."""
+
+    def _make_args(self, json_flag=False):
+        args = MagicMock()
+        args.json = json_flag
+        return args
+
+    def test_json_no_mounts(self, monkeypatch, capsys):
+        from amifuse.fuse_fs import cmd_status
+
+        monkeypatch.setattr(
+            "amifuse.platform.find_amifuse_mounts", lambda: [])
+        cmd_status(self._make_args(json_flag=True))
+        out = json.loads(capsys.readouterr().out)
+        assert out["status"] == "ok"
+        assert out["command"] == "status"
+        assert out["mounts"] == []
+
+    def test_json_with_mounts(self, monkeypatch, capsys):
+        from amifuse.fuse_fs import cmd_status
+
+        mounts = [{
+            "mountpoint": "D:",
+            "image": "C:/images/test.hdf",
+            "pid": 12345,
+            "uptime_seconds": 120,
+            "filesystem_type": None,
+        }]
+        monkeypatch.setattr(
+            "amifuse.platform.find_amifuse_mounts", lambda: mounts)
+        cmd_status(self._make_args(json_flag=True))
+        out = json.loads(capsys.readouterr().out)
+        assert out["status"] == "ok"
+        assert len(out["mounts"]) == 1
+        m = out["mounts"][0]
+        assert m["mountpoint"] == "D:"
+        assert m["image"] == "C:/images/test.hdf"
+        assert m["pid"] == 12345
+        assert m["uptime_seconds"] == 120
+        assert m["filesystem_type"] is None
+
+    def test_json_error(self, monkeypatch, capsys):
+        from amifuse.fuse_fs import cmd_status
+
+        def _raise():
+            raise OSError("wmic not found")
+        monkeypatch.setattr(
+            "amifuse.platform.find_amifuse_mounts", _raise)
+        with pytest.raises(SystemExit):
+            cmd_status(self._make_args(json_flag=True))
+        out = json.loads(capsys.readouterr().out)
+        assert out["status"] == "error"
+        assert out["command"] == "status"
+        assert "wmic not found" in out["error"]
+        assert out["mounts"] == []
+
+    def test_text_no_mounts(self, monkeypatch, capsys):
+        from amifuse.fuse_fs import cmd_status
+
+        monkeypatch.setattr(
+            "amifuse.platform.find_amifuse_mounts", lambda: [])
+        cmd_status(self._make_args(json_flag=False))
+        out = capsys.readouterr().out
+        assert "No active AmiFUSE mounts." in out
+
+    def test_text_with_mounts(self, monkeypatch, capsys):
+        from amifuse.fuse_fs import cmd_status
+
+        mounts = [{
+            "mountpoint": "/mnt/amiga",
+            "image": "/images/test.hdf",
+            "pid": 999,
+            "uptime_seconds": 3661,
+            "filesystem_type": None,
+        }]
+        monkeypatch.setattr(
+            "amifuse.platform.find_amifuse_mounts", lambda: mounts)
+        cmd_status(self._make_args(json_flag=False))
+        out = capsys.readouterr().out
+        assert "999" in out
+        assert "/mnt/amiga" in out
+        assert "/images/test.hdf" in out
+
+    def test_json_multiple_mounts(self, monkeypatch, capsys):
+        from amifuse.fuse_fs import cmd_status
+
+        mounts = [
+            {"mountpoint": "/mnt/a", "image": "a.hdf", "pid": 1,
+             "uptime_seconds": 10, "filesystem_type": None},
+            {"mountpoint": "/mnt/b", "image": "b.hdf", "pid": 2,
+             "uptime_seconds": None, "filesystem_type": None},
+        ]
+        monkeypatch.setattr(
+            "amifuse.platform.find_amifuse_mounts", lambda: mounts)
+        cmd_status(self._make_args(json_flag=True))
+        out = json.loads(capsys.readouterr().out)
+        assert len(out["mounts"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# F. _find_mount_owner_pids refactor
+# ---------------------------------------------------------------------------
+
+
+class TestFindMountOwnerPidsRefactored:
+    """Verify the refactored _find_mount_owner_pids wraps find_amifuse_mounts."""
+
+    def test_filters_by_mountpoint(self, monkeypatch):
+        from amifuse.fuse_fs import _find_mount_owner_pids
+
+        mounts = [
+            {"mountpoint": "/mnt/a", "image": "a.hdf", "pid": 100,
+             "uptime_seconds": None, "filesystem_type": None},
+            {"mountpoint": "/mnt/b", "image": "b.hdf", "pid": 200,
+             "uptime_seconds": None, "filesystem_type": None},
+        ]
+        monkeypatch.setattr(
+            "amifuse.platform.find_amifuse_mounts", lambda: mounts)
+        pids = _find_mount_owner_pids(Path("/mnt/a"))
+        assert pids == [100]
+
+    def test_returns_empty_on_no_match(self, monkeypatch):
+        from amifuse.fuse_fs import _find_mount_owner_pids
+
+        mounts = [
+            {"mountpoint": "/mnt/a", "image": "a.hdf", "pid": 100,
+             "uptime_seconds": None, "filesystem_type": None},
+        ]
+        monkeypatch.setattr(
+            "amifuse.platform.find_amifuse_mounts", lambda: mounts)
+        pids = _find_mount_owner_pids(Path("/mnt/z"))
+        assert pids == []
+
+    def test_returns_empty_on_oserror(self, monkeypatch):
+        from amifuse.fuse_fs import _find_mount_owner_pids
+
+        def _raise():
+            raise OSError("ps not found")
+        monkeypatch.setattr(
+            "amifuse.platform.find_amifuse_mounts", _raise)
+        pids = _find_mount_owner_pids(Path("/mnt/a"))
+        assert pids == []


### PR DESCRIPTION
## Summary

- Adds `amifuse status [--json]` command for discovering active mounts via OS-level process inspection
- Fixes Windows unmount — replaces broken `net use /delete` with direct process termination
- Auto-detects mountpoints for mounts started without `--mountpoint` (Windows: WinFSP drive scan, macOS: `/Volumes/` scan)
- Consolidates mount process discovery into `platform.find_amifuse_mounts()`, refactoring `_find_mount_owner_pids()` as a thin wrapper to eliminate parser duplication

## Design decisions

**OS-level detection over PID files:** The daemon mount mode (PR #22) doesn't write state files, so PID-file tracking would require changes to the mount path. Process inspection is simpler and inherently accurate — it can't go stale.

**`ps`-only on Unix (no `mount` command parsing):** FUSE type strings vary across macOS versions (`macfuse` vs `osxfuse`) and are generic on Linux (indistinguishable from sshfs/rclone). Filtering `ps` output for `amifuse mount` in command-line args is more reliable.

**Nullable fields with explicit `null`:** `uptime_seconds` and `filesystem_type` use `null` rather than key omission — consistent key presence simplifies JSON consumers. `filesystem_type` is reserved for future use when status can query the mounted filesystem.

**Windows mountpoint enrichment via `GetVolumeInformationW`:** WinFSP mounts report filesystem name as `FUSE-AmiFUSE`, providing a reliable discriminator to match drive letters to amifuse processes when `--mountpoint` was not specified.

**Windows unmount via process termination:** `net use /delete` never worked for WinFSP mounts (they aren't network drives). Direct process kill is the reliable approach and was already the fallback — now it's the primary path on Windows.

## Usage

```bash
# Human-readable
amifuse status
# PID      Mountpoint           Image                                    Uptime
# --------------------------------------------------------------------------------
# 12345    D:                   ..FUSE-testing\fixtures\readonly\pfs.hdf 0h 5m 30s

# Machine-readable
amifuse status --json
# {"status": "ok", "command": "status", "mounts": [...]}

# Windows unmount (now works cleanly)
amifuse unmount D:
# Unmounted D: (terminated process 12345).
```

## Test plan

**Automated (378 tests, all pass):**
- [x] 42 unit tests for status — token parsing, both platform discovery paths, mountpoint enrichment (Windows ctypes mock, macOS `/Volumes/` mock), path truncation, error/edge cases, refactored PID wrapper
- [x] 4 integration tests — CLI subprocess JSON schema validation
- [x] Updated unmount tests — process kill path on Windows, no-process-found error
- [x] No regressions in existing test suite

**Manual validation (Windows, WinFSP + pfs.hdf/pfs3aio fixtures):**
- [x] Zero active mounts — JSON and text mode, exit 0
- [x] Single mount, auto-assigned mountpoint — mountpoint enriched to `D:` via `GetVolumeInformationW`
- [x] Single mount, explicit `--mountpoint Z:` — all fields populated
- [x] Two simultaneous mounts — both discovered with correct PIDs, images, mountpoints
- [x] `amifuse unmount D:` — clean success message with PID, exit 0
- [x] `amifuse unmount` after both mounts — both terminated cleanly, status shows empty
- [x] Long image paths — left-truncated with `..` prefix in text table, filename preserved