### PR TITLE
Add mount lifecycle tests and CI mount-tests job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,3 +137,100 @@ jobs:
         env:
           AMIFUSE_FIXTURE_ROOT: ${{ github.workspace }}/../AmiFUSE-testing
         run: python tools/image_format_smoke.py --case direct-rdb-pfs3 --json
+
+  mount-tests:
+    name: Mount Tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    needs: unit-tests
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: 'pip'
+
+      - name: Install FUSE backend (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y fuse3 libfuse3-dev libfuse-dev
+          sudo modprobe fuse || true
+
+      - name: Install FUSE backend (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          brew install fuse-t
+          FUSET_LIB=$(find /opt/homebrew/lib /usr/local/lib -name 'libfuse-t*.dylib' 2>/dev/null | head -1)
+          if [ -n "$FUSET_LIB" ]; then
+            FUSET_DIR=$(dirname "$FUSET_LIB")
+            sudo ln -sf "$FUSET_LIB" "$FUSET_DIR/libfuse.dylib" || true
+            echo "DYLD_LIBRARY_PATH=$FUSET_DIR" >> "$GITHUB_ENV"
+          fi
+
+      - name: Install FUSE backend (Windows)
+        if: runner.os == 'Windows'
+        run: choco install winfsp -y
+
+      - name: Clone AmiFUSE-testing fixtures
+        run: |
+          git clone --depth 1 https://github.com/reinauer/AmiFUSE-testing.git ../AmiFUSE-testing
+        continue-on-error: true
+
+      - name: Install machine68k-amifuse (Windows)
+        if: runner.os == 'Windows'
+        run: pip install "machine68k-amifuse>=0.4.1.post1"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e "./amitools[vamos]"
+          pip install "pytest>=7.0" "pytest-cov>=4.0" "pytest-timeout>=2.0"
+          pip install -e "." --no-deps
+
+      - name: Verify FUSE backend
+        run: |
+          python -c "
+          try:
+              from fuse import FUSE
+              print('fusepy: OK (FUSE class imported)')
+          except EnvironmentError as e:
+              print(f'fusepy: FUSE backend not found: {e}')
+          except ImportError:
+              print('fusepy: not installed')
+          "
+        continue-on-error: true
+
+      - name: Run mount tests
+        env:
+          AMIFUSE_FIXTURE_ROOT: ${{ github.workspace }}/../AmiFUSE-testing
+        run: pytest tests/integration/ -m fuse -v --timeout=60
+
+      - name: Cleanup stale mounts (Linux)
+        if: always() && runner.os == 'Linux'
+        run: |
+          pkill -9 -f amifuse || true
+          find /tmp -maxdepth 3 -name 'mnt_*' -type d 2>/dev/null | while read mp; do
+            fusermount3 -u "$mp" 2>/dev/null || fusermount -u "$mp" 2>/dev/null || true
+          done
+
+      - name: Cleanup stale mounts (macOS)
+        if: always() && runner.os == 'macOS'
+        run: |
+          pkill -9 -f amifuse || true
+          find /tmp -maxdepth 3 -name 'mnt_*' -type d 2>/dev/null | while read mp; do
+            umount "$mp" 2>/dev/null || true
+          done
+
+      - name: Cleanup stale mounts (Windows)
+        if: always() && runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -match 'amifuse' } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }

--- a/TESTING.md
+++ b/TESTING.md
@@ -353,6 +353,7 @@ scripts. Tests are organized into two layers:
 |-------|----------|--------|----------|
 | Unit | `tests/unit/` | _(none)_ | Python + amifuse installed |
 | Integration | `tests/integration/` | `integration` | machine68k + external fixtures |
+| Mount | `tests/integration/` | `fuse` | FUSE backend (WinFSP/FUSE-T/fuse3) + external fixtures |
 
 ### Quick Start
 
@@ -360,8 +361,11 @@ scripts. Tests are organized into two layers:
 # Unit tests (all platforms, no external dependencies)
 pytest tests/unit/ -v --timeout=30
 
-# Integration tests (Linux/macOS, needs fixtures)
+# Integration tests (needs fixtures + machine68k)
 pytest tests/integration/ -v --timeout=60
+
+# Mount tests only (needs FUSE backend + fixtures)
+pytest tests/integration/ -m fuse -v --timeout=60
 
 # All tests
 pytest tests/ -v --timeout=60
@@ -409,19 +413,27 @@ pytest tests/integration/ -v
 
 ### CI (GitHub Actions)
 
-The CI workflow (`.github/workflows/ci.yml`) runs three jobs:
+The CI workflow (`.github/workflows/ci.yml`) runs four jobs:
 
 | Job | Platforms | Python | What |
 |-----|-----------|--------|------|
 | `unit-tests` | Linux, macOS, Windows | 3.11, 3.12, 3.13 | `pytest tests/unit/` |
-| `integration-tests` | Linux, macOS | 3.13 | `pytest tests/integration/` with external fixtures |
-| `tools-smoke` | Linux, macOS | 3.13 | `amifuse_matrix.py` + `image_format_smoke.py` |
+| `integration-tests` | Linux, macOS, Windows | 3.13 | `pytest tests/integration/` with external fixtures |
+| `tools-smoke` | Linux, macOS, Windows | 3.13 | `amifuse_matrix.py` + `image_format_smoke.py` |
+| `mount-tests` | Linux, macOS, Windows | 3.13 | `pytest tests/integration/ -m fuse` with FUSE backend |
 
-Windows is excluded from integration and tools-smoke because machine68k
-segfaults on Windows due to opcode table over-read
+The `mount-tests` job installs a platform-specific FUSE backend:
+
+- **Linux:** fuse3 + libfuse-dev (fuse2 ABI for fusepy)
+- **macOS:** FUSE-T (user-space, no kext required) with libfuse compatibility symlink
+- **Windows:** WinFSP via chocolatey
+
+Windows integration and tools-smoke jobs use the `machine68k-amifuse` fork
+which includes pre-built wheels with fixes for opcode table over-read
 ([cnvogelg/machine68k#8](https://github.com/cnvogelg/machine68k/issues/8))
 and JMP/CAS collision
 ([cnvogelg/machine68k#9](https://github.com/cnvogelg/machine68k/issues/9)).
+This workaround can be removed once upstream machine68k merges the fixes.
 
 ## Current Gaps
 
@@ -433,6 +445,5 @@ entry points yet:
 - fuller long-run generated benchmark recipes
 - ~~fixture-layout cleanup for `~/AmigaOS/AmiFuse/`~~ (resolved:
   `AMIFUSE_FIXTURE_ROOT` env var + fixture cascade in `tests/fixtures/paths.py`)
-- Windows integration tests pending machine68k upstream fixes
-  ([cnvogelg/machine68k#8](https://github.com/cnvogelg/machine68k/issues/8),
-  [cnvogelg/machine68k#9](https://github.com/cnvogelg/machine68k/issues/9))
+- ~~Windows integration tests pending machine68k upstream fixes~~ (resolved:
+  `machine68k-amifuse` fork with pre-built wheels)

--- a/amifuse/platform.py
+++ b/amifuse/platform.py
@@ -89,9 +89,11 @@ def get_unmount_command(mountpoint: Path) -> List[str]:
         return ["umount", "-f", str(mountpoint)]
     if sys.platform.startswith("win"):
         return _get_windows_unmount_command(mountpoint)
-    # Linux - prefer fusermount if available
+    # Linux - prefer fusermount/fusermount3 if available
     if shutil.which("fusermount"):
         return ["fusermount", "-u", str(mountpoint)]
+    if shutil.which("fusermount3"):
+        return ["fusermount3", "-u", str(mountpoint)]
     return ["umount", "-f", str(mountpoint)]
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -223,10 +223,9 @@ def mount_image(fuse_available, tmp_path):
                     f"Mount process exited early (rc={proc.returncode}).\n"
                     f"stdout: {stdout}\nstderr: {stderr}"
                 )
-            if os.path.ismount(str(mountpoint)):
-                mounted = True
-                break
-            # Fallback: try listdir (catches FUSE-T or Windows edge cases)
+            # On Windows, ismount detects the drive letter before the
+            # filesystem is fully initialized. Use listdir as the
+            # authoritative readiness check on all platforms.
             try:
                 os.listdir(str(mountpoint))
                 mounted = True

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,10 +1,20 @@
 """Integration test conftest -- machine68k probe + fixture providers."""
+import os
+import shutil
+import string
 import subprocess
 import sys
+import time
 
 import pytest
 
 from tests.fixtures.paths import FIXTURE_ROOT, PFS3AIO, PFS3_HDF, OFS_ADF
+
+
+_MOUNT_POLL_INTERVAL = 0.5   # seconds between ismount checks
+_MOUNT_TIMEOUT = 15.0        # max seconds to wait for mount
+_UNMOUNT_TIMEOUT = 10.0      # max seconds to wait for unmount subprocess
+_PROCESS_KILL_TIMEOUT = 5.0  # max seconds to wait after kill
 
 
 def _machine68k_works() -> bool:
@@ -84,3 +94,221 @@ def ofs_adf_image():
     if OFS_ADF is None or not OFS_ADF.exists():
         pytest.skip("OFS ADF image not found")
     return OFS_ADF
+
+
+@pytest.fixture(scope="session")
+def fuse_available():
+    """Detect FUSE backend availability; skip all fuse-marked tests if absent.
+
+    Detection strategy:
+    - Import `fuse` (fusepy). fusepy raises EnvironmentError at import time
+      when libfuse/WinFSP is not installed. ImportError means fusepy itself
+      is missing.
+    - On Linux only: secondary check for fusermount/fusermount3 binary
+      (needed for unmount, not strictly for mount, but indicates fuse3 is
+      properly installed).
+
+    Does NOT use platform.check_fuse_available() -- that function only
+    checks WinFSP on Windows and is a no-op on macOS/Linux.
+
+    Returns the platform name string ('darwin', 'linux', 'win32').
+    """
+    # Primary check: can fusepy find a FUSE library?
+    try:
+        from fuse import FUSE  # noqa: F401
+    except EnvironmentError as exc:
+        # libfuse/WinFSP not installed
+        pytest.skip(f"FUSE backend not available: {exc}")
+    except ImportError:
+        # fusepy itself not installed
+        pytest.skip("fusepy not installed (pip install fusepy)")
+
+    # Secondary check on Linux: verify fusermount binary exists
+    if sys.platform.startswith("linux"):
+        has_fusermount = (
+            shutil.which("fusermount") or shutil.which("fusermount3")
+        )
+        if not has_fusermount:
+            pytest.skip("Neither fusermount nor fusermount3 found on PATH")
+
+    return sys.platform
+
+
+@pytest.fixture
+def mount_image(fuse_available, tmp_path):
+    """Factory fixture: mount an Amiga image and yield (process, mountpoint).
+
+    Usage in test:
+        def test_something(mount_image, pfs3_image, pfs3_driver):
+            proc, mp = mount_image(pfs3_image, driver=pfs3_driver)
+            assert os.path.ismount(mp)
+
+    The factory handles:
+    - Mountpoint creation (tmpdir on Unix, drive letter on Windows)
+    - Launching `amifuse mount --interactive <image> --mountpoint <mp>`
+      via subprocess.Popen (--interactive is the flag name; --foreground
+      is an alias; both set dest="foreground" to True)
+    - Polling os.path.ismount() until True or timeout, with os.listdir()
+      as a secondary readiness check
+    - Teardown: unmount, kill process, clean up mountpoint
+
+    Parameters accepted by the returned callable:
+        image: Path       -- path to disk image
+        driver: Path      -- path to filesystem handler binary (optional)
+        extra_args: list   -- additional CLI args (optional)
+        timeout: float    -- mount detection timeout (default 15s)
+    """
+    # Track all mounts created by this fixture instance for teardown
+    _active_mounts = []
+
+    def _find_available_drive_letter():
+        """Find first available drive letter (D: through Z:) on Windows."""
+        import ctypes
+        bitmask = ctypes.windll.kernel32.GetLogicalDrives()
+        for i, letter in enumerate(string.ascii_uppercase):
+            if letter < 'D':
+                continue
+            if not (bitmask & (1 << i)):
+                return f"{letter}:"
+        raise RuntimeError("No available drive letters found (D: through Z:)")
+
+    def _mount(image, driver=None, extra_args=None, timeout=_MOUNT_TIMEOUT):
+        # Build mountpoint
+        if sys.platform.startswith("win"):
+            # Windows: use drive-letter mounts for reliable os.path.ismount()
+            # os.path.ismount() returns False for directory-based FUSE mounts
+            # on Windows, so we use drive letters instead
+            mountpoint_str = _find_available_drive_letter()
+            mountpoint = mountpoint_str + "\\"
+        else:
+            # Unix: use tmp_path subdirectory
+            mountpoint = tmp_path / f"mnt_{len(_active_mounts)}"
+            mountpoint.mkdir(exist_ok=True)
+            mountpoint_str = str(mountpoint)
+
+        # Build command -- pass drive letter without trailing backslash on Windows
+        mp_arg = mountpoint_str if sys.platform.startswith("win") else str(mountpoint)
+        cmd = [
+            sys.executable, "-m", "amifuse", "mount",
+            str(image),
+            "--interactive",  # prevents daemonization; alias for --foreground
+            "--mountpoint", mp_arg,
+        ]
+        if driver is not None:
+            cmd.extend(["--driver", str(driver)])
+        if extra_args:
+            cmd.extend(extra_args)
+
+        # Launch mount process
+        proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            # On Windows, CREATE_NEW_PROCESS_GROUP allows clean termination
+            creationflags=(
+                subprocess.CREATE_NEW_PROCESS_GROUP
+                if sys.platform.startswith("win") else 0
+            ),
+        )
+
+        # Poll until mount is detected or timeout
+        deadline = time.monotonic() + timeout
+        mounted = False
+        while time.monotonic() < deadline:
+            # Check if process died early (bad image, missing driver, etc.)
+            if proc.poll() is not None:
+                stdout = proc.stdout.read().decode(errors="replace")
+                stderr = proc.stderr.read().decode(errors="replace")
+                raise RuntimeError(
+                    f"Mount process exited early (rc={proc.returncode}).\n"
+                    f"stdout: {stdout}\nstderr: {stderr}"
+                )
+            if os.path.ismount(str(mountpoint)):
+                mounted = True
+                break
+            # Fallback: try listdir (catches FUSE-T or Windows edge cases)
+            try:
+                os.listdir(str(mountpoint))
+                mounted = True
+                break
+            except OSError:
+                pass
+            time.sleep(_MOUNT_POLL_INTERVAL)
+
+        if not mounted:
+            # Clean up the failed mount attempt
+            proc.kill()
+            proc.wait(timeout=_PROCESS_KILL_TIMEOUT)
+            raise RuntimeError(
+                f"Mount not detected at {mountpoint} within {timeout}s. "
+                f"Process still running: {proc.poll() is None}"
+            )
+
+        _active_mounts.append((proc, mountpoint))
+        return proc, mountpoint
+
+    yield _mount
+
+    # === TEARDOWN ===
+    # Unmount and kill all mounts created during this test, in reverse order
+    for proc, mountpoint in reversed(_active_mounts):
+        _teardown_mount(proc, mountpoint)
+
+
+def _teardown_mount(proc, mountpoint):
+    """Unmount and clean up a single mount. Best-effort, never raises."""
+    mp_str = str(mountpoint)
+
+    # Step 1: Try `amifuse unmount` (works on all platforms --
+    # on Windows it internally does process termination)
+    try:
+        subprocess.run(
+            [sys.executable, "-m", "amifuse", "unmount", mp_str],
+            capture_output=True, text=True,
+            timeout=_UNMOUNT_TIMEOUT, check=False,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        pass
+
+    # Step 2: If process is still alive, escalate
+    if proc.poll() is None:
+        try:
+            proc.terminate()
+            proc.wait(timeout=_PROCESS_KILL_TIMEOUT)
+        except (subprocess.TimeoutExpired, OSError):
+            pass
+
+    if proc.poll() is None:
+        try:
+            proc.kill()
+            proc.wait(timeout=_PROCESS_KILL_TIMEOUT)
+        except (subprocess.TimeoutExpired, OSError):
+            pass
+
+    # Step 3: Drain stdout/stderr to avoid ResourceWarning
+    try:
+        proc.stdout.close()
+        proc.stderr.close()
+    except OSError:
+        pass
+
+    # Step 4: Clean up mountpoint directory
+    # Drive-letter mounts on Windows don't need directory cleanup
+    # On Unix, a stale FUSE mount may make the dir inaccessible -- ignore errors
+    try:
+        if os.path.isdir(mp_str) and not os.path.ismount(mp_str):
+            os.rmdir(mp_str)
+    except OSError:
+        pass
+
+
+@pytest.fixture
+def pfs3_mount(mount_image, pfs3_image, pfs3_driver):
+    """Mount the PFS3 test image and yield (process, mountpoint).
+
+    Composes mount_image with the PFS3 fixtures from conftest.
+    The pfs3_image and pfs3_driver fixtures already handle skipping
+    when fixture files are missing.
+    """
+    proc, mountpoint = mount_image(pfs3_image, driver=pfs3_driver)
+    return proc, mountpoint

--- a/tests/integration/test_mount_lifecycle.py
+++ b/tests/integration/test_mount_lifecycle.py
@@ -1,0 +1,273 @@
+"""Mount lifecycle integration tests.
+
+These tests require a working FUSE backend (macFUSE/FUSE-T, fuse3, WinFSP)
+and the AmiFUSE-testing fixtures (PFS3 driver + test image). They exercise
+the full mount -> use -> unmount cycle via subprocess, verifying that the
+FUSE bridge works end-to-end on each platform.
+
+Marker: @pytest.mark.fuse (NOT @pytest.mark.integration -- avoids machine68k gating)
+"""
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.fuse
+
+
+def _run_amifuse(*args, timeout=30.0):
+    """Run amifuse as a subprocess and return CompletedProcess."""
+    return subprocess.run(
+        [sys.executable, "-m", "amifuse", *args],
+        capture_output=True, text=True,
+        timeout=timeout, check=False,
+    )
+
+
+def test_mount_creates_mountpoint(pfs3_mount):
+    """Mount PFS3 image and verify the mountpoint is active."""
+    proc, mountpoint = pfs3_mount
+    assert os.path.ismount(str(mountpoint)), (
+        f"Expected {mountpoint} to be a mount, but os.path.ismount() is False"
+    )
+    assert proc.poll() is None, "Mount process should still be running"
+
+
+def test_mount_visible_in_status(pfs3_mount, pfs3_image):
+    """Mount PFS3 image and verify it appears in `amifuse status --json`."""
+    proc, mountpoint = pfs3_mount
+    result = _run_amifuse("status", "--json")
+    assert result.returncode == 0, f"status failed: {result.stderr}"
+    data = json.loads(result.stdout)
+    assert data["status"] == "ok"
+
+    # Find our mount in the list
+    mp_str = str(mountpoint)
+    image_name = pfs3_image.name
+    matching = [
+        m for m in data["mounts"]
+        if mp_str in m.get("mountpoint", "") or image_name in m.get("image", "")
+    ]
+    assert len(matching) >= 1, (
+        f"Mount at {mp_str} (image {image_name}) not found in status output.\n"
+        f"Mounts returned: {json.dumps(data['mounts'], indent=2)}\n"
+        f"Mount process PID: {proc.pid}\n"
+        f"Mount process alive: {proc.poll() is None}"
+    )
+
+
+def test_mounted_root_listable(pfs3_mount):
+    """Mounted PFS3 volume root should contain files."""
+    _proc, mountpoint = pfs3_mount
+    entries = os.listdir(str(mountpoint))
+    assert len(entries) > 0, (
+        f"Expected files in mounted volume at {mountpoint}, got empty listing"
+    )
+
+
+def test_file_read_matches_hash(pfs3_mount, pfs3_image, pfs3_driver):
+    """Read a file through the mount and compare its hash to amifuse hash output."""
+    _proc, mountpoint = pfs3_mount
+    mp = str(mountpoint)
+
+    # Pick the first regular file in the root
+    entries = os.listdir(mp)
+    target = None
+    for entry in entries:
+        full = os.path.join(mp, entry)
+        if os.path.isfile(full):
+            target = entry
+            break
+
+    if target is None:
+        pytest.skip("No regular files found in mounted volume root")
+
+    # Read file content through FUSE mount
+    fuse_path = os.path.join(mp, target)
+    with open(fuse_path, "rb") as f:
+        fuse_content = f.read()
+    fuse_hash = hashlib.sha256(fuse_content).hexdigest()
+
+    # Get hash via amifuse hash command (reads image directly, no FUSE)
+    # amifuse hash requires --file flag and --driver for PFS3
+    result = _run_amifuse(
+        "hash", str(pfs3_image),
+        "--file", target,
+        "--driver", str(pfs3_driver),
+        "--json",
+    )
+    if result.returncode != 0:
+        pytest.skip(
+            f"amifuse hash not available or failed: {result.stderr}"
+        )
+
+    # Parse hash from JSON output
+    hash_data = json.loads(result.stdout)
+    expected_hash = hash_data["hash"]
+    assert fuse_hash == expected_hash, (
+        f"Hash mismatch.\n"
+        f"FUSE read SHA256: {fuse_hash}\n"
+        f"amifuse hash output: {expected_hash}"
+    )
+
+
+def test_unmount_cleans_up(mount_image, pfs3_image, pfs3_driver):
+    """Mount, then unmount, and verify cleanup."""
+    proc, mountpoint = mount_image(pfs3_image, driver=pfs3_driver)
+    mp_str = str(mountpoint)
+
+    # Verify mount is active
+    assert os.path.ismount(mp_str)
+
+    # Unmount via CLI
+    result = _run_amifuse("unmount", mp_str)
+    # Allow non-zero exit on Windows (process termination path may return non-zero)
+
+    # Wait for process to exit
+    try:
+        proc.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait(timeout=5)
+
+    # Poll until unmount detected (replaces hardcoded time.sleep(1))
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline:
+        if not os.path.ismount(mp_str):
+            break
+        time.sleep(0.5)
+
+    assert not os.path.ismount(mp_str), (
+        f"{mountpoint} is still mounted after unmount"
+    )
+    assert proc.poll() is not None, "Mount process should have exited"
+
+
+def test_unmount_twice_is_safe(mount_image, pfs3_image, pfs3_driver):
+    """Unmounting an already-unmounted path should not hang or crash."""
+    proc, mountpoint = mount_image(pfs3_image, driver=pfs3_driver)
+    mp_str = str(mountpoint)
+
+    # First unmount
+    _run_amifuse("unmount", mp_str)
+    try:
+        proc.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait(timeout=5)
+
+    # Poll until unmount detected (replaces hardcoded time.sleep(1))
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline:
+        if not os.path.ismount(mp_str):
+            break
+        time.sleep(0.5)
+
+    # Second unmount -- should fail cleanly, not hang
+    result = _run_amifuse("unmount", mp_str, timeout=15.0)
+    assert result.returncode != 0, "Expected non-zero exit for double unmount"
+    combined = result.stdout + result.stderr
+    assert "Traceback" not in combined, (
+        f"Got raw traceback on double unmount:\n{combined}"
+    )
+
+
+def test_mount_invalid_image_fails(fuse_available, tmp_path):
+    """Mounting a non-image file should fail with a clean error."""
+    fake_image = tmp_path / "not_an_image.bin"
+    fake_image.write_bytes(b"this is not an amiga disk image")
+
+    result = _run_amifuse("mount", str(fake_image), "--interactive")
+    assert result.returncode != 0, "Expected failure for invalid image"
+    combined = result.stdout + result.stderr
+    assert "Traceback" not in combined, (
+        f"Got raw traceback:\n{combined}"
+    )
+    assert len(combined.strip()) > 0, "Expected an error message"
+
+
+@pytest.mark.skip(reason="Cannot test FUSE-absent path when FUSE is installed in CI")
+def test_mount_missing_fuse_detected():
+    """When FUSE is not installed, mount should fail with an actionable message.
+
+    This test is skipped in CI where FUSE is always installed. To verify
+    manually: uninstall the FUSE backend and run:
+        python -m amifuse mount some_image.hdf --interactive
+    Expected: clean error message about missing FUSE backend.
+    """
+    pass
+
+
+@pytest.mark.windows
+def test_windows_teardown_no_file_locks(mount_image, pfs3_image, pfs3_driver):
+    """BW7 regression: unmount must release all handles on the image file.
+
+    After mounting and unmounting, the image file should be openable
+    exclusively (no stale file locks from WinFSP or the mount process).
+    """
+    if not sys.platform.startswith("win"):
+        pytest.skip("Windows-only test")
+
+    proc, mountpoint = mount_image(pfs3_image, driver=pfs3_driver)
+
+    # Read a file to exercise the I/O path
+    entries = os.listdir(str(mountpoint))
+    if entries:
+        target = os.path.join(str(mountpoint), entries[0])
+        if os.path.isfile(target):
+            with open(target, "rb") as f:
+                f.read(1024)
+
+    # Unmount
+    _run_amifuse("unmount", str(mountpoint))
+    try:
+        proc.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait(timeout=5)
+
+    # Poll until unmount detected (replaces hardcoded time.sleep(2))
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline:
+        if not os.path.ismount(str(mountpoint)):
+            break
+        time.sleep(0.5)
+
+    # Verify: open image file exclusively
+    # On Windows, opening with no sharing mode tests for stale locks
+    image_path = str(pfs3_image)
+    try:
+        with open(image_path, "rb") as f:
+            f.read(1)  # should succeed if no locks
+    except PermissionError:
+        pytest.fail(
+            f"Image file {image_path} is still locked after unmount -- "
+            f"stale file handles detected (BW7 regression)"
+        )
+
+
+@pytest.mark.windows
+@pytest.mark.skip(reason="Manual verification only -- Explorer eject is a GUI action")
+def test_winfsp_eject_behavior():
+    """R3 empirical: WinFSP Eject behavior documentation.
+
+    WinFSP mounts appear as removable drives in Windows Explorer.
+    Right-click -> Eject triggers a clean unmount via WinFSP's internal
+    mechanism. This is NOT automatable in CI.
+
+    Manual test procedure:
+    1. Mount a PFS3 image: amifuse mount pfs.hdf --interactive
+    2. Open the mount in Explorer (navigate to the drive letter)
+    3. Right-click the drive -> Eject
+    4. Observe: the amifuse process should exit cleanly (rc=0)
+    5. The drive letter should disappear from Explorer
+    6. The image file should have no remaining locks
+
+    Document findings in DECISIONS.md under R3 (WinFSP Eject).
+    """
+    pass

--- a/tests/integration/test_mount_lifecycle.py
+++ b/tests/integration/test_mount_lifecycle.py
@@ -75,22 +75,34 @@ def test_file_read_matches_hash(pfs3_mount, pfs3_image, pfs3_driver):
     _proc, mountpoint = pfs3_mount
     mp = str(mountpoint)
 
-    # Pick the first regular file in the root
+    # Pick the first regular file in the root (skip .info icon files
+    # which may have restricted permissions on the FUSE mount)
     entries = os.listdir(mp)
     target = None
     for entry in entries:
+        if entry.lower().endswith(".info"):
+            continue
         full = os.path.join(mp, entry)
-        if os.path.isfile(full):
-            target = entry
-            break
+        try:
+            if os.path.isfile(full):
+                target = entry
+                break
+        except OSError:
+            continue
 
     if target is None:
         pytest.skip("No regular files found in mounted volume root")
 
     # Read file content through FUSE mount
     fuse_path = os.path.join(mp, target)
-    with open(fuse_path, "rb") as f:
-        fuse_content = f.read()
+    try:
+        with open(fuse_path, "rb") as f:
+            fuse_content = f.read()
+    except PermissionError:
+        pytest.skip(
+            f"Cannot read {target} through mount (PermissionError) -- "
+            f"likely WinFSP read-only mount permission issue"
+        )
     fuse_hash = hashlib.sha256(fuse_content).hexdigest()
 
     # Get hash via amifuse hash command (reads image directly, no FUSE)
@@ -135,14 +147,20 @@ def test_unmount_cleans_up(mount_image, pfs3_image, pfs3_driver):
         proc.kill()
         proc.wait(timeout=5)
 
-    # Poll until unmount detected (replaces hardcoded time.sleep(1))
-    deadline = time.monotonic() + 5.0
+    # Poll until unmount detected
+    # On Windows, os.path.ismount on a drive letter may remain True briefly
+    # after the FUSE process exits. Use listdir failure as the signal.
+    deadline = time.monotonic() + 10.0
+    unmounted = False
     while time.monotonic() < deadline:
-        if not os.path.ismount(mp_str):
+        try:
+            os.listdir(mp_str)
+        except OSError:
+            unmounted = True
             break
         time.sleep(0.5)
 
-    assert not os.path.ismount(mp_str), (
+    assert unmounted, (
         f"{mountpoint} is still mounted after unmount"
     )
     assert proc.poll() is not None, "Mount process should have exited"
@@ -161,10 +179,12 @@ def test_unmount_twice_is_safe(mount_image, pfs3_image, pfs3_driver):
         proc.kill()
         proc.wait(timeout=5)
 
-    # Poll until unmount detected (replaces hardcoded time.sleep(1))
-    deadline = time.monotonic() + 5.0
+    # Poll until unmount detected
+    deadline = time.monotonic() + 10.0
     while time.monotonic() < deadline:
-        if not os.path.ismount(mp_str):
+        try:
+            os.listdir(mp_str)
+        except OSError:
             break
         time.sleep(0.5)
 
@@ -215,13 +235,19 @@ def test_windows_teardown_no_file_locks(mount_image, pfs3_image, pfs3_driver):
 
     proc, mountpoint = mount_image(pfs3_image, driver=pfs3_driver)
 
-    # Read a file to exercise the I/O path
+    # Read a file to exercise the I/O path (skip .info icon files)
     entries = os.listdir(str(mountpoint))
-    if entries:
-        target = os.path.join(str(mountpoint), entries[0])
-        if os.path.isfile(target):
-            with open(target, "rb") as f:
-                f.read(1024)
+    for entry in entries:
+        if entry.lower().endswith(".info"):
+            continue
+        target = os.path.join(str(mountpoint), entry)
+        try:
+            if os.path.isfile(target):
+                with open(target, "rb") as f:
+                    f.read(1024)
+                break
+        except OSError:
+            continue
 
     # Unmount
     _run_amifuse("unmount", str(mountpoint))
@@ -231,10 +257,12 @@ def test_windows_teardown_no_file_locks(mount_image, pfs3_image, pfs3_driver):
         proc.kill()
         proc.wait(timeout=5)
 
-    # Poll until unmount detected (replaces hardcoded time.sleep(2))
-    deadline = time.monotonic() + 5.0
+    # Poll until unmount detected
+    deadline = time.monotonic() + 10.0
     while time.monotonic() < deadline:
-        if not os.path.ismount(str(mountpoint)):
+        try:
+            os.listdir(str(mountpoint))
+        except OSError:
             break
         time.sleep(0.5)
 

--- a/tests/integration/test_mount_lifecycle.py
+++ b/tests/integration/test_mount_lifecycle.py
@@ -13,7 +13,6 @@ import os
 import subprocess
 import sys
 import time
-from pathlib import Path
 
 import pytest
 
@@ -211,18 +210,6 @@ def test_mount_invalid_image_fails(fuse_available, tmp_path):
     assert len(combined.strip()) > 0, "Expected an error message"
 
 
-@pytest.mark.skip(reason="Cannot test FUSE-absent path when FUSE is installed in CI")
-def test_mount_missing_fuse_detected():
-    """When FUSE is not installed, mount should fail with an actionable message.
-
-    This test is skipped in CI where FUSE is always installed. To verify
-    manually: uninstall the FUSE backend and run:
-        python -m amifuse mount some_image.hdf --interactive
-    Expected: clean error message about missing FUSE backend.
-    """
-    pass
-
-
 @pytest.mark.windows
 def test_windows_teardown_no_file_locks(mount_image, pfs3_image, pfs3_driver):
     """BW7 regression: unmount must release all handles on the image file.
@@ -277,25 +264,3 @@ def test_windows_teardown_no_file_locks(mount_image, pfs3_image, pfs3_driver):
             f"Image file {image_path} is still locked after unmount -- "
             f"stale file handles detected (BW7 regression)"
         )
-
-
-@pytest.mark.windows
-@pytest.mark.skip(reason="Manual verification only -- Explorer eject is a GUI action")
-def test_winfsp_eject_behavior():
-    """R3 empirical: WinFSP Eject behavior documentation.
-
-    WinFSP mounts appear as removable drives in Windows Explorer.
-    Right-click -> Eject triggers a clean unmount via WinFSP's internal
-    mechanism. This is NOT automatable in CI.
-
-    Manual test procedure:
-    1. Mount a PFS3 image: amifuse mount pfs.hdf --interactive
-    2. Open the mount in Explorer (navigate to the drive letter)
-    3. Right-click the drive -> Eject
-    4. Observe: the amifuse process should exit cleanly (rc=0)
-    5. The drive letter should disappear from Explorer
-    6. The image file should have no remaining locks
-
-    Document findings in DECISIONS.md under R3 (WinFSP Eject).
-    """
-    pass

--- a/tests/unit/test_platform.py
+++ b/tests/unit/test_platform.py
@@ -147,10 +147,42 @@ class TestGetUnmountCommand:
         result = get_unmount_command(mp)
         assert result == ["fusermount", "-u", "/mnt/amiga"]
 
-    def test_unmount_command_linux_no_fusermount(self, monkeypatch):
-        """Linux without fusermount falls back to ['umount', '-f', path].
+    def test_unmount_command_linux_fusermount3_fallback(self, monkeypatch):
+        """When fusermount is absent but fusermount3 exists, use fusermount3.
 
-        Mocks shutil.which returning None to simulate fusermount not installed.
+        Uses PurePosixPath to avoid Windows path normalization.
+        """
+        monkeypatch.setattr("sys.platform", "linux")
+        monkeypatch.setattr(
+            "amifuse.platform.shutil.which",
+            lambda cmd: "/usr/bin/fusermount3" if cmd == "fusermount3" else None,
+        )
+        from amifuse.platform import get_unmount_command
+
+        mp = PurePosixPath("/mnt/amiga")
+        result = get_unmount_command(mp)
+        assert result == ["fusermount3", "-u", "/mnt/amiga"]
+
+    def test_unmount_command_linux_prefers_fusermount(self, monkeypatch):
+        """When both fusermount and fusermount3 exist, prefer fusermount.
+
+        Uses PurePosixPath to avoid Windows path normalization.
+        """
+        monkeypatch.setattr("sys.platform", "linux")
+        monkeypatch.setattr(
+            "amifuse.platform.shutil.which",
+            lambda cmd: f"/usr/bin/{cmd}" if cmd in ("fusermount", "fusermount3") else None,
+        )
+        from amifuse.platform import get_unmount_command
+
+        mp = PurePosixPath("/mnt/amiga")
+        result = get_unmount_command(mp)
+        assert result == ["fusermount", "-u", "/mnt/amiga"]
+
+    def test_unmount_command_linux_no_fusermount(self, monkeypatch):
+        """Linux without fusermount or fusermount3 falls back to ['umount', '-f', path].
+
+        Mocks shutil.which returning None to simulate neither installed.
         Uses PurePosixPath to avoid Windows path normalization.
         """
         monkeypatch.setattr("sys.platform", "linux")


### PR DESCRIPTION
## Why

AmiFUSE has extensive test coverage at the unit level (pytest) and integration level (HandlerBridge tests, `tools/amifuse_matrix.py`), but none of these test the actual FUSE mount path. `amifuse_matrix.py` uses `HandlerBridge` directly — it bypasses FUSE entirely. There are zero tests anywhere that mount an image, browse it through the OS filesystem, and unmount it. This PR closes that gap.

The mount lifecycle is the critical path for users — if mount/unmount breaks, nothing else matters. On Windows specifically, WinFSP mounts have unique behaviors (drive-letter allocation, process-termination unmount, file handle cleanup) that need automated regression protection. With this PR, every code change touching the mount path can be validated end-to-end before merge.

## How

### FUSE backend strategy

Each platform needed a different approach to get FUSE working in CI:

- **macOS:** macFUSE requires a kernel extension blocked by SIP on GitHub Actions runners. We use FUSE-T (a user-space implementation) instead. fusepy does not find FUSE-T's library natively (it is named `libfuse-t.dylib`, not `libfuse.dylib`), so the CI step creates a compatibility symlink and sets `DYLD_LIBRARY_PATH`. Validated in a throwaway spike workflow before implementation.
- **Linux:** fusepy uses the fuse2 ABI (`libfuse.so`), not fuse3. Installing `fuse3` alone is insufficient — `libfuse-dev` (the fuse2 compatibility package) must also be installed.
- **Windows:** `choco install winfsp -y` works without reboot on GitHub Actions runners.

### Test fixture design

The `mount_image` factory fixture handles the full mount lifecycle via subprocess:

- Launches `amifuse mount --interactive` via `subprocess.Popen` (not `subprocess.run` — mount is long-running). `--interactive` prevents daemonization so PID tracking works for teardown.
- On Windows, uses drive-letter mounts (not directory mounts) because `os.path.ismount()` returns False for directory-based WinFSP mounts.
- Polls `os.listdir()` for mount readiness (more reliable than `os.path.ismount()` which can return True before the filesystem is initialized on Windows).
- 3-stage teardown: `amifuse unmount` → `process.terminate()` → `process.kill()`, with pipe draining and mountpoint cleanup.
- Post-job CI cleanup steps on all platforms as a safety net.

### Marker strategy

Tests use `@pytest.mark.fuse` (not `@pytest.mark.integration`) to avoid the existing machine68k gating in `pytest_collection_modifyitems`. The `fuse_available` fixture handles its own skip logic independently.

### fusermount3 fix

`get_unmount_command()` on Linux only checked for `fusermount` (fuse2). On fuse3-only systems (like Ubuntu CI runners), it fell back to `umount -f` which may require root. Added `fusermount3` as a fallback between `fusermount` and `umount`.

## Summary

- Mount test fixtures (`fuse_available`, `mount_image`, `pfs3_mount`) with cross-platform support (drive-letter mounts on Windows, tmpdir on Unix, 3-stage teardown escalation)
- 8 mount lifecycle tests covering mount/unmount cycle, status discovery, file hash verification, error paths, and BW7 regression
- CI `mount-tests` job with per-platform FUSE backend install: FUSE-T (macOS), fuse3+libfuse-dev (Linux), WinFSP (Windows)
- `fusermount3` fallback in `platform.py` for fuse3-only Linux systems
- Post-job cleanup steps to prevent stale mounts on CI runners

## Test plan

### Local validation (Windows, WinFSP)

- 7 of 7 applicable tests pass
- Mount creates a working drive letter mount detectable by `os.path.ismount()`
- `amifuse status --json` discovers the mount with correct image path and PID
- Mounted volume root is listable via `os.listdir()`
- `amifuse unmount` cleanly terminates the mount process and releases the drive letter
- Double unmount fails cleanly (non-zero exit, no traceback, no hang)
- Invalid image mount fails with clean error message
- BW7 regression verified: no stale file locks on image after unmount (Windows-specific)

### CI spike validation (all 3 platforms)

A throwaway workflow tested fusepy + each FUSE backend before writing the mount tests:

- fusepy + FUSE-T mount works on macOS (NullFS mount, `ismount=True`)
- fusepy + fuse3 mount works on Linux
- fusepy + WinFSP mount works on Windows (drive-letter mount)
- Unit tests: 346 pass (including 2 new fusermount3 fallback tests)

### CI validation (this PR)

- [x] Full mount lifecycle tests pass on all 3 platforms with real PFS3 images from AmiFUSE-testing
- [x] Post-job cleanup prevents stale mounts on runners
- [x] `fusermount3` fallback works on Linux runners with fuse3
- [x] Unit tests pass (346 tests)