### PR TITLE
Add Windows shell integration and tray mount manager

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,6 +193,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e "./amitools[vamos]"
           pip install "pytest>=7.0" "pytest-cov>=4.0" "pytest-timeout>=2.0"
+          pip install fusepy
           pip install -e "." --no-deps
 
       - name: Verify FUSE backend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,13 +199,29 @@ jobs:
       - name: Verify FUSE backend
         run: |
           python -c "
+          import sys, os
           try:
               from fuse import FUSE
               print('fusepy: OK (FUSE class imported)')
           except EnvironmentError as e:
               print(f'fusepy: FUSE backend not found: {e}')
+              sys.exit(0)
           except ImportError:
               print('fusepy: not installed')
+              sys.exit(0)
+          # Verify /dev/fuse accessible on Linux
+          if sys.platform.startswith('linux'):
+              if os.path.exists('/dev/fuse'):
+                  mode = oct(os.stat('/dev/fuse').st_mode)
+                  print(f'/dev/fuse exists, mode={mode}')
+                  try:
+                      fd = os.open('/dev/fuse', os.O_RDWR)
+                      os.close(fd)
+                      print('/dev/fuse: read-write access OK')
+                  except PermissionError as e:
+                      print(f'/dev/fuse: access denied: {e}')
+              else:
+                  print('/dev/fuse: NOT FOUND')
           "
         continue-on-error: true
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,8 @@ attic/
 mnt/
 *.hdf
 *.adf
-BFFSFilesystem
-FastFileSystem
-SmartFileSystem
-pfs3aio
+/BFFSFilesystem
+/FastFileSystem
+/SmartFileSystem
+/pfs3aio
+*.egg-info/

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ source .venv/bin/activate   # On Windows: .venv\Scripts\activate
 
 pip install -e './amitools[vamos]'   # Install amitools from submodule (includes machine68k)
 pip install -e .                     # Install AmiFUSE
+pip install -e '.[windows]'         # Windows only: adds pystray + Pillow for tray/shell integration
 ```
 
 ### Without virtual environment
@@ -117,6 +118,10 @@ amifuse uses subcommands for different operations:
 ```bash
 amifuse inspect <image>                    # Inspect RDB partitions
 amifuse mount <image>                      # Mount a filesystem
+amifuse unmount <mountpoint>               # Unmount a filesystem
+amifuse doctor                             # Check dependencies and configuration
+amifuse register                           # Add Windows Explorer context menu entries
+amifuse unregister                         # Remove Windows Explorer context menu entries
 ```
 
 ### Inspecting Disk Images
@@ -166,8 +171,10 @@ Mount lifecycle:
 - `--interactive` / `--foreground` keeps AmiFUSE attached to the terminal.
   Use this for debugging or when you want `Ctrl+C` to unmount from the same
   shell.
-- Windows defaults to interactive mode because there is no standalone
-  unmount command there yet.
+- Windows defaults to daemon mode. You can mount via the Explorer context
+  menu (`amifuse register`), unmount from the system tray icon, or use
+  `amifuse unmount <mountpoint>` from the CLI. Note: the WinFSP "Eject"
+  action does not perform a clean unmount — use the tray or CLI instead.
 - `--profile` implies interactive mode.
 
 ### Examples
@@ -284,13 +291,37 @@ The `--icons` flag enables conversion of Amiga `.info` icon files to native Find
 
 *** This feature is experimental and macOS-only. ***
 
+## Windows Shell Integration
+
+On Windows, AmiFUSE can integrate with Explorer for a right-click mount
+experience and a system tray mount manager.
+
+### Context menu registration
+
+```bash
+amifuse register      # Add "Mount with AmiFUSE" to .hdf/.adf context menus
+amifuse unregister    # Remove the context menu entries
+```
+
+Registration writes to `HKCU` (current user only) — no administrator privileges
+are required.
+
+### Tray mount manager
+
+When a filesystem is mounted in daemon mode on Windows, the `amifuse-tray`
+helper appears in the system tray. From the tray icon you can see active mounts
+and unmount them cleanly.
+
+The tray requires optional dependencies: install them with
+`pip install amifuse[windows]` (provides pystray and Pillow).
+
 ## Notes
 
 - The filesystem is mounted **read-only** by default; use `--write` for experimental read-write support
 - macOS and Linux default to daemon mode; use `--interactive` if you want
   Ctrl+C to unmount from the same terminal
 - Use `amifuse unmount <mountpoint>` to tear down daemon mounts
-- Windows defaults to interactive mode until it grows a standalone unmount
-  path
+- Windows defaults to daemon mode; unmount via the system tray icon or
+  `amifuse unmount <mountpoint>`
 - macOS Finder/Spotlight indexing is automatically disabled to improve performance
 - First directory traversal may be slow as the handler processes each path; subsequent accesses are cached

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ source .venv/bin/activate   # On Windows: .venv\Scripts\activate
 
 pip install -e './amitools[vamos]'   # Install amitools from submodule (includes machine68k)
 pip install -e .                     # Install AmiFUSE
+pip install -e '.[windows]'         # Windows only: adds pystray + Pillow for tray/shell integration
 ```
 
 ### macOS-specific
@@ -132,7 +133,10 @@ amifuse uses subcommands for different operations:
 ```bash
 amifuse inspect <image>                    # Inspect RDB partitions
 amifuse mount <image>                      # Mount a filesystem
+amifuse unmount <mountpoint>               # Unmount a filesystem
 amifuse doctor                             # Check dependencies and configuration
+amifuse register                           # Add Windows Explorer context menu entries
+amifuse unregister                         # Remove Windows Explorer context menu entries
 ```
 
 ### Inspecting Disk Images
@@ -182,8 +186,10 @@ Mount lifecycle:
 - `--interactive` / `--foreground` keeps AmiFUSE attached to the terminal.
   Use this for debugging or when you want `Ctrl+C` to unmount from the same
   shell.
-- Windows defaults to interactive mode because there is no standalone
-  unmount command there yet.
+- Windows defaults to daemon mode. You can mount via the Explorer context
+  menu (`amifuse register`), unmount from the system tray icon, or use
+  `amifuse unmount <mountpoint>` from the CLI. Note: the WinFSP "Eject"
+  action does not perform a clean unmount — use the tray or CLI instead.
 - `--profile` implies interactive mode.
 
 ### Diagnosing Issues
@@ -311,13 +317,37 @@ The `--icons` flag enables conversion of Amiga `.info` icon files to native Find
 
 *** This feature is experimental and macOS-only. ***
 
+## Windows Shell Integration
+
+On Windows, AmiFUSE can integrate with Explorer for a right-click mount
+experience and a system tray mount manager.
+
+### Context menu registration
+
+```bash
+amifuse register      # Add "Mount with AmiFUSE" to .hdf/.adf context menus
+amifuse unregister    # Remove the context menu entries
+```
+
+Registration writes to `HKCU` (current user only) — no administrator privileges
+are required.
+
+### Tray mount manager
+
+When a filesystem is mounted in daemon mode on Windows, the `amifuse-tray`
+helper appears in the system tray. From the tray icon you can see active mounts
+and unmount them cleanly.
+
+The tray requires optional dependencies: install them with
+`pip install amifuse[windows]` (provides pystray and Pillow).
+
 ## Notes
 
 - The filesystem is mounted **read-only** by default; use `--write` for experimental read-write support
 - macOS and Linux default to daemon mode; use `--interactive` if you want
   Ctrl+C to unmount from the same terminal
 - Use `amifuse unmount <mountpoint>` to tear down daemon mounts
-- Windows defaults to interactive mode until it grows a standalone unmount
-  path
+- Windows defaults to daemon mode; unmount via the system tray icon or
+  `amifuse unmount <mountpoint>`
 - macOS Finder/Spotlight indexing is automatically disabled to improve performance
 - First directory traversal may be slow as the handler processes each path; subsequent accesses are cached

--- a/amifuse/doctor.py
+++ b/amifuse/doctor.py
@@ -149,7 +149,36 @@ def run_checks() -> List[CheckResult]:
         except ImportError:
             pass  # windows_shell not available, skip check
 
-    # 8. PATH check
+    # 8. Tray dependencies (Windows only, when shell registered)
+    if sys.platform.startswith("win"):
+        try:
+            from .windows_shell import is_registered
+            if is_registered():
+                import importlib.util
+                missing = []
+                if importlib.util.find_spec("pystray") is None:
+                    missing.append("pystray")
+                if importlib.util.find_spec("PIL") is None:
+                    missing.append("Pillow")
+                if missing:
+                    pkgs = " ".join(missing)
+                    results.append(CheckResult(
+                        "tray_deps", "warning",
+                        f"Tray dependencies missing: {pkgs}",
+                        fixable=True,
+                        fix_fn=lambda: __import__("subprocess").check_call(
+                            [sys.executable, "-m", "pip", "install"] + pkgs.split()),
+                        fix_description=f"Run: pip install {pkgs}",
+                    ))
+                else:
+                    results.append(CheckResult(
+                        "tray_deps", "ok",
+                        "Tray dependencies installed (pystray, Pillow)",
+                    ))
+        except ImportError:
+            pass
+
+    # 9. PATH check
     if shutil.which("amifuse"):
         results.append(CheckResult("path", "ok", "amifuse is on PATH"))
     else:

--- a/amifuse/doctor.py
+++ b/amifuse/doctor.py
@@ -166,14 +166,32 @@ def run_checks() -> List[CheckResult]:
                         "tray_deps", "warning",
                         f"Tray dependencies missing: {pkgs}",
                         fixable=True,
-                        fix_fn=lambda: __import__("subprocess").check_call(
-                            [sys.executable, "-m", "pip", "install"] + pkgs.split()),
+                        fix_fn=lambda _pkgs=pkgs: __import__("subprocess").check_call(
+                            [sys.executable, "-m", "pip", "install"] + _pkgs.split()),
                         fix_description=f"Run: pip install {pkgs}",
                     ))
                 else:
                     results.append(CheckResult(
                         "tray_deps", "ok",
                         "Tray dependencies installed (pystray, Pillow)",
+                    ))
+        except ImportError:
+            pass
+
+    # 8b. WScript availability (Windows only, when shell registered)
+    if sys.platform.startswith("win"):
+        try:
+            from .windows_shell import is_registered
+            if is_registered():
+                if not shutil.which("wscript.exe"):
+                    results.append(CheckResult(
+                        "wscript", "warning",
+                        "wscript.exe not found on PATH; context menu actions will not work",
+                    ))
+                else:
+                    results.append(CheckResult(
+                        "wscript", "ok",
+                        "wscript.exe available for context menu actions",
                     ))
         except ImportError:
             pass

--- a/amifuse/fuse_fs.py
+++ b/amifuse/fuse_fs.py
@@ -16,12 +16,10 @@ import subprocess
 import sys
 import time
 
-# signal.SIGKILL is not defined on Windows; fall back to SIGTERM so that
-# _kill_mount_owner_processes() can still compile and will use the strongest
-# signal available.
-_SIGKILL = getattr(signal, "SIGKILL", signal.SIGTERM)
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
+
+from .platform import _kill_mount_owner_processes
 
 try:
     from fuse import FUSE, FuseOSError, LoggingMixIn, Operations  # type: ignore
@@ -1583,8 +1581,9 @@ class AmigaFuseFS(Operations):
 
     def _root_stat(self):
         now = int(time.time())
+        perm = 0o777 if self.bridge._write_enabled else 0o755
         return {
-            "st_mode": (0o755 | 0o040000),  # drwxr-xr-x
+            "st_mode": (perm | 0o040000),
             "st_nlink": 2,
             "st_size": 0,
             "st_ctime": now,
@@ -2495,11 +2494,6 @@ def mount_fuse(
 
     if foreground is None:
         foreground = plat.mount_runs_in_foreground_by_default()
-    if not foreground and not plat.get_unmount_command(mountpoint):
-        raise SystemExit(
-            "Daemon mode is not supported on this platform yet because there is "
-            "no standalone unmount command. Use --interactive instead."
-        )
 
     # Print startup banner
     print(__banner__)
@@ -2562,6 +2556,12 @@ def mount_fuse(
         "fsname": f"amifuse:{volname}",
         "default_permissions": True,  # Let kernel handle permission checks
     }
+    # WinFSP maps FUSE uid=0/gid=0 to Windows SID S-1-5-0 (Nobody), blocking
+    # write access for the current user.  uid/gid=-1 tells WinFSP to use the
+    # mounting user's SID instead.
+    if sys.platform.startswith("win"):
+        fuse_kwargs["uid"] = -1
+        fuse_kwargs["gid"] = -1
     # subtype is a Linux-only FUSE option; WinFSP and macFUSE don't support it
     if sys.platform.startswith("linux"):
         fuse_kwargs["subtype"] = "amifuse"
@@ -3780,12 +3780,13 @@ def cmd_unmount(args):
         raise SystemExit(f"Mountpoint {mountpoint} is not currently mounted.")
 
     cmd = plat.get_unmount_command(mountpoint)
+    _no_window = {"creationflags": 0x08000000} if sys.platform.startswith("win") else {}
     if cmd:
-        result = subprocess.run(cmd, check=False)
+        result = subprocess.run(cmd, check=False, **_no_window)
         if result.returncode != 0:
             killed_pids = _kill_mount_owner_processes(mountpoint)
             if killed_pids:
-                result = subprocess.run(cmd, check=False)
+                result = subprocess.run(cmd, check=False, **_no_window)
         if result.returncode != 0:
             raise SystemExit(
                 f"Unmount failed with exit code {result.returncode}: "
@@ -3976,84 +3977,16 @@ def cmd_doctor(args):
     # else sys.exit(0) -- implicit
 
 
-def _kill_mount_owner_processes(mountpoint: Path) -> List[int]:
-    pids = _find_mount_owner_pids(mountpoint)
-    if not pids:
-        return []
-
-    remaining = []
-    for pid in pids:
-        try:
-            os.kill(pid, signal.SIGTERM)
-            remaining.append(pid)
-        except (ProcessLookupError, OSError):
-            continue
-
-    deadline = time.time() + 1.0
-    while remaining and time.time() < deadline:
-        still_alive = []
-        for pid in remaining:
-            if _pid_exists(pid):
-                still_alive.append(pid)
-        if not still_alive:
-            return pids
-        remaining = still_alive
-        time.sleep(0.05)
-
-    for pid in remaining:
-        try:
-            os.kill(pid, _SIGKILL)
-        except (ProcessLookupError, OSError):
-            continue
-
-    return pids
+def cmd_register(args):
+    """Handle the 'register' subcommand."""
+    from .windows_shell import register
+    register()
 
 
-def _find_mount_owner_pids(mountpoint: Path) -> List[int]:
-    """Find PIDs of amifuse processes that own the given mountpoint.
-
-    Uses platform.find_amifuse_mounts() for process discovery, then
-    filters to those matching the given mountpoint.
-    """
-    from . import platform as plat
-
-    raw_mountpoint = str(mountpoint)
-    abs_mountpoint = str(mountpoint.resolve(strict=False))
-
-    try:
-        all_mounts = plat.find_amifuse_mounts()
-    except OSError:
-        return []
-
-    pids = []
-    for mount in all_mounts:
-        mp = mount.get("mountpoint")
-        if mp is None:
-            continue
-        if mp == raw_mountpoint or mp == abs_mountpoint:
-            pids.append(mount["pid"])
-            continue
-        try:
-            resolved = str(Path(mp).expanduser().resolve(strict=False))
-        except OSError:
-            continue
-        if resolved == abs_mountpoint:
-            pids.append(mount["pid"])
-
-    return pids
-
-
-def _pid_exists(pid: int) -> bool:
-    try:
-        os.kill(pid, 0)
-    except ProcessLookupError:
-        return False
-    except PermissionError:
-        return True
-    except OSError:
-        # Windows raises a generic OSError for invalid/dead PIDs
-        return False
-    return True
+def cmd_unregister(args):
+    """Handle the 'unregister' subcommand."""
+    from .windows_shell import unregister
+    unregister()
 
 
 def _validate_driver_path(driver: Optional[Path]) -> None:
@@ -4100,6 +4033,9 @@ commands:
 
   doctor                    Check prerequisites and environment readiness.
     --json                    Output results as JSON.
+
+  register                  Add Windows Explorer context menu entries.
+  unregister                Remove Windows Explorer context menu entries.
 
   format <image> <partition> [volname]
                               Format an Amiga partition.
@@ -4255,6 +4191,17 @@ commands:
         help="Output results as JSON.",
     )
     doctor_parser.set_defaults(func=cmd_doctor)
+
+    # register / unregister subcommands (Windows shell integration)
+    register_parser = subparsers.add_parser(
+        "register", help="Register AmiFUSE file associations (Windows)."
+    )
+    register_parser.set_defaults(func=cmd_register)
+
+    unregister_parser = subparsers.add_parser(
+        "unregister", help="Remove AmiFUSE file associations (Windows)."
+    )
+    unregister_parser.set_defaults(func=cmd_unregister)
 
     # format subcommand
     format_parser = subparsers.add_parser(

--- a/amifuse/fuse_fs.py
+++ b/amifuse/fuse_fs.py
@@ -19,7 +19,7 @@ import time
 from pathlib import Path
 from typing import Dict, List, Optional, Set, Tuple
 
-from .platform import _kill_mount_owner_processes
+from .platform import kill_mount_owner_processes
 
 try:
     from fuse import FUSE, FuseOSError, LoggingMixIn, Operations  # type: ignore
@@ -1442,6 +1442,13 @@ class HandlerBridge:
             self.launcher.send_flush(self.state)
             replies = self._run_until_replies()
             self._log_replies("flush_volume", replies)
+            # Sync the underlying file to disk
+            self.backend.sync()
+            if self._debug:
+                if replies and replies[-1][2] != 0:
+                    print("[amifuse] Volume flush complete", flush=True)
+                else:
+                    print("[amifuse] Volume flush may have failed", flush=True)
 
     def inhibit_cycle(self):
         """Inhibit then uninhibit the handler to clear all internal state."""
@@ -1726,7 +1733,9 @@ class AmigaFuseFS(Operations):
             self._track_op("getattr", path, cached=True)
             raise FuseOSError(errno.ENOENT)
         # Check if path has a pending (deferred) delete - hide from callers
-        if path in self._pending_deletes:
+        with self._fh_lock:
+            pending = path in self._pending_deletes
+        if pending:
             self._track_op("getattr", path, cached=True)
             raise FuseOSError(errno.ENOENT)
         # Check positive cache
@@ -1808,27 +1817,38 @@ class AmigaFuseFS(Operations):
         resolved_path = path if path else entry.get("path")
         if not resolved_path:
             return 0
-        if resolved_path in self._pending_deletes:
+        with self._fh_lock:
+            if resolved_path not in self._pending_deletes:
+                return 0
+            still_open = any(
+                v.get("dir_handle") and v.get("path") == resolved_path
+                for v in self._fh_cache.values()
+            )
+            if still_open:
+                return 0
+            self._pending_deletes.discard(resolved_path)
+        # Guard: skip deferred delete if handler is dead or read-only
+        if self.bridge.state.crashed or not self.bridge._write_enabled:
+            return 0
+        try:
+            self.bridge.flush_volume()
+            self.bridge.inhibit_cycle()
+            res1, res2 = self.bridge.delete_dir_atomic(resolved_path)
+            if res1 == 0:
+                with self._fh_lock:
+                    self._pending_deletes.add(resolved_path)
+                self._log_op("releasedir", resolved_path, "deferred delete failed permanently, path hidden until unmount")
+            else:
+                self._stat_cache.pop(resolved_path, None)
+                parent_path = resolved_path.rsplit("/", 1)[0] or "/"
+                self._dir_cache.pop(parent_path, None)
+        except Exception as e:
+            self._log_op("releasedir", resolved_path, f"deferred delete exception: {type(e).__name__}: {e}")
             with self._fh_lock:
-                still_open = any(
-                    v.get("dir_handle") and v.get("path") == resolved_path
-                    for v in self._fh_cache.values()
-                )
-            if not still_open:
-                self._pending_deletes.discard(resolved_path)
-                try:
-                    self.bridge.flush_volume()
-                    self.bridge.inhibit_cycle()
-                    res1, res2 = self.bridge.delete_dir_atomic(resolved_path)
-                    if res1 == 0:
-                        self._pending_deletes.add(resolved_path)
-                    else:
-                        self._stat_cache.pop(resolved_path, None)
-                        parent_path = resolved_path.rsplit("/", 1)[0] or "/"
-                        self._dir_cache.pop(parent_path, None)
-                except Exception:
-                    pass
-                self._resolve_pending_dir_deletes(resolved_path)
+                self._pending_deletes.add(resolved_path)
+        # Only resolve parent dir deletes if deletion succeeded
+        if resolved_path not in self._pending_deletes:
+            self._resolve_pending_dir_deletes(resolved_path)
         return 0
 
     def readdir(self, path, fh):
@@ -1839,14 +1859,15 @@ class AmigaFuseFS(Operations):
             if time.time() - ts < self._dir_cache_ttl:
                 self._track_op("readdir", path, cached=True)
                 # Filter pending deletes from cached results
-                if self._pending_deletes:
-                    cached_entries = [
-                        e for e in cached_entries
-                        if e in (".", "..") or (
-                            (path.rstrip("/") + "/" + e if path != "/" else "/" + e)
-                            not in self._pending_deletes
-                        )
-                    ]
+                with self._fh_lock:
+                    if self._pending_deletes:
+                        cached_entries = [
+                            e for e in cached_entries
+                            if e in (".", "..") or (
+                                (path.rstrip("/") + "/" + e if path != "/" else "/" + e)
+                                not in self._pending_deletes
+                            )
+                        ]
                 return cached_entries
             del self._dir_cache[path]
 
@@ -1899,14 +1920,15 @@ class AmigaFuseFS(Operations):
                 entries.append(volume_icon_file)
 
         # Filter out entries with pending (deferred) deletes
-        if self._pending_deletes:
-            entries = [
-                e for e in entries
-                if e in (".", "..") or (
-                    (path.rstrip("/") + "/" + e if path != "/" else "/" + e)
-                    not in self._pending_deletes
-                )
-            ]
+        with self._fh_lock:
+            if self._pending_deletes:
+                entries = [
+                    e for e in entries
+                    if e in (".", "..") or (
+                        (path.rstrip("/") + "/" + e if path != "/" else "/" + e)
+                        not in self._pending_deletes
+                    )
+                ]
 
         # Cache the directory listing
         self._dir_cache[path] = (now, entries)
@@ -2146,9 +2168,11 @@ class AmigaFuseFS(Operations):
             if res2 == 202:
                 # ERROR_OBJECT_IN_USE: file has an active handle (WinFSP calls
                 # unlink before release). Defer deletion to release().
-                has_handle = any(v.get("path") == path for v in self._fh_cache.values())
+                with self._fh_lock:
+                    has_handle = any(v.get("path") == path for v in self._fh_cache.values())
+                    if has_handle:
+                        self._pending_deletes.add(path)
                 if has_handle:
-                    self._pending_deletes.add(path)
                     self._stat_cache.pop(path, None)
                     self._dir_cache.pop(dir_path, None)
                     for l in reversed(locks):
@@ -2174,13 +2198,17 @@ class AmigaFuseFS(Operations):
         dir_path, name = self._split_path(path)
         if not name:
             raise FuseOSError(errno.EINVAL)
-        self.bridge.inhibit_cycle()
         res1, res2 = self.bridge.delete_dir_atomic(path)
+        if res1 == 0 and res2 == 202:
+            # OBJECT_IN_USE — inhibit cycle clears handler internal state, retry
+            self.bridge.inhibit_cycle()
+            res1, res2 = self.bridge.delete_dir_atomic(path)
         self._log_op("rmdir", path, f"delete_dir_atomic res1={res1} res2={res2}")
         if res1 == 0:
             if res2 == 202:
                 # OBJECT_IN_USE — defer unconditionally; releasedir will retry
-                self._pending_deletes.add(path)
+                with self._fh_lock:
+                    self._pending_deletes.add(path)
                 self._stat_cache.pop(path, None)
                 self._dir_cache.pop(dir_path, None)
                 self._dir_cache.pop(path, None)
@@ -2195,10 +2223,10 @@ class AmigaFuseFS(Operations):
                     for d in self._pending_dir_deletes:
                         if d.startswith(path + "/"):
                             pending_children.add(d)
-                if pending_children:
-                    with self._fh_lock:
+                    if pending_children:
                         self._pending_dir_deletes[path] = pending_children.copy()
                         self._pending_deletes.add(path)
+                if pending_children:
                     self._stat_cache.pop(path, None)
                     self._dir_cache.pop(dir_path, None)
                     self._dir_cache.pop(path, None)
@@ -2496,7 +2524,7 @@ class AmigaFuseFS(Operations):
         blocking children have been deleted.
         """
         parent_dir = deleted_child_path.rsplit("/", 1)[0] or "/"
-        while parent_dir in self._pending_dir_deletes:
+        while True:
             with self._fh_lock:
                 if parent_dir not in self._pending_dir_deletes:
                     break
@@ -2504,9 +2532,9 @@ class AmigaFuseFS(Operations):
                 if self._pending_dir_deletes[parent_dir]:
                     # Still has other pending children - stop here
                     break
-                # All children resolved - attempt the directory delete
+                # All children resolved - remove from dir_deletes to prevent re-entry
+                # but keep in _pending_deletes until delete confirmed
                 del self._pending_dir_deletes[parent_dir]
-                self._pending_deletes.discard(parent_dir)
             # Attempt the actual directory deletion outside the lock
             try:
                 dir_path, name = self._split_path(parent_dir)
@@ -2524,13 +2552,21 @@ class AmigaFuseFS(Operations):
                         self._log_op("release", parent_dir, "deferred rmdir failed (dir not empty), discarding")
                         for l in reversed(locks):
                             self.bridge.free_lock(l)
+                        # Delete failed - _pending_deletes still has it, just stop
                         break
+                else:
+                    # Could not locate parent - _pending_deletes still has it, just stop
+                    break
                 for l in reversed(locks):
                     self.bridge.free_lock(l)
+                # Delete succeeded - now remove from _pending_deletes
+                with self._fh_lock:
+                    self._pending_deletes.discard(parent_dir)
                 self._stat_cache.pop(parent_dir, None)
                 self._dir_cache.pop(dir_path, None)
             except Exception:
                 self._log_op("release", parent_dir, "deferred rmdir exception, discarding")
+                # Delete failed - _pending_deletes still has it, just stop
                 break
             # Successfully deleted this directory - walk up to check its parent
             deleted_child_path = parent_dir
@@ -2563,8 +2599,19 @@ class AmigaFuseFS(Operations):
         # Resolve path: use FUSE-provided path, fall back to cached path
         resolved_path = path if path else entry.get("path")
         # Check for deferred deletes (WinFSP unlink-before-release pattern)
-        if resolved_path and resolved_path in self._pending_deletes:
-            self._pending_deletes.discard(resolved_path)
+        if resolved_path:
+            with self._fh_lock:
+                if resolved_path not in self._pending_deletes:
+                    return 0
+                # Check if another handle for this path is still open
+                still_open = any(
+                    v.get("path") == resolved_path and not v.get("closed")
+                    for v in self._fh_cache.values()
+                )
+                if still_open:
+                    return 0
+                self._pending_deletes.discard(resolved_path)
+            delete_succeeded = False
             try:
                 dir_path, name = self._split_path(resolved_path)
                 lock_bptr, _, locks = self.bridge.locate_path(dir_path)
@@ -2575,14 +2622,26 @@ class AmigaFuseFS(Operations):
                 if lock_bptr != 0:
                     res1, res2 = self.bridge.delete_object(lock_bptr, name)
                     self._log_op("release", resolved_path, f"deferred delete res1={res1} res2={res2}")
+                    if res1 != 0:
+                        delete_succeeded = True
+                    else:
+                        with self._fh_lock:
+                            self._pending_deletes.add(resolved_path)
+                else:
+                    with self._fh_lock:
+                        self._pending_deletes.add(resolved_path)
                 for l in reversed(locks):
                     self.bridge.free_lock(l)
-                self._stat_cache.pop(resolved_path, None)
-                self._dir_cache.pop(dir_path, None)
-            except Exception:
-                pass
-            # Resolve any deferred parent directory deletes
-            self._resolve_pending_dir_deletes(resolved_path)
+                if delete_succeeded:
+                    self._stat_cache.pop(resolved_path, None)
+                    self._dir_cache.pop(dir_path, None)
+            except Exception as e:
+                self._log_op("release", resolved_path, f"deferred delete exception: {type(e).__name__}: {e}")
+                with self._fh_lock:
+                    self._pending_deletes.add(resolved_path)
+            # Resolve any deferred parent directory deletes only on success
+            if delete_succeeded:
+                self._resolve_pending_dir_deletes(resolved_path)
         return 0
 
     def destroy(self, path):
@@ -4102,7 +4161,7 @@ def cmd_unmount(args):
     if cmd:
         result = subprocess.run(cmd, check=False, **_no_window)
         if result.returncode != 0:
-            killed_pids = _kill_mount_owner_processes(mountpoint)
+            killed_pids = kill_mount_owner_processes(mountpoint)
             if killed_pids:
                 result = subprocess.run(cmd, check=False, **_no_window)
         if result.returncode != 0:
@@ -4113,7 +4172,7 @@ def cmd_unmount(args):
     else:
         # No platform unmount command (e.g. Windows/WinFSP) -- go straight
         # to process termination.
-        killed_pids = _kill_mount_owner_processes(mountpoint)
+        killed_pids = kill_mount_owner_processes(mountpoint)
         if not killed_pids:
             raise SystemExit(
                 f"No amifuse process found for mountpoint {mountpoint}."

--- a/amifuse/fuse_fs.py
+++ b/amifuse/fuse_fs.py
@@ -16,12 +16,10 @@ import subprocess
 import sys
 import time
 
-# signal.SIGKILL is not defined on Windows; fall back to SIGTERM so that
-# _kill_mount_owner_processes() can still compile and will use the strongest
-# signal available.
-_SIGKILL = getattr(signal, "SIGKILL", signal.SIGTERM)
 from pathlib import Path
 from typing import Dict, List, Optional, Set, Tuple
+
+from .platform import _kill_mount_owner_processes
 
 try:
     from fuse import FUSE, FuseOSError, LoggingMixIn, Operations  # type: ignore
@@ -1590,8 +1588,9 @@ class AmigaFuseFS(Operations):
 
     def _root_stat(self):
         now = int(time.time())
+        perm = 0o777 if self.bridge._write_enabled else 0o755
         return {
-            "st_mode": (0o755 | 0o040000),  # drwxr-xr-x
+            "st_mode": (perm | 0o040000),
             "st_nlink": 2,
             "st_size": 0,
             "st_ctime": now,
@@ -2531,11 +2530,6 @@ def mount_fuse(
 
     if foreground is None:
         foreground = plat.mount_runs_in_foreground_by_default()
-    if not foreground and not plat.get_unmount_command(mountpoint):
-        raise SystemExit(
-            "Daemon mode is not supported on this platform yet because there is "
-            "no standalone unmount command. Use --interactive instead."
-        )
 
     # Print startup banner
     print(__banner__)
@@ -2598,6 +2592,12 @@ def mount_fuse(
         "fsname": f"amifuse:{volname}",
         "default_permissions": True,  # Let kernel handle permission checks
     }
+    # WinFSP maps FUSE uid=0/gid=0 to Windows SID S-1-5-0 (Nobody), blocking
+    # write access for the current user.  uid/gid=-1 tells WinFSP to use the
+    # mounting user's SID instead.
+    if sys.platform.startswith("win"):
+        fuse_kwargs["uid"] = -1
+        fuse_kwargs["gid"] = -1
     # subtype is a Linux-only FUSE option; WinFSP and macFUSE don't support it
     if sys.platform.startswith("linux"):
         fuse_kwargs["subtype"] = "amifuse"
@@ -3832,12 +3832,13 @@ def cmd_unmount(args):
         raise SystemExit(f"Mountpoint {mountpoint} is not currently mounted.")
 
     cmd = plat.get_unmount_command(mountpoint)
+    _no_window = {"creationflags": 0x08000000} if sys.platform.startswith("win") else {}
     if cmd:
-        result = subprocess.run(cmd, check=False)
+        result = subprocess.run(cmd, check=False, **_no_window)
         if result.returncode != 0:
             killed_pids = _kill_mount_owner_processes(mountpoint)
             if killed_pids:
-                result = subprocess.run(cmd, check=False)
+                result = subprocess.run(cmd, check=False, **_no_window)
         if result.returncode != 0:
             raise SystemExit(
                 f"Unmount failed with exit code {result.returncode}: "
@@ -3921,84 +3922,16 @@ def cmd_doctor(args):
     _cmd_doctor(args)
 
 
-def _kill_mount_owner_processes(mountpoint: Path) -> List[int]:
-    pids = _find_mount_owner_pids(mountpoint)
-    if not pids:
-        return []
-
-    remaining = []
-    for pid in pids:
-        try:
-            os.kill(pid, signal.SIGTERM)
-            remaining.append(pid)
-        except (ProcessLookupError, OSError):
-            continue
-
-    deadline = time.time() + 1.0
-    while remaining and time.time() < deadline:
-        still_alive = []
-        for pid in remaining:
-            if _pid_exists(pid):
-                still_alive.append(pid)
-        if not still_alive:
-            return pids
-        remaining = still_alive
-        time.sleep(0.05)
-
-    for pid in remaining:
-        try:
-            os.kill(pid, _SIGKILL)
-        except (ProcessLookupError, OSError):
-            continue
-
-    return pids
+def cmd_register(args):
+    """Handle the 'register' subcommand."""
+    from .windows_shell import register
+    register()
 
 
-def _find_mount_owner_pids(mountpoint: Path) -> List[int]:
-    """Find PIDs of amifuse processes that own the given mountpoint.
-
-    Uses platform.find_amifuse_mounts() for process discovery, then
-    filters to those matching the given mountpoint.
-    """
-    from . import platform as plat
-
-    raw_mountpoint = str(mountpoint)
-    abs_mountpoint = str(mountpoint.resolve(strict=False))
-
-    try:
-        all_mounts = plat.find_amifuse_mounts()
-    except OSError:
-        return []
-
-    pids = []
-    for mount in all_mounts:
-        mp = mount.get("mountpoint")
-        if mp is None:
-            continue
-        if mp == raw_mountpoint or mp == abs_mountpoint:
-            pids.append(mount["pid"])
-            continue
-        try:
-            resolved = str(Path(mp).expanduser().resolve(strict=False))
-        except OSError:
-            continue
-        if resolved == abs_mountpoint:
-            pids.append(mount["pid"])
-
-    return pids
-
-
-def _pid_exists(pid: int) -> bool:
-    try:
-        os.kill(pid, 0)
-    except ProcessLookupError:
-        return False
-    except PermissionError:
-        return True
-    except OSError:
-        # Windows raises a generic OSError for invalid/dead PIDs
-        return False
-    return True
+def cmd_unregister(args):
+    """Handle the 'unregister' subcommand."""
+    from .windows_shell import unregister
+    unregister()
 
 
 def _validate_driver_path(driver: Optional[Path]) -> None:
@@ -4046,6 +3979,9 @@ commands:
   doctor                    Check prerequisites and environment readiness.
     --json                    Output results as JSON.
     --fix                     Auto-fix what can be fixed.
+
+  register                  Add Windows Explorer context menu entries.
+  unregister                Remove Windows Explorer context menu entries.
 
   format <image> <partition> [volname]
                               Format an Amiga partition.
@@ -4205,6 +4141,17 @@ commands:
         help="Auto-fix what can be fixed.",
     )
     doctor_parser.set_defaults(func=cmd_doctor)
+
+    # register / unregister subcommands (Windows shell integration)
+    register_parser = subparsers.add_parser(
+        "register", help="Register AmiFUSE file associations (Windows)."
+    )
+    register_parser.set_defaults(func=cmd_register)
+
+    unregister_parser = subparsers.add_parser(
+        "unregister", help="Remove AmiFUSE file associations (Windows)."
+    )
+    unregister_parser.set_defaults(func=cmd_unregister)
 
     # format subcommand
     format_parser = subparsers.add_parser(

--- a/amifuse/fuse_fs.py
+++ b/amifuse/fuse_fs.py
@@ -1362,6 +1362,42 @@ class HandlerBridge:
                 return 0, -1
             return replies[-1][2], replies[-1][3]
 
+    def delete_dir_atomic(self, path: str) -> Tuple[int, int]:
+        """Atomically locate parent and delete directory, preventing concurrent
+        locates on the target from creating locks that block deletion."""
+        with self._lock:
+            dir_path, name = path.rsplit("/", 1) if "/" in path.lstrip("/") else ("/", path.strip("/"))
+            if not dir_path:
+                dir_path = "/"
+            parts = [p for p in dir_path.split("/") if p]
+            lock = 0
+            locks: List[int] = []
+            for comp in parts:
+                _, name_bptr = self._alloc_bstr(comp)
+                self.launcher.send_locate(self.state, lock, name_bptr)
+                replies = self._run_until_replies()
+                lock = replies[-1][2] if replies else 0
+                if lock == 0:
+                    break
+                locks.append(lock)
+            if dir_path == "/" and lock == 0:
+                lock, _ = self.locate(0, "")
+                if lock:
+                    locks.append(lock)
+            if lock == 0 and dir_path != "/":
+                for l in reversed(locks):
+                    self.free_lock(l)
+                return 0, -1
+            _, name_bptr = self._alloc_bstr(name)
+            self.launcher.send_delete_object(self.state, lock, name_bptr)
+            replies = self._run_until_replies()
+            self._log_replies("delete_dir_atomic", replies)
+            for l in reversed(locks):
+                self.free_lock(l)
+            if not replies:
+                return 0, -1
+            return replies[-1][2], replies[-1][3]
+
     def rename_object(
         self, src_lock_bptr: int, src_name: str, dst_lock_bptr: int, dst_name: str
     ) -> Tuple[int, int]:
@@ -1406,6 +1442,16 @@ class HandlerBridge:
             self.launcher.send_flush(self.state)
             replies = self._run_until_replies()
             self._log_replies("flush_volume", replies)
+
+    def inhibit_cycle(self):
+        """Inhibit then uninhibit the handler to clear all internal state."""
+        with self._lock:
+            if self.state.crashed:
+                return
+            self.launcher.send_inhibit(self.state, True)
+            self._run_until_replies()
+            self.launcher.send_inhibit(self.state, False)
+            replies = self._run_until_replies()
             # Sync the underlying file to disk
             self.backend.sync()
             if self._debug:
@@ -1474,6 +1520,7 @@ class AmigaFuseFS(Operations):
         self._fh_cache: Dict[int, Dict[str, object]] = {}
         self._next_fh = 1
         self._pending_deletes: set = set()
+        self._pending_dir_deletes: Dict[str, set] = {}  # dir_path -> set of pending child paths blocking removal
         self._last_op_time = time.time()
         self._op_count = 0
         # Icon support - use platform-specific handler
@@ -1678,11 +1725,35 @@ class AmigaFuseFS(Operations):
         if self._is_neg_cached(path):
             self._track_op("getattr", path, cached=True)
             raise FuseOSError(errno.ENOENT)
+        # Check if path has a pending (deferred) delete - hide from callers
+        if path in self._pending_deletes:
+            self._track_op("getattr", path, cached=True)
+            raise FuseOSError(errno.ENOENT)
         # Check positive cache
         cached = self._get_cached_stat(path)
         if cached is not None:
             self._track_op("getattr", path, cached=True)
             return cached
+        # Active-handle fallback: if we have an open handle for this path,
+        # return synthetic attrs immediately. This prevents ENOENT races when
+        # WinFSP calls fgetattr right after create() -- the Amiga handler may
+        # not have committed the file yet, so bridge.stat_path() would fail.
+        if self.bridge._write_enabled:
+            with self._fh_lock:
+                for entry in self._fh_cache.values():
+                    if entry.get("path") == path and not entry.get("closed") and not entry.get("dir_handle"):
+                        now = int(time.time())
+                        self._track_op("getattr", path, cached=True)
+                        return {
+                            "st_mode": 0o100644,
+                            "st_nlink": 1,
+                            "st_size": 0,
+                            "st_ctime": now,
+                            "st_mtime": now,
+                            "st_atime": now,
+                            "st_uid": self._uid,
+                            "st_gid": self._gid,
+                        }
         self._track_op("getattr", path, cached=False)
         info = self.bridge.stat_path(path)
         if not info:
@@ -1717,6 +1788,49 @@ class AmigaFuseFS(Operations):
         self._set_cached_stat(path, result)
         return result
 
+    def opendir(self, path):
+        with self._fh_lock:
+            handle = self._next_fh
+            self._next_fh += 1
+            self._fh_cache[handle] = {
+                "dir_handle": True,
+                "path": path,
+                "closed": False,
+            }
+        return handle
+
+    def releasedir(self, path, fh):
+        with self._fh_lock:
+            entry = self._fh_cache.get(fh)
+            if not entry:
+                return 0
+            del self._fh_cache[fh]
+        resolved_path = path if path else entry.get("path")
+        if not resolved_path:
+            return 0
+        if resolved_path in self._pending_deletes:
+            with self._fh_lock:
+                still_open = any(
+                    v.get("dir_handle") and v.get("path") == resolved_path
+                    for v in self._fh_cache.values()
+                )
+            if not still_open:
+                self._pending_deletes.discard(resolved_path)
+                try:
+                    self.bridge.flush_volume()
+                    self.bridge.inhibit_cycle()
+                    res1, res2 = self.bridge.delete_dir_atomic(resolved_path)
+                    if res1 == 0:
+                        self._pending_deletes.add(resolved_path)
+                    else:
+                        self._stat_cache.pop(resolved_path, None)
+                        parent_path = resolved_path.rsplit("/", 1)[0] or "/"
+                        self._dir_cache.pop(parent_path, None)
+                except Exception:
+                    pass
+                self._resolve_pending_dir_deletes(resolved_path)
+        return 0
+
     def readdir(self, path, fh):
         self._check_handler_alive()
         # Check directory cache first
@@ -1724,6 +1838,15 @@ class AmigaFuseFS(Operations):
             ts, cached_entries = self._dir_cache[path]
             if time.time() - ts < self._dir_cache_ttl:
                 self._track_op("readdir", path, cached=True)
+                # Filter pending deletes from cached results
+                if self._pending_deletes:
+                    cached_entries = [
+                        e for e in cached_entries
+                        if e in (".", "..") or (
+                            (path.rstrip("/") + "/" + e if path != "/" else "/" + e)
+                            not in self._pending_deletes
+                        )
+                    ]
                 return cached_entries
             del self._dir_cache[path]
 
@@ -1774,6 +1897,16 @@ class AmigaFuseFS(Operations):
             _, volume_icon_file = platform.get_icon_file_names()
             if volume_icon_file:
                 entries.append(volume_icon_file)
+
+        # Filter out entries with pending (deferred) deletes
+        if self._pending_deletes:
+            entries = [
+                e for e in entries
+                if e in (".", "..") or (
+                    (path.rstrip("/") + "/" + e if path != "/" else "/" + e)
+                    not in self._pending_deletes
+                )
+            ]
 
         # Cache the directory listing
         self._dir_cache[path] = (now, entries)
@@ -2033,7 +2166,53 @@ class AmigaFuseFS(Operations):
         return 0
 
     def rmdir(self, path):
-        return self.unlink(path)
+        """Remove a directory, deferring if children have pending deletes."""
+        self._log_op("rmdir", path, "")
+        self._check_handler_alive()
+        if not self.bridge._write_enabled:
+            raise FuseOSError(errno.EROFS)
+        dir_path, name = self._split_path(path)
+        if not name:
+            raise FuseOSError(errno.EINVAL)
+        self.bridge.inhibit_cycle()
+        res1, res2 = self.bridge.delete_dir_atomic(path)
+        self._log_op("rmdir", path, f"delete_dir_atomic res1={res1} res2={res2}")
+        if res1 == 0:
+            if res2 == 202:
+                # OBJECT_IN_USE — defer unconditionally; releasedir will retry
+                self._pending_deletes.add(path)
+                self._stat_cache.pop(path, None)
+                self._dir_cache.pop(dir_path, None)
+                self._dir_cache.pop(path, None)
+                return 0
+            if res2 == 216:
+                # DIRECTORY_NOT_EMPTY — defer only if pending children exist
+                with self._fh_lock:
+                    pending_children = {
+                        p for p in self._pending_deletes
+                        if p.startswith(path + "/")
+                    }
+                    for d in self._pending_dir_deletes:
+                        if d.startswith(path + "/"):
+                            pending_children.add(d)
+                if pending_children:
+                    with self._fh_lock:
+                        self._pending_dir_deletes[path] = pending_children.copy()
+                        self._pending_deletes.add(path)
+                    self._stat_cache.pop(path, None)
+                    self._dir_cache.pop(dir_path, None)
+                    self._dir_cache.pop(path, None)
+                    self._log_op("rmdir", path, "deferred (pending child deletes)")
+                    return 0
+                # No pending children — genuinely not empty
+                raise FuseOSError(errno.ENOTEMPTY)
+            # Unrecognized error
+            raise FuseOSError(errno.EIO)
+        # Immediate success
+        self._stat_cache.pop(path, None)
+        self._dir_cache.pop(dir_path, None)
+        self._dir_cache.pop(path, None)
+        return 0
 
     def mkdir(self, path, mode):
         self._check_handler_alive()
@@ -2310,6 +2489,53 @@ class AmigaFuseFS(Operations):
             raise FuseOSError(errno.EROFS)
         return 0
 
+    def _resolve_pending_dir_deletes(self, deleted_child_path: str):
+        """After a child is deleted, check if its parent directory can now be removed.
+
+        Walks up the directory tree resolving deferred rmdir operations when all
+        blocking children have been deleted.
+        """
+        parent_dir = deleted_child_path.rsplit("/", 1)[0] or "/"
+        while parent_dir in self._pending_dir_deletes:
+            with self._fh_lock:
+                if parent_dir not in self._pending_dir_deletes:
+                    break
+                self._pending_dir_deletes[parent_dir].discard(deleted_child_path)
+                if self._pending_dir_deletes[parent_dir]:
+                    # Still has other pending children - stop here
+                    break
+                # All children resolved - attempt the directory delete
+                del self._pending_dir_deletes[parent_dir]
+                self._pending_deletes.discard(parent_dir)
+            # Attempt the actual directory deletion outside the lock
+            try:
+                dir_path, name = self._split_path(parent_dir)
+                lock_bptr, _, locks = self.bridge.locate_path(dir_path)
+                if dir_path == "/" and lock_bptr == 0:
+                    lock_bptr, _ = self.bridge.locate(0, "")
+                    if lock_bptr:
+                        locks.append(lock_bptr)
+                if lock_bptr != 0:
+                    self.bridge.inhibit_cycle()
+                    res1, res2 = self.bridge.delete_object(lock_bptr, name)
+                    self._log_op("release", parent_dir, f"deferred rmdir res1={res1} res2={res2}")
+                    if res1 == 0:
+                        # Directory still not empty (new files created?) - silently discard
+                        self._log_op("release", parent_dir, "deferred rmdir failed (dir not empty), discarding")
+                        for l in reversed(locks):
+                            self.bridge.free_lock(l)
+                        break
+                for l in reversed(locks):
+                    self.bridge.free_lock(l)
+                self._stat_cache.pop(parent_dir, None)
+                self._dir_cache.pop(dir_path, None)
+            except Exception:
+                self._log_op("release", parent_dir, "deferred rmdir exception, discarding")
+                break
+            # Successfully deleted this directory - walk up to check its parent
+            deleted_child_path = parent_dir
+            parent_dir = parent_dir.rsplit("/", 1)[0] or "/"
+
     def release(self, path, fh):
         self._log_op("release", path, f"fh={fh}")
         with self._fh_lock:
@@ -2354,7 +2580,9 @@ class AmigaFuseFS(Operations):
                 self._stat_cache.pop(resolved_path, None)
                 self._dir_cache.pop(dir_path, None)
             except Exception:
-                pass  # Best-effort deferred delete
+                pass
+            # Resolve any deferred parent directory deletes
+            self._resolve_pending_dir_deletes(resolved_path)
         return 0
 
     def destroy(self, path):

--- a/amifuse/fuse_fs.py
+++ b/amifuse/fuse_fs.py
@@ -1473,6 +1473,7 @@ class AmigaFuseFS(Operations):
         self._fh_lock = threading.Lock()
         self._fh_cache: Dict[int, Dict[str, object]] = {}
         self._next_fh = 1
+        self._pending_deletes: set = set()
         self._last_op_time = time.time()
         self._op_count = 0
         # Icon support - use platform-specific handler
@@ -1833,6 +1834,7 @@ class AmigaFuseFS(Operations):
                 "lock": threading.Lock(),
                 "closed": False,
                 "dirty": False,  # Track if file was written to
+                "path": path,
             }
         return handle
 
@@ -1957,6 +1959,7 @@ class AmigaFuseFS(Operations):
                     "lock": threading.Lock(),
                     "closed": False,
                     "dirty": True,  # New files are always dirty
+                    "path": path,
                 }
             # Prime stat/dir cache so immediate getattr after create doesn't fail.
             # Pin the entry: in write mode _cache_ttl is 0, so without pinning
@@ -2007,6 +2010,20 @@ class AmigaFuseFS(Operations):
         res1, res2 = self.bridge.delete_object(lock_bptr, name)
         self._log_op("unlink", path, f"delete_object res1={res1} res2={res2}")
         if res1 == 0:
+            if res2 == 202:
+                # ERROR_OBJECT_IN_USE: file has an active handle (WinFSP calls
+                # unlink before release). Defer deletion to release().
+                has_handle = any(v.get("path") == path for v in self._fh_cache.values())
+                if has_handle:
+                    self._pending_deletes.add(path)
+                    self._stat_cache.pop(path, None)
+                    self._dir_cache.pop(dir_path, None)
+                    for l in reversed(locks):
+                        self.bridge.free_lock(l)
+                    return 0
+            # Free locks before raising (fixes a lock leak on error)
+            for l in reversed(locks):
+                self.bridge.free_lock(l)
             raise FuseOSError(errno.EIO)
         self._stat_cache.pop(path, None)
         self._pinned_stats.discard(path)
@@ -2317,6 +2334,27 @@ class AmigaFuseFS(Operations):
         self._pinned_stats.discard(path)
         if self._cache_ttl <= 0:
             self._stat_cache.pop(path, None)
+        # Resolve path: use FUSE-provided path, fall back to cached path
+        resolved_path = path if path else entry.get("path")
+        # Check for deferred deletes (WinFSP unlink-before-release pattern)
+        if resolved_path and resolved_path in self._pending_deletes:
+            self._pending_deletes.discard(resolved_path)
+            try:
+                dir_path, name = self._split_path(resolved_path)
+                lock_bptr, _, locks = self.bridge.locate_path(dir_path)
+                if dir_path == "/" and lock_bptr == 0:
+                    lock_bptr, _ = self.bridge.locate(0, "")
+                    if lock_bptr:
+                        locks.append(lock_bptr)
+                if lock_bptr != 0:
+                    res1, res2 = self.bridge.delete_object(lock_bptr, name)
+                    self._log_op("release", resolved_path, f"deferred delete res1={res1} res2={res2}")
+                for l in reversed(locks):
+                    self.bridge.free_lock(l)
+                self._stat_cache.pop(resolved_path, None)
+                self._dir_cache.pop(dir_path, None)
+            except Exception:
+                pass  # Best-effort deferred delete
         return 0
 
     def destroy(self, path):

--- a/amifuse/launcher.py
+++ b/amifuse/launcher.py
@@ -1,0 +1,136 @@
+"""Console-free launcher for AmiFUSE context menu actions.
+
+This launcher is invoked by Explorer shell verbs. It MUST exit as fast as
+possible -- any delay blocks the Explorer UI thread. All file I/O uses
+open/write/close immediately; process exit uses os._exit() to skip Python
+shutdown overhead.
+"""
+
+import argparse
+import ctypes
+import os
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+
+DETACHED_PROCESS = 0x00000008
+CREATE_NEW_PROCESS_GROUP = 0x00000200
+CREATE_NO_WINDOW = 0x08000000
+CREATE_NEW_CONSOLE = 0x00000010
+CREATE_BREAKAWAY_FROM_JOB = 0x01000000
+
+_DETACHED_FLAGS = DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW
+
+_LOG_DIR = Path(os.environ.get("APPDATA", "")) / "AmiFUSE"
+
+
+def _log(msg: str) -> None:
+    """Append a single log line, opening and closing the file immediately."""
+    try:
+        _LOG_DIR.mkdir(parents=True, exist_ok=True)
+        ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S,%f")[:-3]
+        with open(str(_LOG_DIR / "launcher.log"), "a") as f:
+            f.write(f"{ts} INFO {msg}\n")
+    except OSError:
+        pass
+
+
+def _spawn_detached(cmd: list[str], **kwargs) -> None:
+    """Spawn a fully detached process. Tries CREATE_BREAKAWAY_FROM_JOB first
+    to escape Explorer's job object; falls back without it if the job
+    doesn't allow breakaway."""
+    flags = _DETACHED_FLAGS | CREATE_BREAKAWAY_FROM_JOB
+    try:
+        subprocess.Popen(cmd, creationflags=flags, **kwargs)
+    except OSError:
+        # Job doesn't allow breakaway -- retry without it
+        subprocess.Popen(cmd, creationflags=_DETACHED_FLAGS, **kwargs)
+
+
+def main(argv=None) -> None:
+    parser = argparse.ArgumentParser(description="AmiFUSE launcher")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    mount_p = sub.add_parser("mount", help="Mount a disk image")
+    mount_p.add_argument("image")
+    mount_p.add_argument("--write", action="store_true")
+
+    inspect_p = sub.add_parser("inspect", help="Open inspect in a new console")
+    inspect_p.add_argument("image")
+
+    args = parser.parse_args(argv)
+
+    if args.command == "mount":
+        _do_mount(args)
+    elif args.command == "inspect":
+        _do_inspect(args)
+
+    # Force-exit immediately. Python's normal shutdown (atexit handlers,
+    # logging.shutdown, GC, module cleanup) is unnecessary for a launcher
+    # and can delay process exit enough to hang Explorer.
+    os._exit(0)
+
+
+def _do_mount(args) -> None:
+    python_dir = Path(sys.executable).parent
+    python_exe = str(python_dir / "pythonw.exe")
+    if not os.path.isfile(python_exe):
+        python_exe = sys.executable
+
+    cmd = [python_exe, "-m", "amifuse", "mount"]
+    if args.write:
+        cmd.append("--write")
+    cmd.append("--daemon")
+    cmd.append(args.image)
+
+    _log(f"Launching mount: {cmd}")
+    try:
+        _spawn_detached(
+            cmd,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            close_fds=True,
+        )
+    except Exception as exc:
+        _log(f"Failed to launch mount subprocess: {exc}")
+        return
+
+    _ensure_tray_running()
+
+
+def _do_inspect(args) -> None:
+    cmd = ["cmd", "/k", sys.executable, "-m", "amifuse", "inspect", args.image]
+    subprocess.Popen(cmd, creationflags=CREATE_NEW_CONSOLE)
+
+
+def _ensure_tray_running() -> None:
+    handle = ctypes.windll.kernel32.OpenMutexW(
+        0x00100000, False, "AmiFUSE_Tray_Mutex"
+    )
+    if handle != 0:
+        ctypes.windll.kernel32.CloseHandle(handle)
+        return
+
+    tray_exe = str(Path(sys.executable).parent / "amifuse-tray.exe")
+    if os.path.isfile(tray_exe):
+        cmd = [tray_exe]
+    else:
+        cmd = [sys.executable, "-m", "amifuse.tray"]
+
+    _log(f"Starting tray: {cmd}")
+    try:
+        _spawn_detached(
+            cmd,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            close_fds=True,
+        )
+    except Exception as exc:
+        _log(f"Failed to start tray: {exc}")
+
+
+if __name__ == "__main__":
+    main()

--- a/amifuse/launcher.py
+++ b/amifuse/launcher.py
@@ -101,13 +101,21 @@ def _do_mount(args) -> None:
 
 
 def _do_inspect(args) -> None:
-    cmd = ["cmd", "/k", sys.executable, "-m", "amifuse", "inspect", args.image]
-    subprocess.Popen(cmd, creationflags=CREATE_NEW_CONSOLE)
+    # Launch python directly with CREATE_NEW_CONSOLE to avoid cmd.exe
+    # metacharacter injection. The -c script uses sys.argv for the path
+    # (never interpolated into code) and waits for a keypress so the user
+    # can read output before the console closes.
+    wrapper = [
+        sys.executable, "-c",
+        "import sys; from amifuse.fuse_fs import main; main(['inspect'] + sys.argv[1:]); input('\\nPress Enter to close...')",
+        args.image,
+    ]
+    subprocess.Popen(wrapper, creationflags=CREATE_NEW_CONSOLE)
 
 
 def _ensure_tray_running() -> None:
     handle = ctypes.windll.kernel32.OpenMutexW(
-        0x00100000, False, "AmiFUSE_Tray_Mutex"
+        0x00100000, False, "Local\\AmiFUSE_Tray_Mutex"
     )
     if handle != 0:
         ctypes.windll.kernel32.CloseHandle(handle)

--- a/amifuse/platform.py
+++ b/amifuse/platform.py
@@ -2,7 +2,8 @@
 Platform abstraction layer for amifuse.
 
 This module provides platform-specific functionality with a unified interface,
-including mount options, default mountpoints, unmount commands, and icon handling.
+including mount options, default mountpoints, unmount commands, icon handling,
+and driver resolution.
 
 Platform-specific implementations:
 - macOS/Darwin: icon_darwin.py
@@ -13,6 +14,7 @@ Platform-specific implementations:
 import errno
 import logging
 import os
+import signal
 import shlex
 import shutil
 import subprocess
@@ -23,6 +25,15 @@ from typing import List, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from .icon_darwin import DarwinIconHandler
+
+# Prevent subprocess calls from flashing a console window when invoked from
+# pythonw.exe (e.g. tray/launcher).
+_CREATE_NO_WINDOW = 0x08000000
+
+# signal.SIGKILL is not defined on Windows; fall back to SIGTERM so that
+# _kill_mount_owner_processes() can still compile and will use the strongest
+# signal available.
+_SIGKILL = getattr(signal, "SIGKILL", signal.SIGTERM)
 
 
 def get_default_mountpoint(volname: str) -> Optional[Path]:
@@ -420,6 +431,7 @@ def find_amifuse_mounts():
     else:
         mounts = _find_amifuse_mounts_unix()
 
+    mounts = _deduplicate_fusepy_children(mounts)
     _enrich_null_mountpoints(mounts)
     return mounts
 
@@ -474,9 +486,9 @@ def _find_amifuse_mounts_unix():
 
     # macOS: lstart gives absolute start time; Linux: etimes gives elapsed seconds
     if is_mac:
-        ps_cmd = ["ps", "-axo", "pid=,lstart=,command="]
+        ps_cmd = ["ps", "-axo", "pid=,ppid=,lstart=,command="]
     else:
-        ps_cmd = ["ps", "-axo", "pid=,etimes=,command="]
+        ps_cmd = ["ps", "-axo", "pid=,ppid=,etimes=,command="]
 
     try:
         result = subprocess.run(
@@ -501,25 +513,27 @@ def _find_amifuse_mounts_unix():
 
         try:
             if is_mac:
-                # Format: "  PID  DAY MON DD HH:MM:SS YYYY COMMAND..."
+                # Format: "  PID  PPID  DAY MON DD HH:MM:SS YYYY COMMAND..."
                 # lstart is 5 tokens: e.g. "Sat Apr 19 10:30:00 2026"
-                parts = line.split(None, 6)
-                if len(parts) < 7:
+                parts = line.split(None, 8)
+                if len(parts) < 9:
                     continue
                 pid = int(parts[0])
-                lstart_str = " ".join(parts[1:6])
-                command = parts[6]
+                ppid = int(parts[1])
+                lstart_str = " ".join(parts[2:7])
+                command = parts[8]
                 # Parse lstart to compute uptime
                 uptime = _parse_lstart_uptime(lstart_str)
             else:
-                # Format: "  PID ETIMES COMMAND..."
-                parts = line.split(None, 2)
-                if len(parts) < 3:
+                # Format: "  PID  PPID ETIMES COMMAND..."
+                parts = line.split(None, 3)
+                if len(parts) < 4:
                     continue
                 pid = int(parts[0])
-                command = parts[2]
+                ppid = int(parts[1])
+                command = parts[3]
                 try:
-                    uptime = int(parts[1])
+                    uptime = int(parts[2])
                 except ValueError:
                     uptime = None
         except ValueError:
@@ -547,6 +561,7 @@ def _find_amifuse_mounts_unix():
             "pid": pid,
             "uptime_seconds": uptime,
             "filesystem_type": None,
+            "parent_pid": ppid,
         })
 
     return mounts
@@ -566,6 +581,276 @@ def _parse_lstart_uptime(lstart_str):
         return None
 
 
+# ---------------------------------------------------------------------------
+# CIM/PowerShell fallback for mount discovery (wmic deprecated on Win11)
+# ---------------------------------------------------------------------------
+
+
+def _find_amifuse_mounts_cim():
+    """Discover amifuse mounts on Windows using PowerShell Get-CimInstance.
+
+    Fallback for when wmic is unavailable (removed on newer Windows 11 builds).
+    """
+    ps_cmd = [
+        "powershell", "-NoProfile", "-Command",
+        'Get-CimInstance Win32_Process -Filter "Name like \'%python%\'" '
+        "| Select-Object ProcessId,CommandLine,CreationDate,ParentProcessId "
+        "| ConvertTo-Json",
+    ]
+    try:
+        result = subprocess.run(
+            ps_cmd,
+            check=False,
+            capture_output=True,
+            creationflags=_CREATE_NO_WINDOW if sys.platform.startswith("win") else 0,
+        )
+    except OSError:
+        logger.debug("PowerShell not available for CIM fallback")
+        return []
+    if result.returncode != 0:
+        logger.debug("PowerShell CIM query exited with code %d", result.returncode)
+        return []
+
+    # PowerShell may emit a BOM; handle utf-8-sig
+    try:
+        text = result.stdout.decode("utf-8-sig")
+    except (UnicodeDecodeError, AttributeError):
+        text = result.stdout if isinstance(result.stdout, str) else result.stdout.decode("utf-8", errors="replace")
+
+    import json
+    try:
+        data = json.loads(text)
+    except (json.JSONDecodeError, ValueError):
+        logger.debug("Failed to parse CIM JSON output")
+        return []
+
+    # Single result comes as a dict, multiple as a list
+    if isinstance(data, dict):
+        data = [data]
+
+    current_pid = os.getpid()
+    mounts = []
+
+    for entry in data:
+        cmdline = entry.get("CommandLine") or ""
+        if "amifuse" not in cmdline:
+            continue
+
+        try:
+            pid = int(entry.get("ProcessId", 0))
+        except (ValueError, TypeError):
+            continue
+        if pid == current_pid or pid == 0:
+            continue
+
+        try:
+            tokens = shlex.split(cmdline, posix=False)
+        except ValueError:
+            tokens = cmdline.split()
+
+        if "mount" not in tokens:
+            continue
+
+        image, mountpoint = _parse_mount_tokens(tokens)
+
+        # Parse CreationDate -- CIM returns ISO 8601 or .NET datetime string
+        uptime = None
+        creation = entry.get("CreationDate")
+        if creation and isinstance(creation, str):
+            # CIM JSON may include /Date(milliseconds)/ format
+            import re
+            m = re.search(r"/Date\((\d+)\)/", creation)
+            if m:
+                start_epoch = int(m.group(1)) / 1000.0
+                uptime = max(0, int(time.time() - start_epoch))
+
+        parent_pid = None
+        try:
+            parent_pid = int(entry.get("ParentProcessId", 0)) or None
+        except (ValueError, TypeError):
+            pass
+
+        mounts.append({
+            "mountpoint": mountpoint,
+            "image": image,
+            "pid": pid,
+            "uptime_seconds": uptime,
+            "filesystem_type": None,
+            "parent_pid": parent_pid,
+        })
+
+    return mounts
+
+
+# ---------------------------------------------------------------------------
+# fusepy child deduplication
+# ---------------------------------------------------------------------------
+
+
+def _deduplicate_fusepy_children(mounts: list) -> list:
+    """Filter out fusepy child processes from mount list.
+
+    fusepy spawns a child process for FUSE operations. Both parent and child
+    appear in process scanning, causing duplicate tray entries (e.g., "D:" and
+    "?"). Filter out mounts whose parent_pid matches another mount's pid.
+    """
+    pids = {m["pid"] for m in mounts}
+    return [m for m in mounts if m.get("parent_pid") not in pids]
+
+
+# ---------------------------------------------------------------------------
+# Process killing
+# ---------------------------------------------------------------------------
+
+
+def _pid_exists(pid: int) -> bool:
+    """Check if a process with the given PID exists."""
+    if sys.platform.startswith("win"):
+        # os.kill(pid, 0) is unreliable on Windows -- it raises OSError with
+        # errno EINVAL (WinError 87) for processes we didn't spawn, making
+        # live processes look dead.  Use OpenProcess instead.
+        try:
+            import ctypes
+            PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+            handle = ctypes.windll.kernel32.OpenProcess(
+                PROCESS_QUERY_LIMITED_INFORMATION, False, pid,
+            )
+            if handle:
+                ctypes.windll.kernel32.CloseHandle(handle)
+                return True
+            return False
+        except Exception:
+            return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    return True
+
+
+def _find_mount_owner_pids(mountpoint: Path) -> List[int]:
+    """Find PIDs of amifuse processes that own the given mountpoint.
+
+    Uses find_amifuse_mounts() for process discovery, then filters to those
+    matching the given mountpoint.
+    """
+    raw_mountpoint = str(mountpoint)
+    abs_mountpoint = str(mountpoint.resolve(strict=False))
+
+    try:
+        all_mounts = find_amifuse_mounts()
+    except OSError:
+        return []
+
+    pids = []
+    for mount in all_mounts:
+        mp = mount.get("mountpoint")
+        if mp is None:
+            continue
+        if mp == raw_mountpoint or mp == abs_mountpoint:
+            pids.append(mount["pid"])
+            continue
+        try:
+            resolved = str(Path(mp).expanduser().resolve(strict=False))
+        except OSError:
+            continue
+        if resolved == abs_mountpoint:
+            pids.append(mount["pid"])
+
+    return pids
+
+
+def kill_pids(pids: List[int], timeout: float = 10.0) -> List[int]:
+    """Kill a list of PIDs with graceful-then-force strategy.
+
+    On Windows: sends CTRL_BREAK_EVENT (graceful), then taskkill /F (force).
+    On Unix: sends SIGTERM (graceful), then SIGKILL (force).
+
+    Args:
+        pids: Process IDs to kill.
+        timeout: Seconds to wait for each graceful shutdown before force-kill.
+
+    Returns:
+        List of PIDs that were successfully killed.
+    """
+    if not pids:
+        return []
+
+    killed = []
+    is_win = sys.platform.startswith("win")
+
+    # Phase 1: graceful signal
+    remaining = []
+    for pid in pids:
+        try:
+            if is_win:
+                os.kill(pid, signal.CTRL_BREAK_EVENT)
+            else:
+                os.kill(pid, signal.SIGTERM)
+            remaining.append(pid)
+        except ProcessLookupError:
+            # Already dead -- count as killed
+            killed.append(pid)
+        except OSError:
+            if is_win:
+                # CTRL_BREAK_EVENT fails with OSError (WinError 87) for
+                # detached processes we didn't spawn.  The process is still
+                # alive -- add to remaining so Phase 3 (taskkill /F) runs.
+                remaining.append(pid)
+            else:
+                # On Unix, OSError from os.kill usually means the process
+                # is gone or inaccessible.
+                killed.append(pid)
+
+    # Phase 2: wait for graceful shutdown
+    deadline = time.time() + timeout
+    while remaining and time.time() < deadline:
+        still_alive = []
+        for pid in remaining:
+            if _pid_exists(pid):
+                still_alive.append(pid)
+            else:
+                killed.append(pid)
+        if not still_alive:
+            return killed
+        remaining = still_alive
+        time.sleep(0.1)
+
+    # Phase 3: force kill
+    for pid in remaining:
+        try:
+            if is_win:
+                # os.kill(pid, SIGKILL) maps to SIGTERM on Windows -- useless retry.
+                # Use taskkill /F for reliable force-kill.
+                subprocess.run(
+                    ["taskkill", "/F", "/PID", str(pid)],
+                    check=False,
+                    capture_output=True,
+                    creationflags=_CREATE_NO_WINDOW,
+                )
+            else:
+                os.kill(pid, signal.SIGKILL)
+            killed.append(pid)
+        except (ProcessLookupError, OSError):
+            killed.append(pid)
+
+    return killed
+
+
+def _kill_mount_owner_processes(mountpoint: Path) -> List[int]:
+    """Kill all amifuse processes that own the given mountpoint.
+
+    Returns list of PIDs that were targeted (whether or not each one died).
+    """
+    pids = _find_mount_owner_pids(mountpoint)
+    if not pids:
+        return []
+    kill_pids(pids, timeout=1.0)
+    return pids
 def _find_amifuse_mounts_windows():
     """Discover amifuse mounts on Windows using wmic.
 
@@ -576,16 +861,17 @@ def _find_amifuse_mounts_windows():
         result = subprocess.run(
             ["wmic", "process", "where",
              "name like '%python%'",
-             "get", "ProcessId,CommandLine,CreationDate",
+             "get", "ProcessId,CommandLine,CreationDate,ParentProcessId",
              "/FORMAT:LIST"],
             check=False,
             capture_output=True,
             text=True,
+            creationflags=_CREATE_NO_WINDOW,
         )
     except OSError:
         # wmic not available (e.g., removed on newer Windows 11 builds)
         logger.debug("wmic not available, cannot discover mounts")
-        return []
+        return _find_amifuse_mounts_cim()
     if result.returncode != 0:
         logger.debug("wmic exited with code %d", result.returncode)
         return []
@@ -597,6 +883,7 @@ def _find_amifuse_mounts_windows():
     current_cmdline = None
     current_pid_val = None
     current_creation = None
+    current_parent_pid = None
 
     def _process_record():
         if current_cmdline is None or current_pid_val is None:
@@ -624,6 +911,7 @@ def _find_amifuse_mounts_windows():
             "pid": current_pid_val,
             "uptime_seconds": uptime,
             "filesystem_type": None,
+            "parent_pid": current_parent_pid,
         })
 
     for line in result.stdout.splitlines():
@@ -637,6 +925,7 @@ def _find_amifuse_mounts_windows():
                 current_cmdline = None
                 current_pid_val = None
                 current_creation = None
+                current_parent_pid = None
             continue
         if line.startswith("CommandLine="):
             current_cmdline = line[len("CommandLine="):]
@@ -647,6 +936,11 @@ def _find_amifuse_mounts_windows():
                 current_pid_val = None
         elif line.startswith("CreationDate="):
             current_creation = line[len("CreationDate="):]
+        elif line.startswith("ParentProcessId="):
+            try:
+                current_parent_pid = int(line[len("ParentProcessId="):])
+            except ValueError:
+                current_parent_pid = None
 
     # Handle last record if no trailing blank line
     _process_record()

--- a/amifuse/platform.py
+++ b/amifuse/platform.py
@@ -14,6 +14,7 @@ Platform-specific implementations:
 import errno
 import logging
 import os
+import signal
 import shlex
 import shutil
 import subprocess
@@ -29,6 +30,10 @@ if TYPE_CHECKING:
 # pythonw.exe (e.g. tray/launcher).
 _CREATE_NO_WINDOW = 0x08000000
 
+# signal.SIGKILL is not defined on Windows; fall back to SIGTERM so that
+# _kill_mount_owner_processes() can still compile and will use the strongest
+# signal available.
+_SIGKILL = getattr(signal, "SIGKILL", signal.SIGTERM)
 
 # ---------------------------------------------------------------------------
 # Driver resolution
@@ -504,6 +509,7 @@ def find_amifuse_mounts():
     else:
         mounts = _find_amifuse_mounts_unix()
 
+    mounts = _deduplicate_fusepy_children(mounts)
     _enrich_null_mountpoints(mounts)
     return mounts
 
@@ -558,9 +564,9 @@ def _find_amifuse_mounts_unix():
 
     # macOS: lstart gives absolute start time; Linux: etimes gives elapsed seconds
     if is_mac:
-        ps_cmd = ["ps", "-axo", "pid=,lstart=,command="]
+        ps_cmd = ["ps", "-axo", "pid=,ppid=,lstart=,command="]
     else:
-        ps_cmd = ["ps", "-axo", "pid=,etimes=,command="]
+        ps_cmd = ["ps", "-axo", "pid=,ppid=,etimes=,command="]
 
     try:
         result = subprocess.run(
@@ -585,25 +591,27 @@ def _find_amifuse_mounts_unix():
 
         try:
             if is_mac:
-                # Format: "  PID  DAY MON DD HH:MM:SS YYYY COMMAND..."
+                # Format: "  PID  PPID  DAY MON DD HH:MM:SS YYYY COMMAND..."
                 # lstart is 5 tokens: e.g. "Sat Apr 19 10:30:00 2026"
-                parts = line.split(None, 6)
-                if len(parts) < 7:
+                parts = line.split(None, 8)
+                if len(parts) < 9:
                     continue
                 pid = int(parts[0])
-                lstart_str = " ".join(parts[1:6])
-                command = parts[6]
+                ppid = int(parts[1])
+                lstart_str = " ".join(parts[2:7])
+                command = parts[8]
                 # Parse lstart to compute uptime
                 uptime = _parse_lstart_uptime(lstart_str)
             else:
-                # Format: "  PID ETIMES COMMAND..."
-                parts = line.split(None, 2)
-                if len(parts) < 3:
+                # Format: "  PID  PPID ETIMES COMMAND..."
+                parts = line.split(None, 3)
+                if len(parts) < 4:
                     continue
                 pid = int(parts[0])
-                command = parts[2]
+                ppid = int(parts[1])
+                command = parts[3]
                 try:
-                    uptime = int(parts[1])
+                    uptime = int(parts[2])
                 except ValueError:
                     uptime = None
         except ValueError:
@@ -631,6 +639,7 @@ def _find_amifuse_mounts_unix():
             "pid": pid,
             "uptime_seconds": uptime,
             "filesystem_type": None,
+            "parent_pid": ppid,
         })
 
     return mounts
@@ -650,6 +659,276 @@ def _parse_lstart_uptime(lstart_str):
         return None
 
 
+# ---------------------------------------------------------------------------
+# CIM/PowerShell fallback for mount discovery (wmic deprecated on Win11)
+# ---------------------------------------------------------------------------
+
+
+def _find_amifuse_mounts_cim():
+    """Discover amifuse mounts on Windows using PowerShell Get-CimInstance.
+
+    Fallback for when wmic is unavailable (removed on newer Windows 11 builds).
+    """
+    ps_cmd = [
+        "powershell", "-NoProfile", "-Command",
+        'Get-CimInstance Win32_Process -Filter "Name like \'%python%\'" '
+        "| Select-Object ProcessId,CommandLine,CreationDate,ParentProcessId "
+        "| ConvertTo-Json",
+    ]
+    try:
+        result = subprocess.run(
+            ps_cmd,
+            check=False,
+            capture_output=True,
+            creationflags=_CREATE_NO_WINDOW if sys.platform.startswith("win") else 0,
+        )
+    except OSError:
+        logger.debug("PowerShell not available for CIM fallback")
+        return []
+    if result.returncode != 0:
+        logger.debug("PowerShell CIM query exited with code %d", result.returncode)
+        return []
+
+    # PowerShell may emit a BOM; handle utf-8-sig
+    try:
+        text = result.stdout.decode("utf-8-sig")
+    except (UnicodeDecodeError, AttributeError):
+        text = result.stdout if isinstance(result.stdout, str) else result.stdout.decode("utf-8", errors="replace")
+
+    import json
+    try:
+        data = json.loads(text)
+    except (json.JSONDecodeError, ValueError):
+        logger.debug("Failed to parse CIM JSON output")
+        return []
+
+    # Single result comes as a dict, multiple as a list
+    if isinstance(data, dict):
+        data = [data]
+
+    current_pid = os.getpid()
+    mounts = []
+
+    for entry in data:
+        cmdline = entry.get("CommandLine") or ""
+        if "amifuse" not in cmdline:
+            continue
+
+        try:
+            pid = int(entry.get("ProcessId", 0))
+        except (ValueError, TypeError):
+            continue
+        if pid == current_pid or pid == 0:
+            continue
+
+        try:
+            tokens = shlex.split(cmdline, posix=False)
+        except ValueError:
+            tokens = cmdline.split()
+
+        if "mount" not in tokens:
+            continue
+
+        image, mountpoint = _parse_mount_tokens(tokens)
+
+        # Parse CreationDate -- CIM returns ISO 8601 or .NET datetime string
+        uptime = None
+        creation = entry.get("CreationDate")
+        if creation and isinstance(creation, str):
+            # CIM JSON may include /Date(milliseconds)/ format
+            import re
+            m = re.search(r"/Date\((\d+)\)/", creation)
+            if m:
+                start_epoch = int(m.group(1)) / 1000.0
+                uptime = max(0, int(time.time() - start_epoch))
+
+        parent_pid = None
+        try:
+            parent_pid = int(entry.get("ParentProcessId", 0)) or None
+        except (ValueError, TypeError):
+            pass
+
+        mounts.append({
+            "mountpoint": mountpoint,
+            "image": image,
+            "pid": pid,
+            "uptime_seconds": uptime,
+            "filesystem_type": None,
+            "parent_pid": parent_pid,
+        })
+
+    return mounts
+
+
+# ---------------------------------------------------------------------------
+# fusepy child deduplication
+# ---------------------------------------------------------------------------
+
+
+def _deduplicate_fusepy_children(mounts: list) -> list:
+    """Filter out fusepy child processes from mount list.
+
+    fusepy spawns a child process for FUSE operations. Both parent and child
+    appear in process scanning, causing duplicate tray entries (e.g., "D:" and
+    "?"). Filter out mounts whose parent_pid matches another mount's pid.
+    """
+    pids = {m["pid"] for m in mounts}
+    return [m for m in mounts if m.get("parent_pid") not in pids]
+
+
+# ---------------------------------------------------------------------------
+# Process killing
+# ---------------------------------------------------------------------------
+
+
+def _pid_exists(pid: int) -> bool:
+    """Check if a process with the given PID exists."""
+    if sys.platform.startswith("win"):
+        # os.kill(pid, 0) is unreliable on Windows -- it raises OSError with
+        # errno EINVAL (WinError 87) for processes we didn't spawn, making
+        # live processes look dead.  Use OpenProcess instead.
+        try:
+            import ctypes
+            PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+            handle = ctypes.windll.kernel32.OpenProcess(
+                PROCESS_QUERY_LIMITED_INFORMATION, False, pid,
+            )
+            if handle:
+                ctypes.windll.kernel32.CloseHandle(handle)
+                return True
+            return False
+        except Exception:
+            return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    return True
+
+
+def _find_mount_owner_pids(mountpoint: Path) -> List[int]:
+    """Find PIDs of amifuse processes that own the given mountpoint.
+
+    Uses find_amifuse_mounts() for process discovery, then filters to those
+    matching the given mountpoint.
+    """
+    raw_mountpoint = str(mountpoint)
+    abs_mountpoint = str(mountpoint.resolve(strict=False))
+
+    try:
+        all_mounts = find_amifuse_mounts()
+    except OSError:
+        return []
+
+    pids = []
+    for mount in all_mounts:
+        mp = mount.get("mountpoint")
+        if mp is None:
+            continue
+        if mp == raw_mountpoint or mp == abs_mountpoint:
+            pids.append(mount["pid"])
+            continue
+        try:
+            resolved = str(Path(mp).expanduser().resolve(strict=False))
+        except OSError:
+            continue
+        if resolved == abs_mountpoint:
+            pids.append(mount["pid"])
+
+    return pids
+
+
+def kill_pids(pids: List[int], timeout: float = 10.0) -> List[int]:
+    """Kill a list of PIDs with graceful-then-force strategy.
+
+    On Windows: sends CTRL_BREAK_EVENT (graceful), then taskkill /F (force).
+    On Unix: sends SIGTERM (graceful), then SIGKILL (force).
+
+    Args:
+        pids: Process IDs to kill.
+        timeout: Seconds to wait for each graceful shutdown before force-kill.
+
+    Returns:
+        List of PIDs that were successfully killed.
+    """
+    if not pids:
+        return []
+
+    killed = []
+    is_win = sys.platform.startswith("win")
+
+    # Phase 1: graceful signal
+    remaining = []
+    for pid in pids:
+        try:
+            if is_win:
+                os.kill(pid, signal.CTRL_BREAK_EVENT)
+            else:
+                os.kill(pid, signal.SIGTERM)
+            remaining.append(pid)
+        except ProcessLookupError:
+            # Already dead -- count as killed
+            killed.append(pid)
+        except OSError:
+            if is_win:
+                # CTRL_BREAK_EVENT fails with OSError (WinError 87) for
+                # detached processes we didn't spawn.  The process is still
+                # alive -- add to remaining so Phase 3 (taskkill /F) runs.
+                remaining.append(pid)
+            else:
+                # On Unix, OSError from os.kill usually means the process
+                # is gone or inaccessible.
+                killed.append(pid)
+
+    # Phase 2: wait for graceful shutdown
+    deadline = time.time() + timeout
+    while remaining and time.time() < deadline:
+        still_alive = []
+        for pid in remaining:
+            if _pid_exists(pid):
+                still_alive.append(pid)
+            else:
+                killed.append(pid)
+        if not still_alive:
+            return killed
+        remaining = still_alive
+        time.sleep(0.1)
+
+    # Phase 3: force kill
+    for pid in remaining:
+        try:
+            if is_win:
+                # os.kill(pid, SIGKILL) maps to SIGTERM on Windows -- useless retry.
+                # Use taskkill /F for reliable force-kill.
+                subprocess.run(
+                    ["taskkill", "/F", "/PID", str(pid)],
+                    check=False,
+                    capture_output=True,
+                    creationflags=_CREATE_NO_WINDOW,
+                )
+            else:
+                os.kill(pid, signal.SIGKILL)
+            killed.append(pid)
+        except (ProcessLookupError, OSError):
+            killed.append(pid)
+
+    return killed
+
+
+def _kill_mount_owner_processes(mountpoint: Path) -> List[int]:
+    """Kill all amifuse processes that own the given mountpoint.
+
+    Returns list of PIDs that were targeted (whether or not each one died).
+    """
+    pids = _find_mount_owner_pids(mountpoint)
+    if not pids:
+        return []
+    kill_pids(pids, timeout=1.0)
+    return pids
 def _find_amifuse_mounts_windows():
     """Discover amifuse mounts on Windows using wmic.
 
@@ -660,16 +939,17 @@ def _find_amifuse_mounts_windows():
         result = subprocess.run(
             ["wmic", "process", "where",
              "name like '%python%'",
-             "get", "ProcessId,CommandLine,CreationDate",
+             "get", "ProcessId,CommandLine,CreationDate,ParentProcessId",
              "/FORMAT:LIST"],
             check=False,
             capture_output=True,
             text=True,
+            creationflags=_CREATE_NO_WINDOW,
         )
     except OSError:
         # wmic not available (e.g., removed on newer Windows 11 builds)
         logger.debug("wmic not available, cannot discover mounts")
-        return []
+        return _find_amifuse_mounts_cim()
     if result.returncode != 0:
         logger.debug("wmic exited with code %d", result.returncode)
         return []
@@ -681,6 +961,7 @@ def _find_amifuse_mounts_windows():
     current_cmdline = None
     current_pid_val = None
     current_creation = None
+    current_parent_pid = None
 
     def _process_record():
         if current_cmdline is None or current_pid_val is None:
@@ -708,6 +989,7 @@ def _find_amifuse_mounts_windows():
             "pid": current_pid_val,
             "uptime_seconds": uptime,
             "filesystem_type": None,
+            "parent_pid": current_parent_pid,
         })
 
     for line in result.stdout.splitlines():
@@ -721,6 +1003,7 @@ def _find_amifuse_mounts_windows():
                 current_cmdline = None
                 current_pid_val = None
                 current_creation = None
+                current_parent_pid = None
             continue
         if line.startswith("CommandLine="):
             current_cmdline = line[len("CommandLine="):]
@@ -731,6 +1014,11 @@ def _find_amifuse_mounts_windows():
                 current_pid_val = None
         elif line.startswith("CreationDate="):
             current_creation = line[len("CreationDate="):]
+        elif line.startswith("ParentProcessId="):
+            try:
+                current_parent_pid = int(line[len("ParentProcessId="):])
+            except ValueError:
+                current_parent_pid = None
 
     # Handle last record if no trailing blank line
     _process_record()

--- a/amifuse/platform.py
+++ b/amifuse/platform.py
@@ -563,10 +563,11 @@ def _find_amifuse_mounts_unix():
     is_mac = sys.platform.startswith("darwin")
 
     # macOS: lstart gives absolute start time; Linux: etimes gives elapsed seconds
+    # -ww prevents truncation of long command lines in headless environments
     if is_mac:
-        ps_cmd = ["ps", "-axo", "pid=,ppid=,lstart=,command="]
+        ps_cmd = ["ps", "-axwwo", "pid=,ppid=,lstart=,command="]
     else:
-        ps_cmd = ["ps", "-axo", "pid=,ppid=,etimes=,command="]
+        ps_cmd = ["ps", "-axwwo", "pid=,ppid=,etimes=,command="]
 
     try:
         result = subprocess.run(

--- a/amifuse/platform.py
+++ b/amifuse/platform.py
@@ -229,9 +229,8 @@ def _get_windows_unmount_command(mountpoint: Path) -> List[str]:
 
 def mount_runs_in_foreground_by_default() -> bool:
     """Return the safest default mount mode for the current platform."""
-    # WinFSP foreground mounts do not expose a standalone unmount command.
-    # Keep the process attached by default until we have PID tracking there.
-    return sys.platform.startswith("win")
+    # All platforms now support daemon mode with `amifuse unmount`.
+    return False
 
 
 def check_fuse_available() -> None:
@@ -594,13 +593,13 @@ def _find_amifuse_mounts_unix():
             if is_mac:
                 # Format: "  PID  PPID  DAY MON DD HH:MM:SS YYYY COMMAND..."
                 # lstart is 5 tokens: e.g. "Sat Apr 19 10:30:00 2026"
-                parts = line.split(None, 8)
-                if len(parts) < 9:
+                parts = line.split(None, 7)
+                if len(parts) < 8:
                     continue
                 pid = int(parts[0])
                 ppid = int(parts[1])
                 lstart_str = " ".join(parts[2:7])
-                command = parts[8]
+                command = parts[7]
                 # Parse lstart to compute uptime
                 uptime = _parse_lstart_uptime(lstart_str)
             else:
@@ -669,6 +668,10 @@ def _find_amifuse_mounts_cim():
     """Discover amifuse mounts on Windows using PowerShell Get-CimInstance.
 
     Fallback for when wmic is unavailable (removed on newer Windows 11 builds).
+
+    Note: The CIM filter does not restrict by session, so on multi-user systems
+    this may return processes from other logged-in users.  A SessionId filter
+    could be added if this becomes a practical issue.
     """
     ps_cmd = [
         "powershell", "-NoProfile", "-Command",
@@ -681,8 +684,12 @@ def _find_amifuse_mounts_cim():
             ps_cmd,
             check=False,
             capture_output=True,
+            timeout=15,
             creationflags=_CREATE_NO_WINDOW if sys.platform.startswith("win") else 0,
         )
+    except subprocess.TimeoutExpired:
+        logger.debug("PowerShell CIM query timed out")
+        return []
     except OSError:
         logger.debug("PowerShell not available for CIM fallback")
         return []
@@ -843,10 +850,55 @@ def _find_mount_owner_pids(mountpoint: Path) -> List[int]:
     return pids
 
 
+def _verify_amifuse_process(pid: int) -> bool:
+    """Verify that the given PID is still a python/amifuse process.
+
+    Guards against PID reuse: between discovery and kill, the OS may have
+    recycled the PID for an unrelated process.  Returns True if the process
+    executable looks like python or amifuse, False otherwise.
+
+    On non-Windows or if verification cannot be performed, returns True
+    (optimistic -- better to attempt kill than silently skip).
+    """
+    if not sys.platform.startswith("win"):
+        return True
+    try:
+        import ctypes
+        import ctypes.wintypes
+
+        PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+        handle = ctypes.windll.kernel32.OpenProcess(
+            PROCESS_QUERY_LIMITED_INFORMATION, False, pid,
+        )
+        if not handle:
+            # Cannot open -- process is gone or inaccessible
+            return False
+
+        try:
+            # QueryFullProcessImageNameW to get the executable path
+            buf = ctypes.create_unicode_buffer(1024)
+            size = ctypes.wintypes.DWORD(1024)
+            success = ctypes.windll.kernel32.QueryFullProcessImageNameW(
+                handle, 0, buf, ctypes.byref(size),
+            )
+            if not success:
+                # Can't query name -- optimistically assume it's ours
+                return True
+            exe_path = buf.value.lower()
+            return "python" in exe_path or "amifuse" in exe_path
+        finally:
+            ctypes.windll.kernel32.CloseHandle(handle)
+    except Exception:
+        # Any failure in verification -- be optimistic
+        return True
+
+
 def kill_pids(pids: List[int], timeout: float = 10.0) -> List[int]:
     """Kill a list of PIDs with graceful-then-force strategy.
 
-    On Windows: sends CTRL_BREAK_EVENT (graceful), then taskkill /F (force).
+    On Windows: uses taskkill /PID (graceful, sends WM_CLOSE), then
+    taskkill /F /PID (force).  CTRL_BREAK_EVENT is not used because it is
+    ineffective for detached processes launched with CREATE_NEW_PROCESS_GROUP.
     On Unix: sends SIGTERM (graceful), then SIGKILL (force).
 
     Args:
@@ -865,20 +917,40 @@ def kill_pids(pids: List[int], timeout: float = 10.0) -> List[int]:
     # Phase 1: graceful signal
     remaining = []
     for pid in pids:
+        # Guard against PID reuse -- verify the process is still ours
+        if not _verify_amifuse_process(pid):
+            logger.debug("PID %d is no longer an amifuse process (reused); skipping", pid)
+            killed.append(pid)
+            continue
+
         try:
             if is_win:
-                os.kill(pid, signal.CTRL_BREAK_EVENT)
+                # taskkill without /F sends WM_CLOSE -- works for detached
+                # and GUI processes unlike CTRL_BREAK_EVENT.
+                result = subprocess.run(
+                    ["taskkill", "/PID", str(pid)],
+                    check=False,
+                    capture_output=True,
+                    creationflags=_CREATE_NO_WINDOW,
+                )
+                if result.returncode == 0:
+                    remaining.append(pid)
+                else:
+                    # taskkill failed -- process may already be dead
+                    if not _pid_exists(pid):
+                        killed.append(pid)
+                    else:
+                        # Still alive but taskkill rejected it; force-kill later
+                        remaining.append(pid)
             else:
                 os.kill(pid, signal.SIGTERM)
-            remaining.append(pid)
+                remaining.append(pid)
         except ProcessLookupError:
             # Already dead -- count as killed
             killed.append(pid)
         except OSError:
             if is_win:
-                # CTRL_BREAK_EVENT fails with OSError (WinError 87) for
-                # detached processes we didn't spawn.  The process is still
-                # alive -- add to remaining so Phase 3 (taskkill /F) runs.
+                # Unexpected OS error; still try force-kill in Phase 3
                 remaining.append(pid)
             else:
                 # On Unix, OSError from os.kill usually means the process
@@ -903,24 +975,25 @@ def kill_pids(pids: List[int], timeout: float = 10.0) -> List[int]:
     for pid in remaining:
         try:
             if is_win:
-                # os.kill(pid, SIGKILL) maps to SIGTERM on Windows -- useless retry.
-                # Use taskkill /F for reliable force-kill.
-                subprocess.run(
+                result = subprocess.run(
                     ["taskkill", "/F", "/PID", str(pid)],
                     check=False,
                     capture_output=True,
                     creationflags=_CREATE_NO_WINDOW,
                 )
+                if result.returncode == 0:
+                    killed.append(pid)
             else:
                 os.kill(pid, signal.SIGKILL)
-            killed.append(pid)
+                killed.append(pid)
         except (ProcessLookupError, OSError):
+            # Process already dead = success
             killed.append(pid)
 
     return killed
 
 
-def _kill_mount_owner_processes(mountpoint: Path) -> List[int]:
+def kill_mount_owner_processes(mountpoint: Path) -> List[int]:
     """Kill all amifuse processes that own the given mountpoint.
 
     Returns list of PIDs that were targeted (whether or not each one died).
@@ -930,6 +1003,8 @@ def _kill_mount_owner_processes(mountpoint: Path) -> List[int]:
         return []
     kill_pids(pids, timeout=1.0)
     return pids
+
+
 def _find_amifuse_mounts_windows():
     """Discover amifuse mounts on Windows using wmic.
 

--- a/amifuse/platform.py
+++ b/amifuse/platform.py
@@ -355,6 +355,7 @@ def get_mount_options(volname: str, volicon_path: Optional[str] = None,
         return {
             "volname": volname,
             "FileSystemName": "AmiFUSE",
+            "FileInfoTimeout": "1000",
         }
     # Linux doesn't need special mount options
     return {}

--- a/amifuse/tray.py
+++ b/amifuse/tray.py
@@ -1,0 +1,202 @@
+"""System tray mount manager for AmiFUSE."""
+
+import logging
+import os
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_CREATE_NO_WINDOW = 0x08000000
+_CREATE_NEW_CONSOLE = 0x00000010
+_ERROR_ALREADY_EXISTS = 183
+
+
+class TrayApp:
+    POLL_INTERVAL = 2.5  # seconds
+    GRACE_PERIOD = 10.0  # seconds after last mount disappears before auto-exit
+
+    def __init__(self):
+        self._icon = None
+        self._lock = threading.Lock()
+        self._mounts = []
+        self._stop_event = threading.Event()
+        self._wake_event = threading.Event()
+        self._grace_start = None
+
+    def run(self):
+        import pystray
+        from PIL import Image
+
+        icon_path = Path(os.environ.get("APPDATA", "")) / "AmiFUSE" / "icons" / "tray.ico"
+        if not icon_path.exists():
+            logger.error("Icon not found: %s", icon_path)
+            sys.exit(1)
+
+        icon_image = Image.open(str(icon_path))
+        self._icon = pystray.Icon(
+            "AmiFUSE", icon_image, "AmiFUSE", menu=self._build_menu()
+        )
+
+        poll_thread = threading.Thread(target=self._poll_loop, daemon=True)
+        poll_thread.start()
+
+        self._icon.run()
+        # Unmount after icon.run() returns, not in _quit callback
+        self._unmount_all()
+
+    def _poll_loop(self):
+        from .platform import find_amifuse_mounts
+
+        prev_set = set()
+        while not self._stop_event.is_set():
+            mounts = find_amifuse_mounts()
+            # Compare (pid, mountpoint) tuples to detect mountpoint changes
+            current_set = {(m["pid"], m.get("mountpoint", "")) for m in mounts}
+
+            if current_set != prev_set:
+                prev_set = current_set
+                with self._lock:
+                    self._mounts = mounts
+                self._icon.menu = self._build_menu()
+
+            # Auto-exit grace period
+            if not mounts:
+                if self._grace_start is None:
+                    self._grace_start = time.monotonic()
+                elif time.monotonic() - self._grace_start > self.GRACE_PERIOD:
+                    self._icon.stop()
+            else:
+                self._grace_start = None
+
+            # Event.wait allows instant wakeup after unmount
+            self._wake_event.wait(self.POLL_INTERVAL)
+            self._wake_event.clear()
+
+    def _build_menu(self):
+        import pystray
+
+        with self._lock:
+            mounts = list(self._mounts)
+
+        items = []
+        for mount in mounts:
+            mountpoint = mount.get("mountpoint", "?")
+            image = mount.get("image")
+            image_name = Path(image).name if image else "unknown"
+
+            label = f"{mountpoint} - {image_name}"
+            logger.info("Building submenu for %s (image=%s)", label, image)
+            # Factory functions, not lambdas (pystray rejects lambdas with default args)
+            items.append(pystray.MenuItem(
+                label,
+                pystray.Menu(
+                    pystray.MenuItem("Inspect", self._make_inspect_cb(mount)),
+                    pystray.MenuItem("Unmount", self._make_unmount_cb(mount)),
+                ),
+            ))
+
+        items.append(pystray.Menu.SEPARATOR)
+        items.append(pystray.MenuItem("Unmount All", self._unmount_all_cb))
+        items.append(pystray.MenuItem("Exit", self._quit))
+
+        return pystray.Menu(*items)
+
+    def _make_unmount_cb(self, mount):
+        def cb(icon, item):
+            try:
+                logger.info("Unmount callback fired for %s", mount.get("mountpoint"))
+                self._unmount_single(mount)
+            except Exception:
+                logger.exception("Unmount callback failed for %s", mount.get("mountpoint"))
+        return cb
+
+    def _make_inspect_cb(self, mount):
+        def cb(icon, item):
+            try:
+                logger.info("Inspect callback fired for %s", mount.get("mountpoint"))
+                self._inspect(mount)
+            except Exception:
+                logger.exception("Inspect callback failed for %s", mount.get("mountpoint"))
+        return cb
+
+    def _unmount_single(self, mount):
+        from .platform import kill_pids
+
+        kill_pids([mount["pid"]], timeout=2.0)
+        self._wake_event.set()
+
+    def _unmount_all(self):
+        with self._lock:
+            pids = [m["pid"] for m in self._mounts]
+        if not pids:
+            return
+        from .platform import kill_pids
+
+        kill_pids(pids, timeout=2.0)
+
+    def _unmount_all_cb(self, icon, item):
+        self._unmount_all()
+        self._wake_event.set()
+
+    def _inspect(self, mount):
+        logger.info("_inspect called with mount=%s", mount)
+        image_path = mount.get("image")
+        if not image_path:
+            logger.warning("Cannot determine image path for mount %s", mount)
+            return
+
+        abs_image_path = str(Path(image_path).resolve())
+        logger.info("Resolved image path: %s", abs_image_path)
+        # sys.executable may be pythonw.exe or amifuse-tray.exe (GUI subsystem),
+        # which suppresses console output.  Find python.exe in the same directory
+        # so that inspect output is visible in the new console window.
+        python_dir = Path(sys.executable).parent
+        python_exe = str(python_dir / "python.exe")
+        if not os.path.isfile(python_exe):
+            python_exe = sys.executable  # fallback
+        cmd = [python_exe, "-m", "amifuse", "inspect", abs_image_path]
+        logger.info("Inspect: sys.executable=%s python_exe=%s cmd=%s",
+                     sys.executable, python_exe, cmd)
+        subprocess.Popen(
+            ["cmd", "/k"] + cmd,
+            creationflags=_CREATE_NEW_CONSOLE,
+        )
+
+    def _quit(self, icon, item):
+        # Only stop the icon; unmounting happens after icon.run() returns
+        self._icon.stop()
+
+
+def _check_single_instance() -> bool:
+    """Return True if this is the only instance, False if another exists."""
+    import ctypes
+
+    ctypes.windll.kernel32.CreateMutexW(None, False, "AmiFUSE_Tray_Mutex")
+    return ctypes.windll.kernel32.GetLastError() != _ERROR_ALREADY_EXISTS
+
+
+def main():
+    log_dir = Path(os.environ.get("APPDATA", "")) / "AmiFUSE"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    logging.basicConfig(
+        filename=str(log_dir / "tray.log"),
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+    )
+
+    if not _check_single_instance():
+        logger.info("Another tray instance is already running.")
+        sys.exit(0)
+
+    logger.info("Starting AmiFUSE tray.")
+    app = TrayApp()
+    app.run()
+    logger.info("Tray exited.")
+
+
+if __name__ == "__main__":
+    main()

--- a/amifuse/tray.py
+++ b/amifuse/tray.py
@@ -162,13 +162,18 @@ class TrayApp:
         python_exe = str(python_dir / "python.exe")
         if not os.path.isfile(python_exe):
             python_exe = sys.executable  # fallback
-        cmd = [python_exe, "-m", "amifuse", "inspect", abs_image_path]
-        logger.info("Inspect: sys.executable=%s python_exe=%s cmd=%s",
-                     sys.executable, python_exe, cmd)
-        subprocess.Popen(
-            ["cmd", "/k"] + cmd,
-            creationflags=_CREATE_NEW_CONSOLE,
-        )
+        # Launch python directly with CREATE_NEW_CONSOLE to avoid cmd.exe
+        # metacharacter injection. The -c script uses sys.argv for the path
+        # (never interpolated into code) and waits for a keypress so the user
+        # can read output before the console closes.
+        wrapper = [
+            python_exe, "-c",
+            "import sys; from amifuse.fuse_fs import main; main(['inspect'] + sys.argv[1:]); input('\\nPress Enter to close...')",
+            abs_image_path,
+        ]
+        logger.info("Inspect: sys.executable=%s python_exe=%s wrapper=%s",
+                     sys.executable, python_exe, wrapper)
+        subprocess.Popen(wrapper, creationflags=_CREATE_NEW_CONSOLE)
 
     def _quit(self, icon, item):
         # Signal the poll loop to call icon.stop() — calling it directly from
@@ -177,12 +182,22 @@ class TrayApp:
         self._wake_event.set()
 
 
+_mutex_handle = None
+_kernel32 = None
+
+
 def _check_single_instance() -> bool:
     """Return True if this is the only instance, False if another exists."""
+    global _mutex_handle, _kernel32
     import ctypes
 
-    ctypes.windll.kernel32.CreateMutexW(None, False, "AmiFUSE_Tray_Mutex")
-    return ctypes.windll.kernel32.GetLastError() != _ERROR_ALREADY_EXISTS
+    if _kernel32 is None:
+        _kernel32 = ctypes.WinDLL('kernel32', use_last_error=True)
+
+    _mutex_handle = _kernel32.CreateMutexW(None, False, "Local\\AmiFUSE_Tray_Mutex")
+    if not _mutex_handle:
+        return False
+    return ctypes.get_last_error() != _ERROR_ALREADY_EXISTS
 
 
 def main():

--- a/amifuse/tray.py
+++ b/amifuse/tray.py
@@ -69,12 +69,16 @@ class TrayApp:
                     self._grace_start = time.monotonic()
                 elif time.monotonic() - self._grace_start > self.GRACE_PERIOD:
                     self._icon.stop()
+                    return
             else:
                 self._grace_start = None
 
-            # Event.wait allows instant wakeup after unmount
+            # Event.wait allows instant wakeup after unmount or quit
             self._wake_event.wait(self.POLL_INTERVAL)
             self._wake_event.clear()
+
+        # _quit was called — stop the icon from this thread (safe, not in callback)
+        self._icon.stop()
 
     def _build_menu(self):
         import pystray
@@ -167,8 +171,10 @@ class TrayApp:
         )
 
     def _quit(self, icon, item):
-        # Only stop the icon; unmounting happens after icon.run() returns
-        self._icon.stop()
+        # Signal the poll loop to call icon.stop() — calling it directly from
+        # a pystray callback deadlocks the Win32 message pump.
+        self._stop_event.set()
+        self._wake_event.set()
 
 
 def _check_single_instance() -> bool:

--- a/amifuse/windows_shell.py
+++ b/amifuse/windows_shell.py
@@ -1,0 +1,1008 @@
+"""Windows shell integration: context menu verbs and file type icons."""
+
+from __future__ import annotations
+
+import logging
+import os
+import struct
+import sys
+import zlib
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+EXTENSIONS = {".hdf": "AmiFUSE.DiskImage", ".adf": "AmiFUSE.FloppyImage"}
+
+PROGID_DESCRIPTIONS = {
+    "AmiFUSE.DiskImage": "Amiga Disk Image",
+    "AmiFUSE.FloppyImage": "Amiga Floppy Image",
+}
+
+ICON_DIR = Path(os.environ.get("APPDATA", "")) / "AmiFUSE" / "icons"
+_AMIFUSE_DIR = Path(os.environ.get("APPDATA", "")) / "AmiFUSE"
+_LAUNCH_VBS = _AMIFUSE_DIR / "launch.vbs"
+
+# VBScript launcher: runs a command with hidden window and no wait,
+# avoiding the cmd.exe flash that ``cmd /c start`` causes.
+_LAUNCH_VBS_CONTENT = '''\
+Set a = WScript.Arguments
+cmd = ""
+For i = 0 To a.Count - 1
+    If i > 0 Then cmd = cmd & " "
+    cmd = cmd & """" & a(i) & """"
+Next
+CreateObject("WScript.Shell").Run cmd, 0, False
+'''
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def register(extensions: list[str] | None = None) -> None:
+    """Register file associations and context menu verbs for AmiFUSE."""
+    if not sys.platform.startswith("win"):
+        raise SystemExit("Shell registration is only supported on Windows.")
+
+    import winreg
+
+    exts = _resolve_extensions(extensions)
+    launcher = _get_launcher_path()
+
+    for ext in exts:
+        progid = EXTENSIONS[ext]
+        _register_extension(winreg, ext, progid)
+        logger.info("Registered %s -> %s", ext, progid)
+
+    registered_progids: set[str] = set()
+    for ext in exts:
+        progid = EXTENSIONS[ext]
+        if progid not in registered_progids:
+            _register_progid(winreg, progid, launcher)
+            registered_progids.add(progid)
+
+    _install_icons()
+    _notify_shell_change()
+
+    for ext in exts:
+        print(f"Registered {ext} with AmiFUSE context menu.")
+
+
+def unregister(extensions: list[str] | None = None) -> None:
+    """Remove AmiFUSE file associations and context menu verbs."""
+    if not sys.platform.startswith("win"):
+        raise SystemExit("Shell registration is only supported on Windows.")
+
+    import winreg
+
+    exts = _resolve_extensions(extensions)
+
+    removed_progids: set[str] = set()
+    for ext in exts:
+        progid = EXTENSIONS[ext]
+        _unregister_extension(winreg, ext, progid)
+        if progid not in removed_progids:
+            _delete_key_recursive(
+                winreg.HKEY_CURRENT_USER, rf"Software\Classes\{progid}"
+            )
+            removed_progids.add(progid)
+        logger.info("Unregistered %s", ext)
+
+    _remove_icons()
+    _notify_shell_change()
+
+    for ext in exts:
+        print(f"Unregistered {ext} from AmiFUSE.")
+
+
+def is_registered() -> bool:
+    """Return True if AmiFUSE is registered for .hdf files."""
+    if not sys.platform.startswith("win"):
+        return False
+    import winreg
+
+    try:
+        key = winreg.OpenKey(
+            winreg.HKEY_CURRENT_USER,
+            r"Software\Classes\.hdf\OpenWithProgids",
+        )
+        try:
+            winreg.QueryValueEx(key, "AmiFUSE.DiskImage")
+            return True
+        except FileNotFoundError:
+            return False
+        finally:
+            winreg.CloseKey(key)
+    except OSError:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _resolve_extensions(extensions: list[str] | None) -> list[str]:
+    if extensions is None:
+        return list(EXTENSIONS)
+    for ext in extensions:
+        if ext not in EXTENSIONS:
+            raise ValueError(f"Unknown extension: {ext}")
+    return extensions
+
+
+def _get_launcher_path() -> str:
+    return str(Path(sys.executable).parent / "amifuse-launcher.exe")
+
+
+def _register_extension(winreg, ext: str, progid: str) -> None:
+    """Register a single extension under HKCU\\Software\\Classes."""
+    ext_path = rf"Software\Classes\{ext}"
+
+    key = winreg.CreateKey(winreg.HKEY_CURRENT_USER, ext_path)
+    try:
+        existing = ""
+        try:
+            existing, _ = winreg.QueryValueEx(key, "")
+        except FileNotFoundError:
+            pass
+
+        if existing and existing != progid:
+            logger.warning(
+                "%s already claimed by %s; adding to OpenWithProgids only",
+                ext,
+                existing,
+            )
+            print(
+                f"Warning: {ext} is already associated with {existing}. "
+                f"Adding AmiFUSE to Open With list without overriding."
+            )
+        else:
+            winreg.SetValueEx(key, "", 0, winreg.REG_SZ, progid)
+    finally:
+        winreg.CloseKey(key)
+
+    # Always add to OpenWithProgids
+    owp_key = winreg.CreateKey(winreg.HKEY_CURRENT_USER, rf"{ext_path}\OpenWithProgids")
+    try:
+        winreg.SetValueEx(owp_key, progid, 0, winreg.REG_SZ, "")
+    finally:
+        winreg.CloseKey(owp_key)
+
+
+def _register_progid(winreg, progid: str, launcher: str) -> None:
+    """Create ProgID with flat verb entries and icon."""
+    base = rf"Software\Classes\{progid}"
+    description = PROGID_DESCRIPTIONS[progid]
+
+    # (Default) = description
+    key = winreg.CreateKey(winreg.HKEY_CURRENT_USER, base)
+    try:
+        winreg.SetValueEx(key, "", 0, winreg.REG_SZ, description)
+    finally:
+        winreg.CloseKey(key)
+
+    # Flat verb: mount — wscript runs VBS launcher invisibly (no cmd.exe flash)
+    vbs = str(_LAUNCH_VBS)
+    _set_verb(
+        winreg,
+        base,
+        "mount",
+        "Mount with AmiFUSE",
+        f'wscript.exe //nologo //b "{vbs}" "{launcher}" mount "%1"',
+    )
+
+    # Flat verb: mountrw
+    _set_verb(
+        winreg,
+        base,
+        "mountrw",
+        "Mount Read-Write with AmiFUSE",
+        f'wscript.exe //nologo //b "{vbs}" "{launcher}" mount --write "%1"',
+    )
+
+    # DefaultIcon
+    icon_name = progid.split(".")[-1].lower() + ".ico"
+    icon_path = str(ICON_DIR / icon_name)
+    icon_key = winreg.CreateKey(winreg.HKEY_CURRENT_USER, rf"{base}\DefaultIcon")
+    try:
+        winreg.SetValueEx(icon_key, "", 0, winreg.REG_SZ, icon_path)
+    finally:
+        winreg.CloseKey(icon_key)
+
+
+def _set_verb(winreg, base: str, verb: str, label: str, command: str) -> None:
+    verb_key = winreg.CreateKey(
+        winreg.HKEY_CURRENT_USER, rf"{base}\shell\{verb}"
+    )
+    try:
+        winreg.SetValueEx(verb_key, "", 0, winreg.REG_SZ, label)
+    finally:
+        winreg.CloseKey(verb_key)
+
+    cmd_key = winreg.CreateKey(
+        winreg.HKEY_CURRENT_USER, rf"{base}\shell\{verb}\command"
+    )
+    try:
+        winreg.SetValueEx(cmd_key, "", 0, winreg.REG_SZ, command)
+    finally:
+        winreg.CloseKey(cmd_key)
+
+
+def _unregister_extension(winreg, ext: str, progid: str) -> None:
+    """Remove AmiFUSE entries from a single extension key."""
+    ext_path = rf"Software\Classes\{ext}"
+
+    # Remove from OpenWithProgids
+    try:
+        owp_key = winreg.OpenKey(
+            winreg.HKEY_CURRENT_USER,
+            rf"{ext_path}\OpenWithProgids",
+            0,
+            winreg.KEY_SET_VALUE | winreg.KEY_READ,
+        )
+        try:
+            try:
+                winreg.DeleteValue(owp_key, progid)
+            except FileNotFoundError:
+                pass
+
+            # If no other ProgIDs remain, delete the key
+            try:
+                winreg.EnumValue(owp_key, 0)
+            except OSError:
+                winreg.CloseKey(owp_key)
+                owp_key = None
+                try:
+                    winreg.DeleteKey(
+                        winreg.HKEY_CURRENT_USER,
+                        rf"{ext_path}\OpenWithProgids",
+                    )
+                except OSError:
+                    pass
+        finally:
+            if owp_key is not None:
+                winreg.CloseKey(owp_key)
+    except OSError:
+        pass
+
+    # Only clear (Default) if it's ours
+    try:
+        key = winreg.OpenKey(
+            winreg.HKEY_CURRENT_USER, ext_path, 0, winreg.KEY_READ | winreg.KEY_SET_VALUE
+        )
+        try:
+            current, _ = winreg.QueryValueEx(key, "")
+            if current == progid:
+                winreg.SetValueEx(key, "", 0, winreg.REG_SZ, "")
+        except FileNotFoundError:
+            pass
+        finally:
+            winreg.CloseKey(key)
+    except OSError:
+        pass
+
+    # Remove the extension key entirely if it's now empty (no subkeys, no default)
+    try:
+        key = winreg.OpenKey(winreg.HKEY_CURRENT_USER, ext_path, 0, winreg.KEY_READ)
+        try:
+            has_subkeys = True
+            try:
+                winreg.EnumKey(key, 0)
+            except OSError:
+                has_subkeys = False
+
+            default_empty = True
+            try:
+                val, _ = winreg.QueryValueEx(key, "")
+                if val:
+                    default_empty = False
+            except OSError:
+                pass  # No default value — counts as empty
+
+            if not has_subkeys and default_empty:
+                winreg.CloseKey(key)
+                key = None
+                winreg.DeleteKey(winreg.HKEY_CURRENT_USER, ext_path)
+        finally:
+            if key is not None:
+                winreg.CloseKey(key)
+    except OSError:
+        pass
+
+
+def _delete_key_recursive(hkey, sub_key: str) -> None:
+    """Recursively delete a registry key and all its children."""
+    import winreg
+
+    try:
+        key = winreg.OpenKey(hkey, sub_key, 0, winreg.KEY_READ)
+    except FileNotFoundError:
+        return
+    except OSError:
+        return
+
+    children = []
+    try:
+        i = 0
+        while True:
+            try:
+                children.append(winreg.EnumKey(key, i))
+                i += 1
+            except OSError:
+                break
+    finally:
+        winreg.CloseKey(key)
+
+    for child in children:
+        _delete_key_recursive(hkey, rf"{sub_key}\{child}")
+
+    try:
+        winreg.DeleteKey(hkey, sub_key)
+    except OSError as exc:
+        logger.warning("Failed to delete registry key %s: %s", sub_key, exc)
+
+
+# ---------------------------------------------------------------------------
+# Icons — pretty-file-icons style page icons for HDF and ADF, plus tray icon
+# ---------------------------------------------------------------------------
+
+# Shared page template colors
+_PAGE_FILL = (233, 233, 224, 255)       # warm off-white (#E9E9E0)
+_DOG_EAR_FILL = (217, 215, 202, 255)   # slightly darker warm gray (#D9D7CA)
+_PAGE_OUTLINE = (180, 178, 168, 255)    # medium gray for definition
+_BANNER_TEXT = (255, 255, 255, 255)     # white
+
+# Banner colors per type
+_ADF_BANNER = (60, 179, 113, 255)       # medium sea green (#3CB371)
+_HDF_BANNER = (212, 160, 23, 255)       # amber/gold (#D4A017)
+
+# Tray icon color
+_TRAY_COLOR = (212, 160, 23, 255)       # amber/gold
+
+T = tuple[int, int, int, int]  # RGBA pixel type alias
+
+
+def _new_canvas(size: int) -> list[list[T]]:
+    """Create a size x size transparent canvas (RGBA)."""
+    return [[(0, 0, 0, 0)] * size for _ in range(size)]
+
+
+def _fill_rect(canvas: list[list[T]], x0: int, y0: int, x1: int, y1: int, color: T) -> None:
+    """Fill a rectangle [x0,x1) x [y0,y1) with color, alpha-blending over existing."""
+    h = len(canvas)
+    w = len(canvas[0]) if h else 0
+    for y in range(max(0, y0), min(h, y1)):
+        for x in range(max(0, x0), min(w, x1)):
+            canvas[y][x] = _blend(canvas[y][x], color)
+
+
+def _set_pixel(canvas: list[list[T]], x: int, y: int, color: T) -> None:
+    h = len(canvas)
+    w = len(canvas[0]) if h else 0
+    if 0 <= x < w and 0 <= y < h:
+        canvas[y][x] = _blend(canvas[y][x], color)
+
+
+def _blend(bg: T, fg: T) -> T:
+    """Alpha-blend fg over bg (both RGBA tuples)."""
+    fa = fg[3] / 255.0
+    ba = bg[3] / 255.0
+    oa = fa + ba * (1 - fa)
+    if oa == 0:
+        return (0, 0, 0, 0)
+    r = int((fg[0] * fa + bg[0] * ba * (1 - fa)) / oa)
+    g = int((fg[1] * fa + bg[1] * ba * (1 - fa)) / oa)
+    b = int((fg[2] * fa + bg[2] * ba * (1 - fa)) / oa)
+    return (r, g, b, int(oa * 255))
+
+
+def _draw_outline_rect(canvas: list[list[T]], x0: int, y0: int, x1: int, y1: int, color: T) -> None:
+    """Draw a 1px outline rectangle."""
+    for x in range(x0, x1):
+        _set_pixel(canvas, x, y0, color)
+        _set_pixel(canvas, x, y1 - 1, color)
+    for y in range(y0, y1):
+        _set_pixel(canvas, x0, y, color)
+        _set_pixel(canvas, x1 - 1, y, color)
+
+
+def _draw_filled_circle(canvas: list[list[T]], cx: int, cy: int, r: int, color: T) -> None:
+    """Draw a filled circle."""
+    for dy in range(-r, r + 1):
+        for dx in range(-r, r + 1):
+            if dx * dx + dy * dy <= r * r:
+                _set_pixel(canvas, cx + dx, cy + dy, color)
+
+
+# ---------------------------------------------------------------------------
+# Bitmap fonts for banner text
+# ---------------------------------------------------------------------------
+
+# 3x5 font for 16px icons (tiny, adds texture)
+_FONT_3x5: dict[str, list[list[int]]] = {
+    'A': [[0,1,0],[1,0,1],[1,1,1],[1,0,1],[1,0,1]],
+    'D': [[1,1,0],[1,0,1],[1,0,1],[1,0,1],[1,1,0]],
+    'F': [[1,1,1],[1,0,0],[1,1,0],[1,0,0],[1,0,0]],
+    'H': [[1,0,1],[1,0,1],[1,1,1],[1,0,1],[1,0,1]],
+}
+
+# 4x6 font for 32px icons (readable)
+_FONT_4x6: dict[str, list[list[int]]] = {
+    'A': [[0,1,1,0],[1,0,0,1],[1,0,0,1],[1,1,1,1],[1,0,0,1],[1,0,0,1]],
+    'D': [[1,1,1,0],[1,0,0,1],[1,0,0,1],[1,0,0,1],[1,0,0,1],[1,1,1,0]],
+    'F': [[1,1,1,1],[1,0,0,0],[1,1,1,0],[1,0,0,0],[1,0,0,0],[1,0,0,0]],
+    'H': [[1,0,0,1],[1,0,0,1],[1,1,1,1],[1,0,0,1],[1,0,0,1],[1,0,0,1]],
+}
+
+# 6x8 font for 48px icons (clearly readable)
+_FONT_6x8: dict[str, list[list[int]]] = {
+    'A': [[0,0,1,1,0,0],[0,1,0,0,1,0],[1,0,0,0,0,1],[1,0,0,0,0,1],[1,1,1,1,1,1],[1,0,0,0,0,1],[1,0,0,0,0,1],[1,0,0,0,0,1]],
+    'D': [[1,1,1,1,0,0],[1,0,0,0,1,0],[1,0,0,0,0,1],[1,0,0,0,0,1],[1,0,0,0,0,1],[1,0,0,0,0,1],[1,0,0,0,1,0],[1,1,1,1,0,0]],
+    'F': [[1,1,1,1,1,1],[1,0,0,0,0,0],[1,0,0,0,0,0],[1,1,1,1,0,0],[1,0,0,0,0,0],[1,0,0,0,0,0],[1,0,0,0,0,0],[1,0,0,0,0,0]],
+    'H': [[1,0,0,0,0,1],[1,0,0,0,0,1],[1,0,0,0,0,1],[1,1,1,1,1,1],[1,0,0,0,0,1],[1,0,0,0,0,1],[1,0,0,0,0,1],[1,0,0,0,0,1]],
+}
+
+
+def _render_text(canvas: list[list[T]], text: str, x: int, y: int,
+                 font: dict[str, list[list[int]]], color: T, spacing: int = 1) -> None:
+    """Render text on canvas using a bitmap font."""
+    cx = x
+    for ch in text:
+        glyph = font.get(ch)
+        if glyph is None:
+            continue
+        for row_i, row in enumerate(glyph):
+            for col_i, bit in enumerate(row):
+                if bit:
+                    _set_pixel(canvas, cx + col_i, y + row_i, color)
+        cx += len(glyph[0]) + spacing
+
+
+def _text_width(text: str, font: dict[str, list[list[int]]], spacing: int = 1) -> int:
+    """Compute pixel width of rendered text."""
+    w = 0
+    for i, ch in enumerate(text):
+        glyph = font.get(ch)
+        if glyph is None:
+            continue
+        w += len(glyph[0])
+        if i < len(text) - 1:
+            w += spacing
+    return w
+
+
+# ---------------------------------------------------------------------------
+# Page icon drawing — shared template
+# ---------------------------------------------------------------------------
+
+
+def _draw_page_icon_16(banner_color: T, text: str) -> list[list[T]]:
+    """16x16 pretty-file-icons page icon."""
+    canvas = _new_canvas(16)
+    # Page: x=[3,13), y=[1,15) -> 10px wide, 14px tall
+    px0, py0, px1, py1 = 3, 1, 13, 15
+    ear = 2
+
+    # Page fill (excluding dog-ear)
+    _fill_rect(canvas, px0, py0, px1 - ear, py1, _PAGE_FILL)
+    _fill_rect(canvas, px0, py0 + ear, px1, py1, _PAGE_FILL)
+
+    # Dog-ear fill
+    for i in range(ear):
+        _fill_rect(canvas, px1 - ear + i + 1, py0 + i, px1, py0 + i + 1, _DOG_EAR_FILL)
+
+    # Page outline
+    for y in range(py0, py1):
+        _set_pixel(canvas, px0, y, _PAGE_OUTLINE)          # left
+    for x in range(px0, px1):
+        _set_pixel(canvas, x, py1 - 1, _PAGE_OUTLINE)      # bottom
+    for y in range(py0 + ear, py1):
+        _set_pixel(canvas, px1 - 1, y, _PAGE_OUTLINE)      # right
+    for x in range(px0, px1 - ear):
+        _set_pixel(canvas, x, py0, _PAGE_OUTLINE)           # top
+    # Dog-ear diagonal and crease
+    for i in range(ear + 1):
+        _set_pixel(canvas, px1 - ear + i, py0 + i, _PAGE_OUTLINE)
+    for x in range(px1 - ear, px1):
+        _set_pixel(canvas, x, py0 + ear, _PAGE_OUTLINE)
+
+    # Banner: bottom 4 rows of page
+    bx0, by0, bx1, by1 = px0 + 1, py1 - 5, px1 - 1, py1 - 1
+    _fill_rect(canvas, bx0, by0, bx1, by1, banner_color)
+
+    # Text (3x5 font, centered in banner)
+    font = _FONT_3x5
+    tw = _text_width(text, font)
+    tx = bx0 + (bx1 - bx0 - tw) // 2
+    ty = by0 + (by1 - by0 - 5) // 2
+    _render_text(canvas, text, tx, ty, font, _BANNER_TEXT)
+
+    return canvas
+
+
+def _draw_page_icon_32(banner_color: T, text: str) -> list[list[T]]:
+    """32x32 pretty-file-icons page icon."""
+    canvas = _new_canvas(32)
+    # Page: x=[6,26), y=[2,30) -> 20px wide, 28px tall
+    px0, py0, px1, py1 = 6, 2, 26, 30
+    ear = 4
+
+    # Page fill
+    _fill_rect(canvas, px0, py0, px1 - ear, py1, _PAGE_FILL)
+    _fill_rect(canvas, px0, py0 + ear, px1, py1, _PAGE_FILL)
+
+    # Dog-ear fill
+    for i in range(ear):
+        _fill_rect(canvas, px1 - ear + i + 1, py0 + i, px1, py0 + i + 1, _DOG_EAR_FILL)
+
+    # Outline
+    for y in range(py0, py1):
+        _set_pixel(canvas, px0, y, _PAGE_OUTLINE)
+    for x in range(px0, px1):
+        _set_pixel(canvas, x, py1 - 1, _PAGE_OUTLINE)
+    for y in range(py0 + ear, py1):
+        _set_pixel(canvas, px1 - 1, y, _PAGE_OUTLINE)
+    for x in range(px0, px1 - ear):
+        _set_pixel(canvas, x, py0, _PAGE_OUTLINE)
+    for i in range(ear + 1):
+        _set_pixel(canvas, px1 - ear + i, py0 + i, _PAGE_OUTLINE)
+    for x in range(px1 - ear, px1):
+        _set_pixel(canvas, x, py0 + ear, _PAGE_OUTLINE)
+
+    # Banner: bottom 8 rows
+    bx0, by0, bx1, by1 = px0 + 1, py1 - 9, px1 - 1, py1 - 1
+    _fill_rect(canvas, bx0, by0, bx1, by1, banner_color)
+
+    # Text (4x6 font, centered)
+    font = _FONT_4x6
+    tw = _text_width(text, font)
+    tx = bx0 + (bx1 - bx0 - tw) // 2
+    ty = by0 + (by1 - by0 - 6) // 2
+    _render_text(canvas, text, tx, ty, font, _BANNER_TEXT)
+
+    return canvas
+
+
+def _draw_page_icon_48(banner_color: T, text: str) -> list[list[T]]:
+    """48x48 pretty-file-icons page icon."""
+    canvas = _new_canvas(48)
+    # Page: x=[9,39), y=[3,45) -> 30px wide, 42px tall
+    px0, py0, px1, py1 = 9, 3, 39, 45
+    ear = 7
+
+    # Page fill
+    _fill_rect(canvas, px0, py0, px1 - ear, py1, _PAGE_FILL)
+    _fill_rect(canvas, px0, py0 + ear, px1, py1, _PAGE_FILL)
+
+    # Dog-ear fill
+    for i in range(ear):
+        _fill_rect(canvas, px1 - ear + i + 1, py0 + i, px1, py0 + i + 1, _DOG_EAR_FILL)
+
+    # Outline
+    for y in range(py0, py1):
+        _set_pixel(canvas, px0, y, _PAGE_OUTLINE)
+    for x in range(px0, px1):
+        _set_pixel(canvas, x, py1 - 1, _PAGE_OUTLINE)
+    for y in range(py0 + ear, py1):
+        _set_pixel(canvas, px1 - 1, y, _PAGE_OUTLINE)
+    for x in range(px0, px1 - ear):
+        _set_pixel(canvas, x, py0, _PAGE_OUTLINE)
+    for i in range(ear + 1):
+        _set_pixel(canvas, px1 - ear + i, py0 + i, _PAGE_OUTLINE)
+    for x in range(px1 - ear, px1):
+        _set_pixel(canvas, x, py0 + ear, _PAGE_OUTLINE)
+
+    # Banner: bottom 12 rows
+    bx0, by0, bx1, by1 = px0 + 1, py1 - 13, px1 - 1, py1 - 1
+    _fill_rect(canvas, bx0, by0, bx1, by1, banner_color)
+
+    # Text (6x8 font, centered)
+    font = _FONT_6x8
+    tw = _text_width(text, font)
+    tx = bx0 + (bx1 - bx0 - tw) // 2
+    ty = by0 + (by1 - by0 - 8) // 2
+    _render_text(canvas, text, tx, ty, font, _BANNER_TEXT)
+
+    return canvas
+
+
+def _draw_page_icon_256(banner_color: T, text: str, content_color: T | None = None) -> list[list[T]]:
+    """256x256 pretty-file-icons page icon with optional content illustration."""
+    canvas = _new_canvas(256)
+    # Page: x=[43,213), y=[15,240) -> 170px wide, 225px tall
+    px0, py0, px1, py1 = 43, 15, 213, 240
+    ear = 35
+
+    # Rounded-corner page fill
+    _fill_rect(canvas, px0 + 4, py0, px1 - ear, py0 + 4, _PAGE_FILL)  # top strip
+    _fill_rect(canvas, px0, py0 + 4, px1 - ear, py1 - 4, _PAGE_FILL)  # main body left
+    _fill_rect(canvas, px0, py0 + ear, px1, py1 - 4, _PAGE_FILL)      # main body full
+    _fill_rect(canvas, px0 + 4, py1 - 4, px1 - 4, py1, _PAGE_FILL)   # bottom strip
+
+    # Dog-ear fill
+    for i in range(ear):
+        _fill_rect(canvas, px1 - ear + i + 1, py0 + i, px1, py0 + i + 1, _DOG_EAR_FILL)
+
+    # Outline — left
+    for y in range(py0 + 4, py1 - 4):
+        _set_pixel(canvas, px0, y, _PAGE_OUTLINE)
+    # Outline — bottom
+    for x in range(px0 + 4, px1 - 4):
+        _set_pixel(canvas, x, py1 - 1, _PAGE_OUTLINE)
+    # Outline — right (below ear)
+    for y in range(py0 + ear, py1 - 4):
+        _set_pixel(canvas, px1 - 1, y, _PAGE_OUTLINE)
+    # Outline — top (before ear)
+    for x in range(px0 + 4, px1 - ear):
+        _set_pixel(canvas, x, py0, _PAGE_OUTLINE)
+    # Dog-ear diagonal
+    for i in range(ear + 1):
+        _set_pixel(canvas, px1 - ear + i, py0 + i, _PAGE_OUTLINE)
+    # Dog-ear horizontal crease
+    for x in range(px1 - ear, px1):
+        _set_pixel(canvas, x, py0 + ear, _PAGE_OUTLINE)
+    # Rounded corners (small arcs)
+    for dx, dy in [(1,3),(2,2),(3,1)]:
+        _set_pixel(canvas, px0 + dx, py0 + dy, _PAGE_OUTLINE)   # top-left
+        _set_pixel(canvas, px0 + dx, py1 - 1 - dy, _PAGE_OUTLINE)  # bottom-left
+        _set_pixel(canvas, px1 - 1 - dx, py1 - 1 - dy, _PAGE_OUTLINE)  # bottom-right
+
+    # Content illustration lines (above banner, in lighter banner color)
+    if content_color:
+        for ly in range(py0 + 55, py0 + 130, 16):
+            _fill_rect(canvas, px0 + 25, ly, px1 - 30, ly + 3, content_color)
+
+    # Banner: bottom 65 rows
+    bx0, by0, bx1, by1 = px0 + 1, py1 - 66, px1 - 1, py1 - 1
+    _fill_rect(canvas, bx0, by0, bx1, by1, banner_color)
+
+    # Text — scale up the 6x8 font by 4x for crisp large rendering
+    font = _FONT_6x8
+    scale = 4
+    tw = _text_width(text, font, spacing=1) * scale
+    tx = bx0 + (bx1 - bx0 - tw) // 2
+    ty = by0 + (by1 - by0 - 8 * scale) // 2
+    for i, ch in enumerate(text):
+        glyph = font.get(ch)
+        if glyph is None:
+            continue
+        for row_i, row in enumerate(glyph):
+            for col_i, bit in enumerate(row):
+                if bit:
+                    _fill_rect(canvas, tx + col_i * scale, ty + row_i * scale,
+                               tx + col_i * scale + scale, ty + row_i * scale + scale,
+                               _BANNER_TEXT)
+        tx += (len(glyph[0]) + 1) * scale
+
+    return canvas
+
+
+# ---------------------------------------------------------------------------
+# Tray icon — amber eject symbol (triangle + bar)
+# ---------------------------------------------------------------------------
+
+
+def _draw_tray_16() -> list[list[T]]:
+    """16x16 tray icon: 'AF' text in a rounded box."""
+    canvas = _new_canvas(16)
+    bg = (245, 245, 245, 255)
+    outline = (60, 60, 60, 220)
+    text_color = (180, 130, 10, 255)
+
+    # Fill entire canvas with background
+    _fill_rect(canvas, 0, 0, 16, 16, bg)
+
+    # Clip 4 corner pixels (1px rounded corners)
+    transparent = (0, 0, 0, 0)
+    for cx, cy in [(0, 0), (15, 0), (0, 15), (15, 15)]:
+        canvas[cy][cx] = transparent
+
+    # 1px outline
+    _draw_outline_rect(canvas, 0, 0, 16, 16, outline)
+    # Re-clear corners over outline
+    for cx, cy in [(0, 0), (15, 0), (0, 15), (15, 15)]:
+        canvas[cy][cx] = transparent
+
+    # Bold "A" glyph 6x10 (2px strokes)
+    _A_6x10 = [
+        [0,0,1,1,0,0],
+        [0,1,1,1,1,0],
+        [1,1,0,0,1,1],
+        [1,1,0,0,1,1],
+        [1,1,0,0,1,1],
+        [1,1,1,1,1,1],
+        [1,1,0,0,1,1],
+        [1,1,0,0,1,1],
+        [1,1,0,0,1,1],
+        [1,1,0,0,1,1],
+    ]
+    # Bold "F" glyph 6x10 (2px strokes)
+    _F_6x10 = [
+        [1,1,1,1,1,1],
+        [1,1,1,1,1,1],
+        [1,1,0,0,0,0],
+        [1,1,0,0,0,0],
+        [1,1,1,1,1,0],
+        [1,1,1,1,1,0],
+        [1,1,0,0,0,0],
+        [1,1,0,0,0,0],
+        [1,1,0,0,0,0],
+        [1,1,0,0,0,0],
+    ]
+
+    # Position: 13px wide (6+1+6), centered in 14px interior (1px border)
+    # x_start = 1 + (14 - 13) // 2 = 1, y_start = 1 + (14 - 10) // 2 = 3
+    x0, y0 = 1, 3
+    for row_i, row in enumerate(_A_6x10):
+        for col_i, bit in enumerate(row):
+            if bit:
+                _set_pixel(canvas, x0 + col_i, y0 + row_i, text_color)
+    x_f = x0 + 6 + 1  # 1px spacing
+    for row_i, row in enumerate(_F_6x10):
+        for col_i, bit in enumerate(row):
+            if bit:
+                _set_pixel(canvas, x_f + col_i, y0 + row_i, text_color)
+
+    return canvas
+
+
+def _draw_tray_32() -> list[list[T]]:
+    """32x32 tray icon: 'AF' text in a rounded box."""
+    canvas = _new_canvas(32)
+    bg = (245, 245, 245, 255)
+    outline = (60, 60, 60, 220)
+    text_color = (180, 130, 10, 255)
+
+    # Fill entire canvas with background
+    _fill_rect(canvas, 0, 0, 32, 32, bg)
+
+    # Clip 2px rounded corners
+    transparent = (0, 0, 0, 0)
+    corners = [(0, 0), (1, 0), (0, 1),
+               (30, 0), (31, 0), (31, 1),
+               (0, 30), (0, 31), (1, 31),
+               (30, 31), (31, 31), (31, 30)]
+    for cx, cy in corners:
+        canvas[cy][cx] = transparent
+
+    # 1px outline
+    _draw_outline_rect(canvas, 0, 0, 32, 32, outline)
+    # Re-clear corners over outline
+    for cx, cy in corners:
+        canvas[cy][cx] = transparent
+
+    # Scale 6x10 glyphs by 2x -> 12x20 per letter, 2px spacing = 26px wide
+    # Centered in 30px interior: (30-26)//2 = 2, so x_start = 1 + 2 = 3
+    # Vertically: (30-20)//2 = 5, so y_start = 1 + 5 = 6
+    _A_6x10 = [
+        [0,0,1,1,0,0],
+        [0,1,1,1,1,0],
+        [1,1,0,0,1,1],
+        [1,1,0,0,1,1],
+        [1,1,0,0,1,1],
+        [1,1,1,1,1,1],
+        [1,1,0,0,1,1],
+        [1,1,0,0,1,1],
+        [1,1,0,0,1,1],
+        [1,1,0,0,1,1],
+    ]
+    _F_6x10 = [
+        [1,1,1,1,1,1],
+        [1,1,1,1,1,1],
+        [1,1,0,0,0,0],
+        [1,1,0,0,0,0],
+        [1,1,1,1,1,0],
+        [1,1,1,1,1,0],
+        [1,1,0,0,0,0],
+        [1,1,0,0,0,0],
+        [1,1,0,0,0,0],
+        [1,1,0,0,0,0],
+    ]
+
+    scale = 2
+    x0, y0 = 3, 6
+    for glyph, gx in [(_A_6x10, x0), (_F_6x10, x0 + 12 + 2)]:
+        for row_i, row in enumerate(glyph):
+            for col_i, bit in enumerate(row):
+                if bit:
+                    _fill_rect(canvas, gx + col_i * scale, y0 + row_i * scale,
+                               gx + col_i * scale + scale, y0 + row_i * scale + scale,
+                               text_color)
+
+    return canvas
+
+
+def _canvas_to_bgra(canvas: list[list[T]]) -> bytes:
+    """Convert RGBA canvas to BGRA bytes (bottom-up for BMP)."""
+    size = len(canvas)
+    rows = []
+    for y in range(size - 1, -1, -1):  # bottom-up
+        for x in range(size):
+            r, g, b, a = canvas[y][x]
+            rows.append(struct.pack("BBBB", b, g, r, a))
+    return b"".join(rows)
+
+
+def _canvas_to_rgba_topdown(canvas: list[list[T]]) -> bytes:
+    """Convert RGBA canvas to RGBA bytes (top-down for PNG)."""
+    parts = []
+    for row in canvas:
+        for r, g, b, a in row:
+            parts.append(struct.pack("BBBB", r, g, b, a))
+    return b"".join(parts)
+
+
+def _make_png(canvas: list[list[T]]) -> bytes:
+    """Create a PNG file from an RGBA canvas."""
+    size = len(canvas)
+    # Build raw scanlines: filter byte 0 + RGBA row data
+    raw = bytearray()
+    for row in canvas:
+        raw.append(0)  # filter: None
+        for r, g, b, a in row:
+            raw.extend((r, g, b, a))
+    compressed = zlib.compress(bytes(raw))
+
+    def _chunk(chunk_type: bytes, data: bytes) -> bytes:
+        c = chunk_type + data
+        return struct.pack(">I", len(data)) + c + struct.pack(">I", zlib.crc32(c) & 0xFFFFFFFF)
+
+    ihdr_data = struct.pack(">IIBBBBB", size, size, 8, 6, 0, 0, 0)
+    # 8=bit depth, 6=RGBA, 0=compression, 0=filter, 0=interlace
+
+    return (
+        b"\x89PNG\r\n\x1a\n"
+        + _chunk(b"IHDR", ihdr_data)
+        + _chunk(b"IDAT", compressed)
+        + _chunk(b"IEND", b"")
+    )
+
+
+def _make_bmp_entry(canvas: list[list[T]]) -> bytes:
+    """Create a BMP DIB for an ICO entry from an RGBA canvas."""
+    size = len(canvas)
+    bgra = _canvas_to_bgra(canvas)
+    bih = struct.pack(
+        "<IiiHHIIiiII",
+        40, size, size * 2, 1, 32, 0, 0, 0, 0, 0, 0,
+    )
+    mask_row_bytes = (size + 31) // 32 * 4
+    mask = b"\x00" * mask_row_bytes * size
+    return bih + bgra + mask
+
+
+def _make_ico(icon_type: str) -> bytes:
+    """Generate a multi-resolution ICO file for the given type."""
+    if icon_type == "hdf":
+        banner, text = _HDF_BANNER, "HDF"
+        content_color = (232, 195, 90, 80)  # light amber, semi-transparent
+        canvases = {
+            16: _draw_page_icon_16(banner, text),
+            32: _draw_page_icon_32(banner, text),
+            48: _draw_page_icon_48(banner, text),
+            256: _draw_page_icon_256(banner, text, content_color),
+        }
+    elif icon_type == "adf":
+        banner, text = _ADF_BANNER, "ADF"
+        content_color = (100, 200, 150, 80)  # light green, semi-transparent
+        canvases = {
+            16: _draw_page_icon_16(banner, text),
+            32: _draw_page_icon_32(banner, text),
+            48: _draw_page_icon_48(banner, text),
+            256: _draw_page_icon_256(banner, text, content_color),
+        }
+    elif icon_type == "tray":
+        canvases = {
+            16: _draw_tray_16(),
+            32: _draw_tray_32(),
+        }
+    else:
+        raise ValueError(f"Unknown icon type: {icon_type}")
+
+    entries: list[tuple[int, bytes]] = []
+    for size in sorted(canvases):
+        if size == 256:
+            entries.append((size, _make_png(canvases[size])))
+        else:
+            entries.append((size, _make_bmp_entry(canvases[size])))
+
+    header = struct.pack("<HHH", 0, 1, len(entries))
+    offset = 6 + 16 * len(entries)
+    directory = b""
+    image_data = b""
+
+    for size, data in entries:
+        w = size if size < 256 else 0
+        h = size if size < 256 else 0
+        directory += struct.pack(
+            "<BBBBHHII",
+            w, h, 0, 0, 1, 32, len(data), offset,
+        )
+        image_data += data
+        offset += len(data)
+
+    return header + directory + image_data
+
+
+_ICON_SPECS = {
+    "diskimage.ico": "hdf",
+    "floppyimage.ico": "adf",
+    "tray.ico": "tray",
+}
+
+
+def _install_icons() -> None:
+    """Write icon files and launcher script to APPDATA."""
+    import tempfile
+
+    ICON_DIR.mkdir(parents=True, exist_ok=True)
+    for name, icon_type in _ICON_SPECS.items():
+        path = ICON_DIR / name
+        data = _make_ico(icon_type)
+        try:
+            path.write_bytes(data)
+        except PermissionError:
+            # File may be locked by Explorer; write to temp and atomic-rename
+            try:
+                fd, tmp = tempfile.mkstemp(dir=ICON_DIR, suffix=".ico")
+                os.write(fd, data)
+                os.close(fd)
+                os.replace(tmp, path)
+            except OSError as exc:
+                logger.warning("Could not update icon %s (locked): %s", path, exc)
+                # Clean up temp file if rename failed
+                try:
+                    os.unlink(tmp)
+                except OSError:
+                    pass
+                continue
+        logger.info("Installed icon %s", path)
+    # VBS launcher for invisible context-menu invocation
+    _LAUNCH_VBS.write_text(_LAUNCH_VBS_CONTENT, encoding="utf-8")
+    logger.info("Installed launcher %s", _LAUNCH_VBS)
+
+
+def _remove_icons() -> None:
+    """Delete icon files, launcher script, and clean up empty directories."""
+    for name in _ICON_SPECS:
+        path = ICON_DIR / name
+        try:
+            path.unlink()
+            logger.info("Removed icon %s", path)
+        except FileNotFoundError:
+            pass
+        except (PermissionError, OSError) as exc:
+            logger.warning("Could not remove icon %s (locked): %s", path, exc)
+
+    try:
+        _LAUNCH_VBS.unlink()
+        logger.info("Removed launcher %s", _LAUNCH_VBS)
+    except FileNotFoundError:
+        pass
+    except (PermissionError, OSError) as exc:
+        logger.warning("Could not remove launcher %s: %s", _LAUNCH_VBS, exc)
+
+    # Clean up empty dirs (may fail if files remain due to locks)
+    for d in (ICON_DIR, ICON_DIR.parent):
+        try:
+            d.rmdir()
+        except OSError:
+            break
+
+
+# ---------------------------------------------------------------------------
+# Shell notification
+# ---------------------------------------------------------------------------
+
+
+def _notify_shell_change() -> None:
+    """Tell Explorer that file associations have changed."""
+    import ctypes
+
+    SHCNE_ASSOCCHANGED = 0x08000000
+    SHCNF_IDLIST = 0x0000
+    ctypes.windll.shell32.SHChangeNotify(
+        SHCNE_ASSOCCHANGED, SHCNF_IDLIST, None, None
+    )

--- a/amifuse/windows_shell.py
+++ b/amifuse/windows_shell.py
@@ -29,7 +29,16 @@ Set a = WScript.Arguments
 cmd = ""
 For i = 0 To a.Count - 1
     If i > 0 Then cmd = cmd & " "
-    cmd = cmd & """" & a(i) & """"
+    s = a(i)
+    s = Replace(s, """", """""")
+    ' Double trailing backslashes (MSVCRT: 2N \\ + " = N \\ + end-of-arg)
+    j = Len(s)
+    Do While j > 0
+        If Mid(s, j, 1) <> "\\" Then Exit Do
+        j = j - 1
+    Loop
+    s = s & String(Len(s) - j, "\\")
+    cmd = cmd & """" & s & """"
 Next
 CreateObject("WScript.Shell").Run cmd, 0, False
 '''
@@ -44,6 +53,8 @@ def register(extensions: list[str] | None = None) -> None:
     """Register file associations and context menu verbs for AmiFUSE."""
     if not sys.platform.startswith("win"):
         raise SystemExit("Shell registration is only supported on Windows.")
+    if not os.environ.get("APPDATA"):
+        raise SystemExit("APPDATA environment variable is not set. Cannot determine icon/config directory.")
 
     import winreg
 
@@ -73,6 +84,8 @@ def unregister(extensions: list[str] | None = None) -> None:
     """Remove AmiFUSE file associations and context menu verbs."""
     if not sys.platform.startswith("win"):
         raise SystemExit("Shell registration is only supported on Windows.")
+    if not os.environ.get("APPDATA"):
+        raise SystemExit("APPDATA environment variable is not set. Cannot determine icon/config directory.")
 
     import winreg
 
@@ -187,10 +200,19 @@ def _register_extension(winreg, ext: str, progid: str) -> None:
         winreg.CloseKey(owp_key)
 
 
+def _ensure_vbs_launcher() -> None:
+    """Write the VBS launcher, overwriting any existing file."""
+    _LAUNCH_VBS.parent.mkdir(parents=True, exist_ok=True)
+    _LAUNCH_VBS.write_text(_LAUNCH_VBS_CONTENT, encoding="utf-8")
+
+
 def _register_progid(winreg, progid: str, launcher: str) -> None:
     """Create ProgID with flat verb entries and icon."""
     base = rf"Software\Classes\{progid}"
     description = PROGID_DESCRIPTIONS[progid]
+
+    # Ensure VBS launcher exists with expected content before referencing it
+    _ensure_vbs_launcher()
 
     # (Default) = description
     key = winreg.CreateKey(winreg.HKEY_CURRENT_USER, base)

--- a/amifuse/windows_shell.py
+++ b/amifuse/windows_shell.py
@@ -133,6 +133,22 @@ def _resolve_extensions(extensions: list[str] | None) -> list[str]:
 
 
 def _get_launcher_path() -> str:
+    import shutil
+    import sysconfig
+    found = shutil.which("amifuse-launcher")
+    if found:
+        return found
+    candidate = Path(sys.executable).parent / "amifuse-launcher.exe"
+    if candidate.exists():
+        return str(candidate)
+    for scheme in (None, "nt_user"):
+        try:
+            scripts = Path(sysconfig.get_path("scripts", scheme))
+        except KeyError:
+            continue
+        candidate = scripts / "amifuse-launcher.exe"
+        if candidate.exists():
+            return str(candidate)
     return str(Path(sys.executable).parent / "amifuse-launcher.exe")
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,10 @@ amifuse = "amifuse.fuse_fs:main"
 rdb-inspect = "amifuse.rdb_inspect:main"
 driver-info = "amifuse.driver_info:main"
 
+[project.gui-scripts]
+amifuse-launcher = "amifuse.launcher:main"
+amifuse-tray = "amifuse.tray:main"
+
 [project.urls]
 Homepage = "https://github.com/reinauer/amifuse"
 
@@ -41,6 +45,10 @@ test = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
     "pytest-timeout>=2.0",
+]
+windows = [
+    "pystray>=0.19",
+    "Pillow>=9.0",
 ]
 
 [tool.pytest.ini_options]

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -211,6 +211,11 @@ def mount_image(fuse_available, tmp_path):
             ),
         )
 
+        # Cache parent device ID for Unix mount detection (st_dev changes
+        # when FUSE attaches).
+        if not sys.platform.startswith("win"):
+            parent_dev = os.stat(os.path.dirname(str(mountpoint))).st_dev
+
         # Poll until mount is detected or timeout
         deadline = time.monotonic() + timeout
         mounted = False
@@ -223,11 +228,22 @@ def mount_image(fuse_available, tmp_path):
                     f"Mount process exited early (rc={proc.returncode}).\n"
                     f"stdout: {stdout}\nstderr: {stderr}"
                 )
-            # On Windows, ismount detects the drive letter before the
-            # filesystem is fully initialized. Use listdir as the
-            # authoritative readiness check on all platforms.
+            # Platform-aware readiness detection:
+            # - Windows: drive letter doesn't exist until WinFSP creates it,
+            #   so listdir not throwing means the mount appeared.
+            # - Unix: mountpoint directory already exists, so listdir would
+            #   succeed immediately. Instead check st_dev -- FUSE attaches a
+            #   new device, so st_dev will differ from the parent directory.
             try:
-                os.listdir(str(mountpoint))
+                if sys.platform.startswith("win"):
+                    os.listdir(str(mountpoint))
+                else:
+                    if os.stat(str(mountpoint)).st_dev != parent_dev:
+                        mounted = True
+                        break
+                    else:
+                        time.sleep(_MOUNT_POLL_INTERVAL)
+                        continue
                 mounted = True
                 break
             except OSError:
@@ -235,12 +251,14 @@ def mount_image(fuse_available, tmp_path):
             time.sleep(_MOUNT_POLL_INTERVAL)
 
         if not mounted:
-            # Clean up the failed mount attempt
+            # Clean up the failed mount attempt and capture diagnostics
             proc.kill()
             proc.wait(timeout=_PROCESS_KILL_TIMEOUT)
+            stdout = proc.stdout.read().decode(errors="replace")
+            stderr = proc.stderr.read().decode(errors="replace")
             raise RuntimeError(
-                f"Mount not detected at {mountpoint} within {timeout}s. "
-                f"Process still running: {proc.poll() is None}"
+                f"Mount not detected at {mountpoint} within {timeout}s.\n"
+                f"stdout: {stdout}\nstderr: {stderr}"
             )
 
         _active_mounts.append((proc, mountpoint))

--- a/tests/integration/test_detached_process.py
+++ b/tests/integration/test_detached_process.py
@@ -1,0 +1,71 @@
+"""Integration tests for detached process lifecycle."""
+
+import os
+import subprocess
+import sys
+import time
+
+import pytest
+
+pytestmark = [
+    pytest.mark.skipif(sys.platform != "win32", reason="Windows-only"),
+    pytest.mark.windows,
+]
+
+DETACHED_FLAGS = 0x00000008 | 0x00000200 | 0x08000000  # DETACHED | NEW_GROUP | NO_WINDOW
+
+
+class TestDetachedProcess:
+    """Real OS-level detached process tests."""
+
+    def test_detached_process_detected_by_pid_exists(self):
+        """A detached process should be visible to _pid_exists()."""
+        from amifuse.platform import _pid_exists
+
+        proc = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(30)"],
+            creationflags=DETACHED_FLAGS,
+        )
+        try:
+            assert _pid_exists(proc.pid)
+        finally:
+            proc.kill()
+            proc.wait(timeout=5)
+
+    def test_kill_pids_terminates_detached_process(self):
+        """kill_pids() should terminate a detached process (graceful then force)."""
+        from amifuse.platform import _pid_exists, kill_pids
+
+        proc = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(60)"],
+            creationflags=DETACHED_FLAGS,
+        )
+        pid = proc.pid
+        try:
+            assert _pid_exists(pid)
+            killed = kill_pids([pid], timeout=3.0)
+            assert pid in killed
+            # Verify process actually exited
+            retcode = proc.wait(timeout=5)
+            assert retcode is not None, "Process did not exit after kill_pids"
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=5)
+
+    def test_pid_exists_false_for_dead_process(self):
+        """_pid_exists() should return False for a terminated process."""
+        from amifuse.platform import _pid_exists
+
+        proc = subprocess.Popen(
+            [sys.executable, "-c", "pass"],
+            creationflags=DETACHED_FLAGS,
+        )
+        proc.wait(timeout=5)
+        pid = proc.pid
+        # Release the Popen handle so Windows can fully reclaim the PID
+        del proc
+
+        time.sleep(0.5)
+
+        assert not _pid_exists(pid)

--- a/tests/integration/test_launcher_e2e.py
+++ b/tests/integration/test_launcher_e2e.py
@@ -1,0 +1,145 @@
+"""End-to-end launcher tests (require WinFSP and test fixtures)."""
+
+import os
+import subprocess
+import sys
+import time
+
+import pytest
+
+pytestmark = [
+    pytest.mark.skipif(sys.platform != "win32", reason="Windows-only"),
+    pytest.mark.fuse,
+    pytest.mark.slow,
+    pytest.mark.integration,
+]
+
+DETACHED_FLAGS = 0x00000008 | 0x00000200 | 0x08000000
+
+
+@pytest.fixture(autouse=True)
+def require_winfsp():
+    """Skip if WinFSP is not installed."""
+    try:
+        from amifuse.platform import _get_winfsp_install_dir
+        if not _get_winfsp_install_dir():
+            pytest.skip("WinFSP not installed")
+    except Exception:
+        pytest.skip("WinFSP not available")
+
+
+def _find_free_drive() -> str:
+    """Find first available drive letter, return as 'X:'."""
+    for letter in "ZYXWVUTSRQPONMLKJIHGFED":
+        drive = f"{letter}:"
+        if not os.path.exists(drive + "\\"):
+            return drive
+    pytest.skip("No free drive letter available")
+
+
+def _wait_for_mount(drive: str, timeout: float = 15.0) -> bool:
+    """Wait until os.listdir(drive) succeeds (filesystem ready)."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            os.listdir(drive + "\\")
+            return True
+        except OSError:
+            time.sleep(0.5)
+    return False
+
+
+def _wait_for_unmount(drive: str, timeout: float = 10.0) -> bool:
+    """Wait until drive letter disappears."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if not os.path.exists(drive + "\\"):
+            return True
+        time.sleep(0.5)
+    return False
+
+
+class TestLauncherE2E:
+    """Full mount/unmount cycle tests."""
+
+    def test_launcher_mount_creates_drive_letter(self, ofs_adf_image):
+        """Mounting a test image should make a drive letter appear."""
+        from amifuse.platform import kill_pids
+
+        drive = _find_free_drive()
+        proc = subprocess.Popen(
+            [
+                sys.executable, "-m", "amifuse", "mount",
+                "--mountpoint", drive,
+                str(ofs_adf_image),
+            ],
+            creationflags=DETACHED_FLAGS,
+        )
+        try:
+            assert _wait_for_mount(drive), f"Drive {drive} did not become ready"
+        finally:
+            kill_pids([proc.pid], timeout=5.0)
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=5)
+            _wait_for_unmount(drive)
+
+    def test_launcher_mount_visible_in_status(self, ofs_adf_image):
+        """After mounting, find_amifuse_mounts() should include the mount."""
+        from amifuse.platform import find_amifuse_mounts, kill_pids
+
+        drive = _find_free_drive()
+        proc = subprocess.Popen(
+            [
+                sys.executable, "-m", "amifuse", "mount",
+                "--mountpoint", drive,
+                str(ofs_adf_image),
+            ],
+            creationflags=DETACHED_FLAGS,
+        )
+        try:
+            assert _wait_for_mount(drive), f"Drive {drive} did not become ready"
+
+            mounts = find_amifuse_mounts()
+            mountpoints = [m["mountpoint"] for m in mounts]
+            assert drive in mountpoints, (
+                f"Expected {drive} in mounts, got: {mountpoints}"
+            )
+        finally:
+            kill_pids([proc.pid], timeout=5.0)
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=5)
+            _wait_for_unmount(drive)
+
+    def test_launcher_unmount_cleans_up(self, ofs_adf_image):
+        """After kill_pids, drive letter should disappear."""
+        from amifuse.platform import kill_pids
+
+        drive = _find_free_drive()
+        proc = subprocess.Popen(
+            [
+                sys.executable, "-m", "amifuse", "mount",
+                "--mountpoint", drive,
+                str(ofs_adf_image),
+            ],
+            creationflags=DETACHED_FLAGS,
+        )
+        try:
+            assert _wait_for_mount(drive), f"Drive {drive} did not become ready"
+        except AssertionError:
+            # Clean up even if mount failed
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=5)
+            raise
+
+        killed = kill_pids([proc.pid], timeout=5.0)
+        assert proc.pid in killed
+
+        assert _wait_for_unmount(drive), f"Drive {drive} did not disappear after unmount"
+
+        # Final safety net
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=5)

--- a/tests/integration/test_launcher_e2e.py
+++ b/tests/integration/test_launcher_e2e.py
@@ -62,7 +62,7 @@ def _wait_for_unmount(drive: str, timeout: float = 10.0) -> bool:
 class TestLauncherE2E:
     """Full mount/unmount cycle tests."""
 
-    def test_launcher_mount_creates_drive_letter(self, ofs_adf_image):
+    def test_launcher_mount_creates_drive_letter(self, pfs3_image, pfs3_driver):
         """Mounting a test image should make a drive letter appear."""
         from amifuse.platform import kill_pids
 
@@ -71,9 +71,12 @@ class TestLauncherE2E:
             [
                 sys.executable, "-m", "amifuse", "mount",
                 "--mountpoint", drive,
-                str(ofs_adf_image),
+                "--driver", str(pfs3_driver),
+                str(pfs3_image),
             ],
             creationflags=DETACHED_FLAGS,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
         )
         try:
             assert _wait_for_mount(drive), f"Drive {drive} did not become ready"
@@ -84,7 +87,7 @@ class TestLauncherE2E:
                 proc.wait(timeout=5)
             _wait_for_unmount(drive)
 
-    def test_launcher_mount_visible_in_status(self, ofs_adf_image):
+    def test_launcher_mount_visible_in_status(self, pfs3_image, pfs3_driver):
         """After mounting, find_amifuse_mounts() should include the mount."""
         from amifuse.platform import find_amifuse_mounts, kill_pids
 
@@ -93,9 +96,12 @@ class TestLauncherE2E:
             [
                 sys.executable, "-m", "amifuse", "mount",
                 "--mountpoint", drive,
-                str(ofs_adf_image),
+                "--driver", str(pfs3_driver),
+                str(pfs3_image),
             ],
             creationflags=DETACHED_FLAGS,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
         )
         try:
             assert _wait_for_mount(drive), f"Drive {drive} did not become ready"
@@ -112,7 +118,7 @@ class TestLauncherE2E:
                 proc.wait(timeout=5)
             _wait_for_unmount(drive)
 
-    def test_launcher_unmount_cleans_up(self, ofs_adf_image):
+    def test_launcher_unmount_cleans_up(self, pfs3_image, pfs3_driver):
         """After kill_pids, drive letter should disappear."""
         from amifuse.platform import kill_pids
 
@@ -121,9 +127,12 @@ class TestLauncherE2E:
             [
                 sys.executable, "-m", "amifuse", "mount",
                 "--mountpoint", drive,
-                str(ofs_adf_image),
+                "--driver", str(pfs3_driver),
+                str(pfs3_image),
             ],
             creationflags=DETACHED_FLAGS,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
         )
         try:
             assert _wait_for_mount(drive), f"Drive {drive} did not become ready"

--- a/tests/integration/test_launcher_e2e.py
+++ b/tests/integration/test_launcher_e2e.py
@@ -19,7 +19,13 @@ DETACHED_FLAGS = 0x00000008 | 0x00000200 | 0x08000000
 
 @pytest.fixture(autouse=True)
 def require_winfsp():
-    """Skip if WinFSP is not installed."""
+    """Skip if WinFSP or fusepy is not installed."""
+    try:
+        from fuse import FUSE  # noqa: F401
+    except ImportError:
+        pytest.skip("fusepy not installed")
+    except EnvironmentError as exc:
+        pytest.skip(f"FUSE backend not available: {exc}")
     try:
         from amifuse.platform import _get_winfsp_install_dir
         if not _get_winfsp_install_dir():

--- a/tests/integration/test_mount_lifecycle.py
+++ b/tests/integration/test_mount_lifecycle.py
@@ -147,16 +147,22 @@ def test_unmount_cleans_up(mount_image, pfs3_image, pfs3_driver):
         proc.wait(timeout=5)
 
     # Poll until unmount detected
-    # On Windows, os.path.ismount on a drive letter may remain True briefly
-    # after the FUSE process exits. Use listdir failure as the signal.
     deadline = time.monotonic() + 10.0
     unmounted = False
     while time.monotonic() < deadline:
-        try:
-            os.listdir(mp_str)
-        except OSError:
-            unmounted = True
-            break
+        if sys.platform.startswith("win"):
+            # Windows: drive letter disappears, listdir throws
+            try:
+                os.listdir(mp_str)
+            except OSError:
+                unmounted = True
+                break
+        else:
+            # Unix: mountpoint reverts to empty dir after FUSE detaches,
+            # so listdir won't throw. Use ismount (st_dev comparison).
+            if not os.path.ismount(mp_str):
+                unmounted = True
+                break
         time.sleep(0.5)
 
     assert unmounted, (

--- a/tests/integration/test_windows_shell_integration.py
+++ b/tests/integration/test_windows_shell_integration.py
@@ -1,0 +1,161 @@
+"""Integration tests for Windows shell registration (real registry)."""
+
+import sys
+import pytest
+
+pytestmark = [
+    pytest.mark.skipif(sys.platform != "win32", reason="Windows-only"),
+    pytest.mark.windows,
+]
+
+
+@pytest.fixture(scope="session")
+def registry_snapshot():
+    """Snapshot relevant HKCU keys before tests, restore after all tests."""
+    import winreg
+
+    KEY_PATHS = [
+        r"Software\Classes\.hdf",
+        r"Software\Classes\.adf",
+        r"Software\Classes\AmiFUSE.DiskImage",
+        r"Software\Classes\AmiFUSE.FloppyImage",
+    ]
+
+    def _snapshot_key(path):
+        """Return (exists, {values}, [subkeys]) or (False, {}, [])."""
+        try:
+            key = winreg.OpenKey(winreg.HKEY_CURRENT_USER, path, 0, winreg.KEY_READ)
+        except OSError:
+            return (False, {}, [])
+        values = {}
+        try:
+            i = 0
+            while True:
+                try:
+                    name, data, typ = winreg.EnumValue(key, i)
+                    values[name] = (data, typ)
+                    i += 1
+                except OSError:
+                    break
+        finally:
+            winreg.CloseKey(key)
+        return (True, values, [])
+
+    snapshots = {p: _snapshot_key(p) for p in KEY_PATHS}
+    yield
+    # Restore: delete any keys we created, leave pre-existing ones alone
+    for path, (existed, _values, _subkeys) in snapshots.items():
+        if not existed:
+            # Key didn't exist before -- remove it if it exists now
+            from amifuse.windows_shell import _delete_key_recursive
+            _delete_key_recursive(winreg.HKEY_CURRENT_USER, path)
+
+
+@pytest.fixture(autouse=True)
+def clean_registration(registry_snapshot):
+    """Ensure clean state before/after each test."""
+    from amifuse.windows_shell import unregister
+    try:
+        unregister()
+    except Exception:
+        pass
+    yield
+    try:
+        unregister()
+    except Exception:
+        pass
+
+
+class TestWindowsShellRegistration:
+    """Real registry round-trip tests using HKCU (no elevation needed)."""
+
+    def test_register_creates_progid_key(self):
+        """register() should create the AmiFUSE.DiskImage ProgID key."""
+        import winreg
+        from amifuse.windows_shell import register
+
+        register()
+
+        key = winreg.OpenKey(
+            winreg.HKEY_CURRENT_USER,
+            r"Software\Classes\AmiFUSE.DiskImage",
+            0,
+            winreg.KEY_READ,
+        )
+        try:
+            value, _ = winreg.QueryValueEx(key, "")
+            assert value == "Amiga Disk Image"
+        finally:
+            winreg.CloseKey(key)
+
+    def test_register_creates_file_associations(self):
+        """register() should add .hdf to OpenWithProgids."""
+        import winreg
+        from amifuse.windows_shell import register
+
+        register()
+
+        key = winreg.OpenKey(
+            winreg.HKEY_CURRENT_USER,
+            r"Software\Classes\.hdf\OpenWithProgids",
+            0,
+            winreg.KEY_READ,
+        )
+        try:
+            # Should not raise -- value exists
+            winreg.QueryValueEx(key, "AmiFUSE.DiskImage")
+        finally:
+            winreg.CloseKey(key)
+
+    def test_register_installs_icon_files(self):
+        """register() should create icon files under APPDATA/AmiFUSE/icons/."""
+        from amifuse.windows_shell import register, ICON_DIR
+
+        register()
+
+        assert (ICON_DIR / "diskimage.ico").exists()
+        assert (ICON_DIR / "floppyimage.ico").exists()
+
+    def test_register_idempotent(self):
+        """Calling register() twice should not error and keys remain correct."""
+        import winreg
+        from amifuse.windows_shell import register
+
+        register()
+        register()  # second call -- should not raise
+
+        key = winreg.OpenKey(
+            winreg.HKEY_CURRENT_USER,
+            r"Software\Classes\AmiFUSE.DiskImage",
+            0,
+            winreg.KEY_READ,
+        )
+        try:
+            value, _ = winreg.QueryValueEx(key, "")
+            assert value == "Amiga Disk Image"
+        finally:
+            winreg.CloseKey(key)
+
+    def test_unregister_removes_keys_and_icons(self):
+        """register() then unregister() should remove ProgID key and icons."""
+        import winreg
+        from amifuse.windows_shell import register, unregister, ICON_DIR
+
+        register()
+        # Verify precondition
+        assert (ICON_DIR / "diskimage.ico").exists()
+
+        unregister()
+
+        # ProgID key should be gone
+        with pytest.raises(OSError):
+            winreg.OpenKey(
+                winreg.HKEY_CURRENT_USER,
+                r"Software\Classes\AmiFUSE.DiskImage",
+                0,
+                winreg.KEY_READ,
+            )
+
+        # Icons should be removed
+        assert not (ICON_DIR / "diskimage.ico").exists()
+        assert not (ICON_DIR / "floppyimage.ico").exists()

--- a/tests/unit/test_cli_help.py
+++ b/tests/unit/test_cli_help.py
@@ -36,6 +36,7 @@ def _run_amifuse(*args: str, timeout: float = 30.0) -> subprocess.CompletedProce
 ALL_SUBCOMMANDS = [
     "inspect", "mount", "unmount", "doctor", "format",
     "ls", "verify", "hash", "read", "write",
+    "register", "unregister",
 ]
 
 

--- a/tests/unit/test_fuse_fs.py
+++ b/tests/unit/test_fuse_fs.py
@@ -250,27 +250,6 @@ class TestMountFuseOptions:
         assert kwargs is not None, "FUSE was not called"
         assert kwargs["foreground"] is True
 
-    def test_mount_rejects_daemon_mode_without_unmount_command(
-        self, monkeypatch, mock_mount_fuse_deps
-    ):
-        """Background mode is rejected if the platform cannot unmount it later."""
-        monkeypatch.setattr("sys.platform", "win32")
-        import amifuse.platform as plat_mod
-        from amifuse.fuse_fs import mount_fuse
-
-        monkeypatch.setattr(plat_mod, "get_unmount_command", lambda mp: [])
-
-        with pytest.raises(SystemExit) as exc_info:
-            mount_fuse(
-                image=Path("/tmp/test.hdf"),
-                driver=None,
-                mountpoint=None,
-                block_size=None,
-                foreground=False,
-            )
-
-        assert "Daemon mode is not supported" in str(exc_info.value)
-
     def test_mount_aborts_if_handler_crashes_before_fuse_starts(self, monkeypatch, fuse_mock):
         import amifuse.fuse_fs as fuse_fs_mod
 
@@ -368,7 +347,7 @@ class TestUnmountCommand:
         )
         called = {}
 
-        def fake_run(cmd, check=False):
+        def fake_run(cmd, check=False, **kwargs):
             called["cmd"] = cmd
             called["check"] = check
             return argparse.Namespace(returncode=0)
@@ -442,7 +421,7 @@ class TestUnmountCommand:
         )
         called = {}
 
-        def fake_run(cmd, check=False):
+        def fake_run(cmd, check=False, **kwargs):
             called["cmd"] = cmd
             return argparse.Namespace(returncode=0)
 
@@ -464,11 +443,11 @@ class TestUnmountCommand:
 
         run_calls = {"unmount": 0}
 
-        def fake_run(cmd, check=False, capture_output=False, text=False):
+        def fake_run(cmd, check=False, capture_output=False, text=False, **kwargs):
             if cmd[:2] == ["ps", "-axo"]:
                 return argparse.Namespace(
                     returncode=0,
-                    stdout="123 python3 -m amifuse mount disk.iso --mountpoint ./mnt\n",
+                    stdout="123  1 python3 -m amifuse mount disk.iso --mountpoint ./mnt\n",
                 )
             run_calls["unmount"] += 1
             return argparse.Namespace(returncode=1 if run_calls["unmount"] == 1 else 0)
@@ -479,15 +458,19 @@ class TestUnmountCommand:
             if sig != 0:
                 killed.append((pid, sig))
             else:
-                if any(saved_pid == pid and saved_sig == fuse_fs_mod._SIGKILL for saved_pid, saved_sig in killed):
+                if any(saved_pid == pid and saved_sig == plat_mod._SIGKILL for saved_pid, saved_sig in killed):
                     raise ProcessLookupError()
 
         import amifuse.fuse_fs as fuse_fs_mod
+        import amifuse.platform as plat_mod
 
         monkeypatch.setattr("sys.platform", "linux")
+        # subprocess.run for unmount is called from fuse_fs, but kill functions
+        # use platform.subprocess.run and platform.os.kill
         monkeypatch.setattr(fuse_fs_mod.subprocess, "run", fake_run)
-        monkeypatch.setattr(fuse_fs_mod.os, "kill", fake_kill)
-        monkeypatch.setattr(fuse_fs_mod.os, "getpid", lambda: 999)
+        monkeypatch.setattr(plat_mod.subprocess, "run", fake_run)
+        monkeypatch.setattr(plat_mod.os, "kill", fake_kill)
+        monkeypatch.setattr(plat_mod.os, "getpid", lambda: 999)
 
         fuse_fs_mod.cmd_unmount(argparse.Namespace(mountpoint=Path("./mnt")))
 
@@ -496,53 +479,64 @@ class TestUnmountCommand:
 
 
 class TestPidExists:
-    """Tests for _pid_exists() cross-platform behaviour."""
+    """Tests for _pid_exists() cross-platform behaviour.
+
+    _pid_exists moved to platform.py in Phase 8.
+    """
 
     def test_pid_exists_returns_true_for_live_process(self, fuse_mock, monkeypatch):
-        import amifuse.fuse_fs as fuse_fs_mod
+        import amifuse.platform as plat_mod
 
-        monkeypatch.setattr(fuse_fs_mod.os, "kill", lambda pid, sig: None)
-        assert fuse_fs_mod._pid_exists(12345) is True
+        monkeypatch.setattr(plat_mod.sys, "platform", "linux")
+        monkeypatch.setattr(plat_mod.os, "kill", lambda pid, sig: None)
+        assert plat_mod._pid_exists(12345) is True
 
     def test_pid_exists_returns_false_for_dead_process(self, fuse_mock, monkeypatch):
-        import amifuse.fuse_fs as fuse_fs_mod
+        import amifuse.platform as plat_mod
+
+        monkeypatch.setattr(plat_mod.sys, "platform", "linux")
 
         def raise_lookup(pid, sig):
             raise ProcessLookupError()
 
-        monkeypatch.setattr(fuse_fs_mod.os, "kill", raise_lookup)
-        assert fuse_fs_mod._pid_exists(12345) is False
+        monkeypatch.setattr(plat_mod.os, "kill", raise_lookup)
+        assert plat_mod._pid_exists(12345) is False
 
     def test_pid_exists_returns_true_on_permission_error(self, fuse_mock, monkeypatch):
-        import amifuse.fuse_fs as fuse_fs_mod
+        import amifuse.platform as plat_mod
+
+        monkeypatch.setattr(plat_mod.sys, "platform", "linux")
 
         def raise_perm(pid, sig):
             raise PermissionError("Access denied")
 
-        monkeypatch.setattr(fuse_fs_mod.os, "kill", raise_perm)
-        assert fuse_fs_mod._pid_exists(12345) is True
+        monkeypatch.setattr(plat_mod.os, "kill", raise_perm)
+        assert plat_mod._pid_exists(12345) is True
 
     def test_pid_exists_returns_false_on_windows_oserror(self, fuse_mock, monkeypatch):
-        """Windows raises generic OSError for invalid PIDs."""
-        import amifuse.fuse_fs as fuse_fs_mod
+        """Generic OSError means process is dead (Unix path)."""
+        import amifuse.platform as plat_mod
+
+        monkeypatch.setattr(plat_mod.sys, "platform", "linux")
 
         def raise_oserror(pid, sig):
             raise OSError(22, "Invalid argument")
 
-        monkeypatch.setattr(fuse_fs_mod.os, "kill", raise_oserror)
-        assert fuse_fs_mod._pid_exists(12345) is False
+        monkeypatch.setattr(plat_mod.os, "kill", raise_oserror)
+        assert plat_mod._pid_exists(12345) is False
 
 
 class TestWindowsProcessDiscovery:
     """Tests for _find_mount_owner_pids() wrapper around platform.find_amifuse_mounts().
 
     The raw wmic/ps parsing has moved to platform.py and is tested in
-    test_status.py. These tests verify the refactored wrapper in fuse_fs.py
+    test_status.py. These tests verify the wrapper in platform.py
     correctly filters by mountpoint and handles errors.
+
+    _find_mount_owner_pids moved to platform.py in Phase 8.
     """
 
     def test_finds_amifuse_pid_from_wmic_output(self, fuse_mock, monkeypatch):
-        import amifuse.fuse_fs as fuse_fs_mod
         import amifuse.platform as plat_mod
 
         monkeypatch.setattr(plat_mod, "find_amifuse_mounts", lambda: [
@@ -550,11 +544,10 @@ class TestWindowsProcessDiscovery:
              "uptime_seconds": None, "filesystem_type": None},
         ])
 
-        pids = fuse_fs_mod._find_mount_owner_pids(Path("Z:"))
+        pids = plat_mod._find_mount_owner_pids(Path("Z:"))
         assert 4567 in pids
 
     def test_excludes_non_matching_mountpoint(self, fuse_mock, monkeypatch):
-        import amifuse.fuse_fs as fuse_fs_mod
         import amifuse.platform as plat_mod
 
         monkeypatch.setattr(plat_mod, "find_amifuse_mounts", lambda: [
@@ -562,33 +555,30 @@ class TestWindowsProcessDiscovery:
              "uptime_seconds": None, "filesystem_type": None},
         ])
 
-        pids = fuse_fs_mod._find_mount_owner_pids(Path("Y:"))
+        pids = plat_mod._find_mount_owner_pids(Path("Y:"))
         assert pids == []
 
     def test_returns_empty_on_discovery_failure(self, fuse_mock, monkeypatch):
-        import amifuse.fuse_fs as fuse_fs_mod
         import amifuse.platform as plat_mod
 
         def _raise():
             raise OSError("wmic not found")
         monkeypatch.setattr(plat_mod, "find_amifuse_mounts", _raise)
 
-        pids = fuse_fs_mod._find_mount_owner_pids(Path("Z:"))
+        pids = plat_mod._find_mount_owner_pids(Path("Z:"))
         assert pids == []
 
     def test_returns_empty_on_oserror(self, fuse_mock, monkeypatch):
-        import amifuse.fuse_fs as fuse_fs_mod
         import amifuse.platform as plat_mod
 
         def _raise():
             raise OSError("ps not found")
         monkeypatch.setattr(plat_mod, "find_amifuse_mounts", _raise)
 
-        pids = fuse_fs_mod._find_mount_owner_pids(Path("Z:"))
+        pids = plat_mod._find_mount_owner_pids(Path("Z:"))
         assert pids == []
 
     def test_filters_multiple_mounts(self, fuse_mock, monkeypatch):
-        import amifuse.fuse_fs as fuse_fs_mod
         import amifuse.platform as plat_mod
 
         monkeypatch.setattr(plat_mod, "find_amifuse_mounts", lambda: [
@@ -600,7 +590,7 @@ class TestWindowsProcessDiscovery:
              "uptime_seconds": None, "filesystem_type": None},
         ])
 
-        pids = fuse_fs_mod._find_mount_owner_pids(Path("Z:"))
+        pids = plat_mod._find_mount_owner_pids(Path("Z:"))
         assert sorted(pids) == [100, 300]
 
 
@@ -1029,44 +1019,42 @@ class TestCommandMatchesMountpoint:
     The _command_matches_mountpoint helper was removed during refactoring.
     Mountpoint matching is now tested through the wrapper. Detailed token
     parsing is covered in test_status.py::TestParseMountTokens.
+
+    _find_mount_owner_pids moved to platform.py in Phase 8.
     """
 
     def test_matches_literal_mountpoint(self, fuse_mock, monkeypatch):
         """Matches when mountpoint value equals the raw mountpoint string."""
-        import amifuse.fuse_fs as fuse_fs_mod
         import amifuse.platform as plat_mod
 
         monkeypatch.setattr(plat_mod, "find_amifuse_mounts", lambda: [
             {"mountpoint": "/mnt/amiga", "image": "disk.hdf", "pid": 42,
              "uptime_seconds": None, "filesystem_type": None},
         ])
-        pids = fuse_fs_mod._find_mount_owner_pids(Path("/mnt/amiga"))
+        pids = plat_mod._find_mount_owner_pids(Path("/mnt/amiga"))
         assert pids == [42]
 
     def test_no_match_different_mountpoint(self, fuse_mock, monkeypatch):
         """Does not match when the mountpoint value differs."""
-        import amifuse.fuse_fs as fuse_fs_mod
         import amifuse.platform as plat_mod
 
         monkeypatch.setattr(plat_mod, "find_amifuse_mounts", lambda: [
             {"mountpoint": "/mnt/other", "image": "disk.hdf", "pid": 42,
              "uptime_seconds": None, "filesystem_type": None},
         ])
-        pids = fuse_fs_mod._find_mount_owner_pids(Path("/mnt/amiga"))
+        pids = plat_mod._find_mount_owner_pids(Path("/mnt/amiga"))
         assert pids == []
 
     def test_no_match_empty_mounts(self, fuse_mock, monkeypatch):
         """Returns empty when no mounts are active."""
-        import amifuse.fuse_fs as fuse_fs_mod
         import amifuse.platform as plat_mod
 
         monkeypatch.setattr(plat_mod, "find_amifuse_mounts", lambda: [])
-        pids = fuse_fs_mod._find_mount_owner_pids(Path("/mnt/amiga"))
+        pids = plat_mod._find_mount_owner_pids(Path("/mnt/amiga"))
         assert pids == []
 
     def test_matches_resolved_path(self, fuse_mock, monkeypatch, tmp_path):
         """Matches when the mountpoint arg resolves to the same absolute path."""
-        import amifuse.fuse_fs as fuse_fs_mod
         import amifuse.platform as plat_mod
 
         abs_mp = str(tmp_path / "amiga")
@@ -1074,29 +1062,32 @@ class TestCommandMatchesMountpoint:
             {"mountpoint": abs_mp, "image": "disk.hdf", "pid": 42,
              "uptime_seconds": None, "filesystem_type": None},
         ])
-        pids = fuse_fs_mod._find_mount_owner_pids(Path(abs_mp))
+        pids = plat_mod._find_mount_owner_pids(Path(abs_mp))
         assert pids == [42]
 
 
 class TestKillEscalation:
-    """Tests for _kill_mount_owner_processes() edge cases."""
+    """Tests for _kill_mount_owner_processes() edge cases.
+
+    _kill_mount_owner_processes moved to platform.py in Phase 8.
+    """
 
     def test_oserror_during_sigterm_does_not_crash(self, fuse_mock, monkeypatch):
         """OSError(22) during SIGTERM is caught and the process is skipped."""
-        import amifuse.fuse_fs as fuse_fs_mod
+        import amifuse.platform as plat_mod
 
         monkeypatch.setattr(
-            fuse_fs_mod, "_find_mount_owner_pids", lambda mp: [1234]
+            plat_mod, "_find_mount_owner_pids", lambda mp: [1234]
         )
 
         def fake_kill(pid, sig):
             if sig == signal.SIGTERM:
                 raise OSError(22, "Invalid argument")
 
-        monkeypatch.setattr(fuse_fs_mod.os, "kill", fake_kill)
+        monkeypatch.setattr(plat_mod.os, "kill", fake_kill)
 
         # Should not raise; OSError during SIGTERM is caught
-        result = fuse_fs_mod._kill_mount_owner_processes(Path("/mnt/amiga"))
+        result = plat_mod._kill_mount_owner_processes(Path("/mnt/amiga"))
         assert result == [1234]
 
 

--- a/tests/unit/test_fuse_fs.py
+++ b/tests/unit/test_fuse_fs.py
@@ -217,8 +217,8 @@ class TestMountFuseOptions:
         assert kwargs is not None, "FUSE was not called"
         assert kwargs["foreground"] is False
 
-    def test_mount_defaults_to_foreground_on_windows(self, monkeypatch, mock_mount_fuse_deps):
-        """Windows keeps the mount attached by default."""
+    def test_mount_defaults_to_daemon_on_windows(self, monkeypatch, mock_mount_fuse_deps):
+        """Windows defaults to daemon mode now that unmount is available."""
         monkeypatch.setattr("sys.platform", "win32")
         from amifuse.fuse_fs import mount_fuse
 
@@ -231,7 +231,7 @@ class TestMountFuseOptions:
 
         kwargs = mock_mount_fuse_deps["fuse_kwargs"]
         assert kwargs is not None, "FUSE was not called"
-        assert kwargs["foreground"] is True
+        assert kwargs["foreground"] is False
 
     def test_mount_respects_explicit_interactive_mode(self, monkeypatch, mock_mount_fuse_deps):
         """An explicit foreground request overrides the platform default."""
@@ -383,7 +383,7 @@ class TestUnmountCommand:
 
         killed_pids = [42]
         monkeypatch.setattr(
-            fuse_fs_mod, "_kill_mount_owner_processes",
+            fuse_fs_mod, "kill_mount_owner_processes",
             lambda mp: killed_pids,
         )
 
@@ -400,7 +400,7 @@ class TestUnmountCommand:
         import amifuse.fuse_fs as fuse_fs_mod
 
         monkeypatch.setattr(
-            fuse_fs_mod, "_kill_mount_owner_processes",
+            fuse_fs_mod, "kill_mount_owner_processes",
             lambda mp: [],
         )
 
@@ -1067,9 +1067,9 @@ class TestCommandMatchesMountpoint:
 
 
 class TestKillEscalation:
-    """Tests for _kill_mount_owner_processes() edge cases.
+    """Tests for kill_mount_owner_processes() edge cases.
 
-    _kill_mount_owner_processes moved to platform.py in Phase 8.
+    kill_mount_owner_processes moved to platform.py in Phase 8.
     """
 
     def test_oserror_during_sigterm_does_not_crash(self, fuse_mock, monkeypatch):
@@ -1087,7 +1087,7 @@ class TestKillEscalation:
         monkeypatch.setattr(plat_mod.os, "kill", fake_kill)
 
         # Should not raise; OSError during SIGTERM is caught
-        result = plat_mod._kill_mount_owner_processes(Path("/mnt/amiga"))
+        result = plat_mod.kill_mount_owner_processes(Path("/mnt/amiga"))
         assert result == [1234]
 
 

--- a/tests/unit/test_fuse_fs.py
+++ b/tests/unit/test_fuse_fs.py
@@ -444,7 +444,7 @@ class TestUnmountCommand:
         run_calls = {"unmount": 0}
 
         def fake_run(cmd, check=False, capture_output=False, text=False, **kwargs):
-            if cmd[:2] == ["ps", "-axo"]:
+            if cmd[0] == "ps":
                 return argparse.Namespace(
                     returncode=0,
                     stdout="123  1 python3 -m amifuse mount disk.iso --mountpoint ./mnt\n",

--- a/tests/unit/test_launcher.py
+++ b/tests/unit/test_launcher.py
@@ -1,0 +1,185 @@
+"""Unit tests for amifuse.launcher module.
+
+Mocks subprocess.Popen and ctypes.windll so tests run on all platforms.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+
+
+@pytest.fixture
+def mock_popen(monkeypatch):
+    """Mock subprocess.Popen and return the mock."""
+    mock = MagicMock()
+    monkeypatch.setattr("amifuse.launcher.subprocess.Popen", mock)
+    return mock
+
+
+@pytest.fixture
+def mock_windll(monkeypatch):
+    """Mock ctypes.windll and return it."""
+    mock = MagicMock()
+    import ctypes
+    monkeypatch.setattr(ctypes, "windll", mock)
+    return mock
+
+
+@pytest.fixture
+def mock_exit(monkeypatch):
+    """Mock os._exit to prevent test process from exiting."""
+    mock = MagicMock()
+    monkeypatch.setattr("amifuse.launcher.os._exit", mock)
+    return mock
+
+
+class TestMountCommand:
+    def test_mount_command_includes_daemon(self, mock_popen, mock_windll, mock_exit):
+        """--daemon is included in mount command."""
+        # Mutex exists (tray already running)
+        mock_windll.kernel32.OpenMutexW.return_value = 1
+
+        from amifuse.launcher import main
+        main(["mount", "test.hdf"])
+
+        args = mock_popen.call_args_list[0]
+        cmd = args[0][0]
+        assert "--daemon" in cmd
+
+    def test_mount_command_includes_write_flag(self, mock_popen, mock_windll, mock_exit):
+        """--write is included when specified."""
+        mock_windll.kernel32.OpenMutexW.return_value = 1
+
+        from amifuse.launcher import main
+        main(["mount", "--write", "test.hdf"])
+
+        cmd = mock_popen.call_args_list[0][0][0]
+        assert "--write" in cmd
+
+    def test_mount_creation_flags_include_breakaway(self, mock_popen, mock_windll, mock_exit):
+        """Mount uses DETACHED flags with CREATE_BREAKAWAY_FROM_JOB."""
+        mock_windll.kernel32.OpenMutexW.return_value = 1
+
+        from amifuse.launcher import (
+            main, DETACHED_PROCESS, CREATE_NEW_PROCESS_GROUP,
+            CREATE_NO_WINDOW, CREATE_BREAKAWAY_FROM_JOB,
+        )
+        main(["mount", "test.hdf"])
+
+        expected_flags = (
+            DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP
+            | CREATE_NO_WINDOW | CREATE_BREAKAWAY_FROM_JOB
+        )
+        kwargs = mock_popen.call_args_list[0][1]
+        assert kwargs["creationflags"] == expected_flags
+
+    def test_mount_falls_back_without_breakaway(self, mock_popen, mock_windll, mock_exit):
+        """If CREATE_BREAKAWAY_FROM_JOB fails, retry without it."""
+        mock_windll.kernel32.OpenMutexW.return_value = 1
+
+        # First Popen raises (breakaway denied), second succeeds
+        mock_popen.side_effect = [OSError("breakaway denied"), MagicMock()]
+
+        from amifuse.launcher import (
+            main, DETACHED_PROCESS, CREATE_NEW_PROCESS_GROUP, CREATE_NO_WINDOW,
+        )
+        main(["mount", "test.hdf"])
+
+        expected_fallback = DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW
+        kwargs = mock_popen.call_args_list[1][1]
+        assert kwargs["creationflags"] == expected_fallback
+
+
+class TestInspectCommand:
+    def test_inspect_uses_create_new_console(self, mock_popen, mock_windll, mock_exit):
+        """Inspect uses CREATE_NEW_CONSOLE flag."""
+        from amifuse.launcher import main, CREATE_NEW_CONSOLE
+        main(["inspect", "test.hdf"])
+
+        kwargs = mock_popen.call_args_list[0][1]
+        assert kwargs["creationflags"] == CREATE_NEW_CONSOLE
+
+    def test_inspect_command_uses_cmd_k(self, mock_popen, mock_windll, mock_exit):
+        """Inspect command starts with ["cmd", "/k", ...]."""
+        from amifuse.launcher import main
+        main(["inspect", "test.hdf"])
+
+        cmd = mock_popen.call_args_list[0][0][0]
+        assert cmd[0] == "cmd"
+        assert cmd[1] == "/k"
+
+
+class TestEnsureTrayRunning:
+    def test_ensure_tray_running_skips_when_running(self, mock_popen, mock_windll, mock_exit, monkeypatch):
+        """When mutex exists, no tray Popen is spawned."""
+        mock_windll.kernel32.OpenMutexW.return_value = 42  # non-zero = exists
+
+        from amifuse.launcher import main
+        main(["mount", "test.hdf"])
+
+        # First call is mount Popen; should be no second call for tray
+        assert mock_popen.call_count == 1
+
+    def test_ensure_tray_running_spawns_when_not_running(self, mock_popen, mock_windll, mock_exit, monkeypatch):
+        """When mutex doesn't exist, tray is spawned."""
+        mock_windll.kernel32.OpenMutexW.return_value = 0  # 0 = not found
+        # Make tray exe not exist so it falls back to python -m
+        monkeypatch.setattr("amifuse.launcher.os.path.isfile", lambda p: False)
+
+        from amifuse.launcher import main
+        main(["mount", "test.hdf"])
+
+        # Two Popen calls: mount + tray
+        assert mock_popen.call_count == 2
+
+
+class TestMainExits:
+    def test_main_calls_os_exit(self, mock_popen, mock_windll, mock_exit):
+        """main() calls os._exit(0) for immediate exit."""
+        mock_windll.kernel32.OpenMutexW.return_value = 1
+
+        from amifuse.launcher import main
+        main(["mount", "test.hdf"])
+        mock_exit.assert_called_once_with(0)
+
+    def test_inspect_calls_os_exit(self, mock_popen, mock_windll, mock_exit):
+        """Inspect path also calls os._exit(0)."""
+        from amifuse.launcher import main
+        main(["inspect", "test.hdf"])
+        mock_exit.assert_called_once_with(0)
+
+
+class TestMountUsesPythonw:
+    def test_mount_uses_pythonw(self, mock_popen, mock_windll, mock_exit, monkeypatch):
+        """Mount subprocess uses pythonw.exe."""
+        mock_windll.kernel32.OpenMutexW.return_value = 1
+        monkeypatch.setattr("sys.executable", r"C:\Python\python.exe")
+        monkeypatch.setattr(
+            "amifuse.launcher.os.path.isfile",
+            lambda p: p == r"C:\Python\pythonw.exe",
+        )
+
+        from amifuse.launcher import main
+        main(["mount", "test.hdf"])
+
+        cmd = mock_popen.call_args_list[0][0][0]
+        assert cmd[0] == r"C:\Python\pythonw.exe"
+
+
+class TestLauncherUsesFileLogging:
+    def test_launcher_uses_file_logging(self, mock_popen, mock_windll, mock_exit, tmp_path, monkeypatch):
+        """Logging writes via open/write/close, not logging module."""
+        mock_windll.kernel32.OpenMutexW.return_value = 1
+        monkeypatch.setattr("amifuse.launcher._LOG_DIR", tmp_path)
+
+        from amifuse.launcher import _log
+        _log("test message")
+
+        log_file = tmp_path / "launcher.log"
+        assert log_file.exists()
+        content = log_file.read_text()
+        assert "test message" in content

--- a/tests/unit/test_launcher.py
+++ b/tests/unit/test_launcher.py
@@ -11,6 +11,8 @@ from unittest.mock import MagicMock, patch, call
 
 import pytest
 
+pytestmark = pytest.mark.skipif(sys.platform != "win32", reason="Windows-only")
+
 
 @pytest.fixture
 def mock_popen(monkeypatch):

--- a/tests/unit/test_launcher.py
+++ b/tests/unit/test_launcher.py
@@ -105,14 +105,16 @@ class TestInspectCommand:
         kwargs = mock_popen.call_args_list[0][1]
         assert kwargs["creationflags"] == CREATE_NEW_CONSOLE
 
-    def test_inspect_command_uses_cmd_k(self, mock_popen, mock_windll, mock_exit):
-        """Inspect command starts with ["cmd", "/k", ...]."""
+    def test_inspect_command_launches_python_directly(self, mock_popen, mock_windll, mock_exit):
+        """Inspect launches python -c wrapper directly (no cmd.exe for security)."""
         from amifuse.launcher import main
         main(["inspect", "test.hdf"])
 
         cmd = mock_popen.call_args_list[0][0][0]
-        assert cmd[0] == "cmd"
-        assert cmd[1] == "/k"
+        assert cmd[0] == sys.executable
+        assert cmd[1] == "-c"
+        # Image path passed as positional arg (sys.argv), not interpolated into code
+        assert cmd[-1] == "test.hdf"
 
 
 class TestEnsureTrayRunning:

--- a/tests/unit/test_platform.py
+++ b/tests/unit/test_platform.py
@@ -876,6 +876,7 @@ class TestKillPids:
         assert 42 in result
         assert (42, signal.SIGKILL) in signals_sent
 
+    @pytest.mark.skipif(not hasattr(signal, "CTRL_BREAK_EVENT"), reason="Windows-only signal")
     def test_kill_pids_sends_ctrl_break_on_windows(self, monkeypatch):
         """On Windows, sends CTRL_BREAK_EVENT."""
         import signal
@@ -895,6 +896,7 @@ class TestKillPids:
         assert 42 in result
         assert (42, signal.CTRL_BREAK_EVENT) in signals_sent
 
+    @pytest.mark.skipif(not hasattr(signal, "CTRL_BREAK_EVENT"), reason="Windows-only signal")
     def test_kill_pids_force_kills_with_taskkill(self, monkeypatch):
         """On Windows, uses taskkill /F when pid survives CTRL_BREAK."""
         import signal

--- a/tests/unit/test_platform.py
+++ b/tests/unit/test_platform.py
@@ -11,6 +11,7 @@ Mock targets are patched at the module level where they are looked up:
 """
 
 import errno
+import signal
 import sys
 import types
 from pathlib import Path, PurePosixPath
@@ -741,3 +742,247 @@ class TestWindowsUnmountCommand:
 
         result = get_unmount_command(Path("Z:"))
         assert result == []
+
+
+# ---------------------------------------------------------------------------
+# L. _pid_exists -- 4 tests
+# ---------------------------------------------------------------------------
+
+
+class TestPidExists:
+    """Tests for _pid_exists() cross-platform behaviour."""
+
+    def test_pid_exists_true_for_live_pid(self, monkeypatch):
+        from amifuse.platform import _pid_exists
+
+        monkeypatch.setattr("amifuse.platform.sys.platform", "linux")
+        monkeypatch.setattr("amifuse.platform.os.kill", lambda pid, sig: None)
+        assert _pid_exists(12345) is True
+
+    def test_pid_exists_false_for_dead_pid(self, monkeypatch):
+        from amifuse.platform import _pid_exists
+
+        monkeypatch.setattr("amifuse.platform.sys.platform", "linux")
+
+        def raise_lookup(pid, sig):
+            raise ProcessLookupError()
+
+        monkeypatch.setattr("amifuse.platform.os.kill", raise_lookup)
+        assert _pid_exists(12345) is False
+
+    def test_pid_exists_true_on_permission_error(self, monkeypatch):
+        from amifuse.platform import _pid_exists
+
+        monkeypatch.setattr("amifuse.platform.sys.platform", "linux")
+
+        def raise_perm(pid, sig):
+            raise PermissionError("Access denied")
+
+        monkeypatch.setattr("amifuse.platform.os.kill", raise_perm)
+        assert _pid_exists(12345) is True
+
+    def test_pid_exists_false_on_generic_oserror(self, monkeypatch):
+        from amifuse.platform import _pid_exists
+
+        monkeypatch.setattr("amifuse.platform.sys.platform", "linux")
+
+        def raise_oserror(pid, sig):
+            raise OSError(22, "Invalid argument")
+
+        monkeypatch.setattr("amifuse.platform.os.kill", raise_oserror)
+        assert _pid_exists(12345) is False
+
+
+# ---------------------------------------------------------------------------
+# M. _deduplicate_fusepy_children -- 2 tests
+# ---------------------------------------------------------------------------
+
+
+class TestDeduplicateFusepyChildren:
+    """Tests for _deduplicate_fusepy_children()."""
+
+    def test_deduplicate_filters_child(self):
+        from amifuse.platform import _deduplicate_fusepy_children
+
+        mounts = [
+            {"pid": 100, "parent_pid": 1, "mountpoint": "/mnt/a"},
+            {"pid": 200, "parent_pid": 100, "mountpoint": None},
+        ]
+        result = _deduplicate_fusepy_children(mounts)
+        assert len(result) == 1
+        assert result[0]["pid"] == 100
+
+    def test_deduplicate_keeps_unrelated_processes(self):
+        from amifuse.platform import _deduplicate_fusepy_children
+
+        mounts = [
+            {"pid": 100, "parent_pid": 1, "mountpoint": "/mnt/a"},
+            {"pid": 200, "parent_pid": 1, "mountpoint": "/mnt/b"},
+        ]
+        result = _deduplicate_fusepy_children(mounts)
+        assert len(result) == 2
+
+
+# ---------------------------------------------------------------------------
+# N. kill_pids -- 4 tests
+# ---------------------------------------------------------------------------
+
+
+class TestKillPids:
+    """Tests for kill_pids() graceful-then-force strategy."""
+
+    def test_kill_pids_sends_sigterm_on_unix(self, monkeypatch):
+        """On Unix, sends SIGTERM then checks pid existence."""
+        import signal
+        from amifuse.platform import kill_pids
+
+        monkeypatch.setattr("sys.platform", "linux")
+        signals_sent = []
+
+        def fake_kill(pid, sig):
+            signals_sent.append((pid, sig))
+            if sig == 0:
+                raise ProcessLookupError()
+
+        monkeypatch.setattr("amifuse.platform.os.kill", fake_kill)
+
+        result = kill_pids([42], timeout=0.1)
+        assert 42 in result
+        assert (42, signal.SIGTERM) in signals_sent
+
+    @pytest.mark.skipif(not hasattr(signal, "SIGKILL"), reason="SIGKILL not available on Windows")
+    def test_kill_pids_force_kills_with_sigkill_unix(self, monkeypatch):
+        """On Unix, sends SIGKILL when pid survives SIGTERM."""
+        import signal
+        from amifuse.platform import kill_pids, _SIGKILL
+
+        monkeypatch.setattr("sys.platform", "linux")
+        signals_sent = []
+        alive = {42}
+
+        def fake_kill(pid, sig):
+            signals_sent.append((pid, sig))
+            if sig == 0:
+                if pid in alive:
+                    return  # still alive
+                raise ProcessLookupError()
+            if sig == _SIGKILL:
+                alive.discard(pid)
+
+        monkeypatch.setattr("amifuse.platform.os.kill", fake_kill)
+        monkeypatch.setattr("amifuse.platform.time.time", lambda: 999999)
+
+        result = kill_pids([42], timeout=0.0)
+        assert 42 in result
+        assert (42, signal.SIGKILL) in signals_sent
+
+    def test_kill_pids_sends_ctrl_break_on_windows(self, monkeypatch):
+        """On Windows, sends CTRL_BREAK_EVENT."""
+        import signal
+        from amifuse.platform import kill_pids
+
+        monkeypatch.setattr("sys.platform", "win32")
+        signals_sent = []
+
+        def fake_kill(pid, sig):
+            signals_sent.append((pid, sig))
+            if sig == 0:
+                raise ProcessLookupError()
+
+        monkeypatch.setattr("amifuse.platform.os.kill", fake_kill)
+
+        result = kill_pids([42], timeout=0.1)
+        assert 42 in result
+        assert (42, signal.CTRL_BREAK_EVENT) in signals_sent
+
+    def test_kill_pids_force_kills_with_taskkill(self, monkeypatch):
+        """On Windows, uses taskkill /F when pid survives CTRL_BREAK."""
+        import signal
+        from unittest.mock import MagicMock
+        from amifuse.platform import kill_pids
+
+        monkeypatch.setattr("sys.platform", "win32")
+        alive = {42}
+        taskkill_called = []
+
+        def fake_kill(pid, sig):
+            if sig == 0:
+                if pid in alive:
+                    return
+                raise ProcessLookupError()
+
+        def fake_run(cmd, check=False, capture_output=False, creationflags=0):
+            taskkill_called.append(cmd)
+            alive.discard(42)
+            return MagicMock(returncode=0)
+
+        monkeypatch.setattr("amifuse.platform.os.kill", fake_kill)
+        monkeypatch.setattr("amifuse.platform.subprocess.run", fake_run)
+        monkeypatch.setattr("amifuse.platform.time.time", lambda: 999999)
+
+        result = kill_pids([42], timeout=0.0)
+        assert 42 in result
+        assert any("taskkill" in cmd[0] for cmd in taskkill_called)
+
+
+# ---------------------------------------------------------------------------
+# O. CIM fallback -- 1 test
+# ---------------------------------------------------------------------------
+
+
+class TestCimFallback:
+    """Tests for _find_amifuse_mounts_cim fallback."""
+
+    def test_wmic_oserror_falls_through_to_cim(self, monkeypatch):
+        from unittest.mock import MagicMock
+        from amifuse.platform import _find_amifuse_mounts_windows
+
+        monkeypatch.setattr("sys.platform", "win32")
+
+        call_count = {"n": 0}
+
+        def fake_run(cmd, **kwargs):
+            call_count["n"] += 1
+            if cmd[0] == "wmic":
+                raise OSError("wmic not found")
+            # powershell fallback
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = b'[]'
+            return result
+
+        monkeypatch.setattr("amifuse.platform.subprocess.run", fake_run)
+
+        mounts = _find_amifuse_mounts_windows()
+        assert mounts == []
+        # Should have tried wmic then PowerShell
+        assert call_count["n"] >= 2
+
+
+# ---------------------------------------------------------------------------
+# P. find_mounts wmic uses CREATE_NO_WINDOW -- 1 test
+# ---------------------------------------------------------------------------
+
+
+class TestWmicCreationFlags:
+    """Verify wmic subprocess call uses CREATE_NO_WINDOW."""
+
+    def test_find_mounts_wmic_uses_create_no_window(self, monkeypatch):
+        from unittest.mock import MagicMock
+        from amifuse.platform import _find_amifuse_mounts_windows, _CREATE_NO_WINDOW
+
+        monkeypatch.setattr("sys.platform", "win32")
+
+        captured_kwargs = {}
+
+        def fake_run(cmd, **kwargs):
+            captured_kwargs.update(kwargs)
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = ""
+            return result
+
+        monkeypatch.setattr("amifuse.platform.subprocess.run", fake_run)
+
+        _find_amifuse_mounts_windows()
+        assert captured_kwargs.get("creationflags") == _CREATE_NO_WINDOW

--- a/tests/unit/test_platform.py
+++ b/tests/unit/test_platform.py
@@ -908,6 +908,7 @@ class TestKillPids:
         assert 42 in result
         assert (42, signal.SIGKILL) in signals_sent
 
+    @pytest.mark.skipif(not hasattr(signal, "CTRL_BREAK_EVENT"), reason="Windows-only signal")
     def test_kill_pids_sends_ctrl_break_on_windows(self, monkeypatch):
         """On Windows, sends CTRL_BREAK_EVENT."""
         import signal
@@ -927,6 +928,7 @@ class TestKillPids:
         assert 42 in result
         assert (42, signal.CTRL_BREAK_EVENT) in signals_sent
 
+    @pytest.mark.skipif(not hasattr(signal, "CTRL_BREAK_EVENT"), reason="Windows-only signal")
     def test_kill_pids_force_kills_with_taskkill(self, monkeypatch):
         """On Windows, uses taskkill /F when pid survives CTRL_BREAK."""
         import signal

--- a/tests/unit/test_platform.py
+++ b/tests/unit/test_platform.py
@@ -231,12 +231,12 @@ class TestGetMountOptions:
         assert result == {}
 
     def test_mount_options_windows_volname(self, monkeypatch):
-        """On Windows, returns dict with volname and FileSystemName."""
+        """On Windows, returns dict with volname, FileSystemName, and FileInfoTimeout."""
         monkeypatch.setattr("sys.platform", "win32")
         from amifuse.platform import get_mount_options
 
         result = get_mount_options("TestVol")
-        assert result == {"volname": "TestVol", "FileSystemName": "AmiFUSE"}
+        assert result == {"volname": "TestVol", "FileSystemName": "AmiFUSE", "FileInfoTimeout": "1000"}
 
     def test_mount_options_windows_ignores_icon_args(self, monkeypatch):
         """On Windows, icon args are ignored (macOS-only)."""
@@ -246,7 +246,7 @@ class TestGetMountOptions:
         result = get_mount_options(
             "TestVol", volicon_path="/tmp/icon.icns", icons_enabled=True
         )
-        assert result == {"volname": "TestVol", "FileSystemName": "AmiFUSE"}
+        assert result == {"volname": "TestVol", "FileSystemName": "AmiFUSE", "FileInfoTimeout": "1000"}
 
     def test_mount_options_darwin_unchanged(self, monkeypatch):
         """On darwin, get_mount_options returns a dict containing 'volname' key.

--- a/tests/unit/test_platform.py
+++ b/tests/unit/test_platform.py
@@ -736,7 +736,7 @@ class TestMountRunsInForegroundByDefault:
         [
             ("darwin", False),
             ("linux", False),
-            ("win32", True),
+            ("win32", False),
         ],
     )
     def test_default_mode_by_platform(self, monkeypatch, platform, expected):
@@ -909,28 +909,33 @@ class TestKillPids:
         assert (42, signal.SIGKILL) in signals_sent
 
     @pytest.mark.skipif(not hasattr(signal, "CTRL_BREAK_EVENT"), reason="Windows-only signal")
-    def test_kill_pids_sends_ctrl_break_on_windows(self, monkeypatch):
-        """On Windows, sends CTRL_BREAK_EVENT."""
-        import signal
+    def test_kill_pids_sends_taskkill_graceful_on_windows(self, monkeypatch):
+        """On Windows, uses taskkill /PID (graceful WM_CLOSE) instead of CTRL_BREAK_EVENT."""
+        from unittest.mock import MagicMock
         from amifuse.platform import kill_pids
 
         monkeypatch.setattr("sys.platform", "win32")
-        signals_sent = []
+        taskkill_calls = []
 
-        def fake_kill(pid, sig):
-            signals_sent.append((pid, sig))
-            if sig == 0:
-                raise ProcessLookupError()
+        def fake_run(cmd, check=False, capture_output=False, creationflags=0):
+            taskkill_calls.append(cmd)
+            return MagicMock(returncode=0)
 
-        monkeypatch.setattr("amifuse.platform.os.kill", fake_kill)
+        def fake_pid_exists(pid):
+            return False
+
+        monkeypatch.setattr("amifuse.platform.subprocess.run", fake_run)
+        monkeypatch.setattr("amifuse.platform._pid_exists", fake_pid_exists)
+        monkeypatch.setattr("amifuse.platform._verify_amifuse_process", lambda pid: True)
 
         result = kill_pids([42], timeout=0.1)
         assert 42 in result
-        assert (42, signal.CTRL_BREAK_EVENT) in signals_sent
+        # Phase 1 should call taskkill without /F (graceful)
+        assert ["taskkill", "/PID", "42"] in taskkill_calls
 
     @pytest.mark.skipif(not hasattr(signal, "CTRL_BREAK_EVENT"), reason="Windows-only signal")
     def test_kill_pids_force_kills_with_taskkill(self, monkeypatch):
-        """On Windows, uses taskkill /F when pid survives CTRL_BREAK."""
+        """On Windows, uses taskkill /F when pid survives graceful taskkill."""
         import signal
         from unittest.mock import MagicMock
         from amifuse.platform import kill_pids
@@ -939,24 +944,23 @@ class TestKillPids:
         alive = {42}
         taskkill_called = []
 
-        def fake_kill(pid, sig):
-            if sig == 0:
-                if pid in alive:
-                    return
-                raise ProcessLookupError()
-
         def fake_run(cmd, check=False, capture_output=False, creationflags=0):
             taskkill_called.append(cmd)
-            alive.discard(42)
+            if "/F" in cmd:
+                alive.discard(42)
             return MagicMock(returncode=0)
 
-        monkeypatch.setattr("amifuse.platform.os.kill", fake_kill)
+        def fake_pid_exists(pid):
+            return pid in alive
+
         monkeypatch.setattr("amifuse.platform.subprocess.run", fake_run)
+        monkeypatch.setattr("amifuse.platform._pid_exists", fake_pid_exists)
+        monkeypatch.setattr("amifuse.platform._verify_amifuse_process", lambda pid: True)
         monkeypatch.setattr("amifuse.platform.time.time", lambda: 999999)
 
         result = kill_pids([42], timeout=0.0)
         assert 42 in result
-        assert any("taskkill" in cmd[0] for cmd in taskkill_called)
+        assert any("/F" in cmd for cmd in taskkill_called)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_platform.py
+++ b/tests/unit/test_platform.py
@@ -11,6 +11,7 @@ Mock targets are patched at the module level where they are looked up:
 """
 
 import errno
+import signal
 import sys
 import types
 from pathlib import Path, PurePosixPath
@@ -773,3 +774,247 @@ class TestWindowsUnmountCommand:
 
         result = get_unmount_command(Path("Z:"))
         assert result == []
+
+
+# ---------------------------------------------------------------------------
+# L. _pid_exists -- 4 tests
+# ---------------------------------------------------------------------------
+
+
+class TestPidExists:
+    """Tests for _pid_exists() cross-platform behaviour."""
+
+    def test_pid_exists_true_for_live_pid(self, monkeypatch):
+        from amifuse.platform import _pid_exists
+
+        monkeypatch.setattr("amifuse.platform.sys.platform", "linux")
+        monkeypatch.setattr("amifuse.platform.os.kill", lambda pid, sig: None)
+        assert _pid_exists(12345) is True
+
+    def test_pid_exists_false_for_dead_pid(self, monkeypatch):
+        from amifuse.platform import _pid_exists
+
+        monkeypatch.setattr("amifuse.platform.sys.platform", "linux")
+
+        def raise_lookup(pid, sig):
+            raise ProcessLookupError()
+
+        monkeypatch.setattr("amifuse.platform.os.kill", raise_lookup)
+        assert _pid_exists(12345) is False
+
+    def test_pid_exists_true_on_permission_error(self, monkeypatch):
+        from amifuse.platform import _pid_exists
+
+        monkeypatch.setattr("amifuse.platform.sys.platform", "linux")
+
+        def raise_perm(pid, sig):
+            raise PermissionError("Access denied")
+
+        monkeypatch.setattr("amifuse.platform.os.kill", raise_perm)
+        assert _pid_exists(12345) is True
+
+    def test_pid_exists_false_on_generic_oserror(self, monkeypatch):
+        from amifuse.platform import _pid_exists
+
+        monkeypatch.setattr("amifuse.platform.sys.platform", "linux")
+
+        def raise_oserror(pid, sig):
+            raise OSError(22, "Invalid argument")
+
+        monkeypatch.setattr("amifuse.platform.os.kill", raise_oserror)
+        assert _pid_exists(12345) is False
+
+
+# ---------------------------------------------------------------------------
+# M. _deduplicate_fusepy_children -- 2 tests
+# ---------------------------------------------------------------------------
+
+
+class TestDeduplicateFusepyChildren:
+    """Tests for _deduplicate_fusepy_children()."""
+
+    def test_deduplicate_filters_child(self):
+        from amifuse.platform import _deduplicate_fusepy_children
+
+        mounts = [
+            {"pid": 100, "parent_pid": 1, "mountpoint": "/mnt/a"},
+            {"pid": 200, "parent_pid": 100, "mountpoint": None},
+        ]
+        result = _deduplicate_fusepy_children(mounts)
+        assert len(result) == 1
+        assert result[0]["pid"] == 100
+
+    def test_deduplicate_keeps_unrelated_processes(self):
+        from amifuse.platform import _deduplicate_fusepy_children
+
+        mounts = [
+            {"pid": 100, "parent_pid": 1, "mountpoint": "/mnt/a"},
+            {"pid": 200, "parent_pid": 1, "mountpoint": "/mnt/b"},
+        ]
+        result = _deduplicate_fusepy_children(mounts)
+        assert len(result) == 2
+
+
+# ---------------------------------------------------------------------------
+# N. kill_pids -- 4 tests
+# ---------------------------------------------------------------------------
+
+
+class TestKillPids:
+    """Tests for kill_pids() graceful-then-force strategy."""
+
+    def test_kill_pids_sends_sigterm_on_unix(self, monkeypatch):
+        """On Unix, sends SIGTERM then checks pid existence."""
+        import signal
+        from amifuse.platform import kill_pids
+
+        monkeypatch.setattr("sys.platform", "linux")
+        signals_sent = []
+
+        def fake_kill(pid, sig):
+            signals_sent.append((pid, sig))
+            if sig == 0:
+                raise ProcessLookupError()
+
+        monkeypatch.setattr("amifuse.platform.os.kill", fake_kill)
+
+        result = kill_pids([42], timeout=0.1)
+        assert 42 in result
+        assert (42, signal.SIGTERM) in signals_sent
+
+    @pytest.mark.skipif(not hasattr(signal, "SIGKILL"), reason="SIGKILL not available on Windows")
+    def test_kill_pids_force_kills_with_sigkill_unix(self, monkeypatch):
+        """On Unix, sends SIGKILL when pid survives SIGTERM."""
+        import signal
+        from amifuse.platform import kill_pids, _SIGKILL
+
+        monkeypatch.setattr("sys.platform", "linux")
+        signals_sent = []
+        alive = {42}
+
+        def fake_kill(pid, sig):
+            signals_sent.append((pid, sig))
+            if sig == 0:
+                if pid in alive:
+                    return  # still alive
+                raise ProcessLookupError()
+            if sig == _SIGKILL:
+                alive.discard(pid)
+
+        monkeypatch.setattr("amifuse.platform.os.kill", fake_kill)
+        monkeypatch.setattr("amifuse.platform.time.time", lambda: 999999)
+
+        result = kill_pids([42], timeout=0.0)
+        assert 42 in result
+        assert (42, signal.SIGKILL) in signals_sent
+
+    def test_kill_pids_sends_ctrl_break_on_windows(self, monkeypatch):
+        """On Windows, sends CTRL_BREAK_EVENT."""
+        import signal
+        from amifuse.platform import kill_pids
+
+        monkeypatch.setattr("sys.platform", "win32")
+        signals_sent = []
+
+        def fake_kill(pid, sig):
+            signals_sent.append((pid, sig))
+            if sig == 0:
+                raise ProcessLookupError()
+
+        monkeypatch.setattr("amifuse.platform.os.kill", fake_kill)
+
+        result = kill_pids([42], timeout=0.1)
+        assert 42 in result
+        assert (42, signal.CTRL_BREAK_EVENT) in signals_sent
+
+    def test_kill_pids_force_kills_with_taskkill(self, monkeypatch):
+        """On Windows, uses taskkill /F when pid survives CTRL_BREAK."""
+        import signal
+        from unittest.mock import MagicMock
+        from amifuse.platform import kill_pids
+
+        monkeypatch.setattr("sys.platform", "win32")
+        alive = {42}
+        taskkill_called = []
+
+        def fake_kill(pid, sig):
+            if sig == 0:
+                if pid in alive:
+                    return
+                raise ProcessLookupError()
+
+        def fake_run(cmd, check=False, capture_output=False, creationflags=0):
+            taskkill_called.append(cmd)
+            alive.discard(42)
+            return MagicMock(returncode=0)
+
+        monkeypatch.setattr("amifuse.platform.os.kill", fake_kill)
+        monkeypatch.setattr("amifuse.platform.subprocess.run", fake_run)
+        monkeypatch.setattr("amifuse.platform.time.time", lambda: 999999)
+
+        result = kill_pids([42], timeout=0.0)
+        assert 42 in result
+        assert any("taskkill" in cmd[0] for cmd in taskkill_called)
+
+
+# ---------------------------------------------------------------------------
+# O. CIM fallback -- 1 test
+# ---------------------------------------------------------------------------
+
+
+class TestCimFallback:
+    """Tests for _find_amifuse_mounts_cim fallback."""
+
+    def test_wmic_oserror_falls_through_to_cim(self, monkeypatch):
+        from unittest.mock import MagicMock
+        from amifuse.platform import _find_amifuse_mounts_windows
+
+        monkeypatch.setattr("sys.platform", "win32")
+
+        call_count = {"n": 0}
+
+        def fake_run(cmd, **kwargs):
+            call_count["n"] += 1
+            if cmd[0] == "wmic":
+                raise OSError("wmic not found")
+            # powershell fallback
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = b'[]'
+            return result
+
+        monkeypatch.setattr("amifuse.platform.subprocess.run", fake_run)
+
+        mounts = _find_amifuse_mounts_windows()
+        assert mounts == []
+        # Should have tried wmic then PowerShell
+        assert call_count["n"] >= 2
+
+
+# ---------------------------------------------------------------------------
+# P. find_mounts wmic uses CREATE_NO_WINDOW -- 1 test
+# ---------------------------------------------------------------------------
+
+
+class TestWmicCreationFlags:
+    """Verify wmic subprocess call uses CREATE_NO_WINDOW."""
+
+    def test_find_mounts_wmic_uses_create_no_window(self, monkeypatch):
+        from unittest.mock import MagicMock
+        from amifuse.platform import _find_amifuse_mounts_windows, _CREATE_NO_WINDOW
+
+        monkeypatch.setattr("sys.platform", "win32")
+
+        captured_kwargs = {}
+
+        def fake_run(cmd, **kwargs):
+            captured_kwargs.update(kwargs)
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = ""
+            return result
+
+        monkeypatch.setattr("amifuse.platform.subprocess.run", fake_run)
+
+        _find_amifuse_mounts_windows()
+        assert captured_kwargs.get("creationflags") == _CREATE_NO_WINDOW

--- a/tests/unit/test_status.py
+++ b/tests/unit/test_status.py
@@ -112,7 +112,7 @@ class TestFindAmifuseMountsUnix:
         # Simulate current PID != 12345
         monkeypatch.setattr("amifuse.platform.os.getpid", lambda: 99999)
         self._mock_ps(monkeypatch,
-            "12345   3600 python -m amifuse mount /images/test.hdf --mountpoint /mnt/amiga\n")
+            "12345  1  3600 python -m amifuse mount /images/test.hdf --mountpoint /mnt/amiga\n")
 
         mounts = _find_amifuse_mounts_unix()
         assert len(mounts) == 1
@@ -121,6 +121,7 @@ class TestFindAmifuseMountsUnix:
         assert mounts[0]["mountpoint"] == "/mnt/amiga"
         assert mounts[0]["uptime_seconds"] == 3600
         assert mounts[0]["filesystem_type"] is None
+        assert mounts[0]["parent_pid"] == 1
 
     def test_empty_process_list(self, monkeypatch):
         from amifuse.platform import _find_amifuse_mounts_unix
@@ -134,9 +135,9 @@ class TestFindAmifuseMountsUnix:
 
         monkeypatch.setattr("amifuse.platform.os.getpid", lambda: 99999)
         self._mock_ps(monkeypatch,
-            "111   100 python some_other_script.py\n"
-            "222   200 python -m amifuse doctor --json\n"
-            "333   300 python -m amifuse mount /img.hdf --mountpoint /mnt/x\n")
+            "111  1  100 python some_other_script.py\n"
+            "222  1  200 python -m amifuse doctor --json\n"
+            "333  1  300 python -m amifuse mount /img.hdf --mountpoint /mnt/x\n")
 
         mounts = _find_amifuse_mounts_unix()
         assert len(mounts) == 1
@@ -147,7 +148,7 @@ class TestFindAmifuseMountsUnix:
 
         monkeypatch.setattr("amifuse.platform.os.getpid", lambda: 12345)
         self._mock_ps(monkeypatch,
-            "12345   100 python -m amifuse mount /img.hdf --mountpoint /mnt/x\n")
+            "12345  1  100 python -m amifuse mount /img.hdf --mountpoint /mnt/x\n")
 
         mounts = _find_amifuse_mounts_unix()
         assert mounts == []
@@ -157,8 +158,8 @@ class TestFindAmifuseMountsUnix:
 
         monkeypatch.setattr("amifuse.platform.os.getpid", lambda: 99999)
         self._mock_ps(monkeypatch,
-            "100   60 python -m amifuse mount /a.hdf --mountpoint /mnt/a\n"
-            "200   120 python -m amifuse mount /b.hdf --mountpoint /mnt/b\n")
+            "100  1  60 python -m amifuse mount /a.hdf --mountpoint /mnt/a\n"
+            "200  1  120 python -m amifuse mount /b.hdf --mountpoint /mnt/b\n")
 
         mounts = _find_amifuse_mounts_unix()
         assert len(mounts) == 2
@@ -170,7 +171,7 @@ class TestFindAmifuseMountsUnix:
         monkeypatch.setattr("amifuse.platform.os.getpid", lambda: 99999)
         self._mock_ps(monkeypatch,
             "not_a_pid amifuse mount something\n"
-            "100   60 python -m amifuse mount /a.hdf --mountpoint /mnt/a\n")
+            "100  1  60 python -m amifuse mount /a.hdf --mountpoint /mnt/a\n")
 
         mounts = _find_amifuse_mounts_unix()
         assert len(mounts) == 1
@@ -221,6 +222,7 @@ class TestFindAmifuseMountsWindows:
         self._mock_wmic(monkeypatch,
             "CommandLine=python -m amifuse mount C:/images/test.hdf --mountpoint D:\r\n"
             "CreationDate=20260419103000.123456+000\r\n"
+            "ParentProcessId=1\r\n"
             "ProcessId=12345\r\n"
             "\r\n")
 
@@ -230,6 +232,7 @@ class TestFindAmifuseMountsWindows:
         assert mounts[0]["image"] == "C:/images/test.hdf"
         assert mounts[0]["mountpoint"] == "D:"
         assert mounts[0]["filesystem_type"] is None
+        assert mounts[0]["parent_pid"] == 1
 
     def test_empty_process_list(self, monkeypatch):
         from amifuse.platform import _find_amifuse_mounts_windows
@@ -245,10 +248,12 @@ class TestFindAmifuseMountsWindows:
         self._mock_wmic(monkeypatch,
             "CommandLine=python some_script.py\r\n"
             "CreationDate=20260419100000.000000+000\r\n"
+            "ParentProcessId=1\r\n"
             "ProcessId=111\r\n"
             "\r\n"
             "CommandLine=python -m amifuse mount C:/img.hdf --mountpoint E:\r\n"
             "CreationDate=20260419100000.000000+000\r\n"
+            "ParentProcessId=1\r\n"
             "ProcessId=222\r\n"
             "\r\n")
 
@@ -280,10 +285,12 @@ class TestFindAmifuseMountsWindows:
         self._mock_wmic(monkeypatch,
             "CommandLine=python -m amifuse mount C:/a.hdf --mountpoint D:\r\n"
             "CreationDate=20260419100000.000000+000\r\n"
+            "ParentProcessId=1\r\n"
             "ProcessId=100\r\n"
             "\r\n"
             "CommandLine=python -m amifuse mount C:/b.hdf --mountpoint E:\r\n"
             "CreationDate=20260419100000.000000+000\r\n"
+            "ParentProcessId=1\r\n"
             "ProcessId=200\r\n"
             "\r\n")
 
@@ -429,10 +436,13 @@ class TestCmdStatus:
 
 
 class TestFindMountOwnerPidsRefactored:
-    """Verify the refactored _find_mount_owner_pids wraps find_amifuse_mounts."""
+    """Verify the refactored _find_mount_owner_pids wraps find_amifuse_mounts.
+
+    _find_mount_owner_pids moved to platform.py in Phase 8.
+    """
 
     def test_filters_by_mountpoint(self, monkeypatch):
-        from amifuse.fuse_fs import _find_mount_owner_pids
+        from amifuse.platform import _find_mount_owner_pids
 
         mounts = [
             {"mountpoint": "/mnt/a", "image": "a.hdf", "pid": 100,
@@ -446,7 +456,7 @@ class TestFindMountOwnerPidsRefactored:
         assert pids == [100]
 
     def test_returns_empty_on_no_match(self, monkeypatch):
-        from amifuse.fuse_fs import _find_mount_owner_pids
+        from amifuse.platform import _find_mount_owner_pids
 
         mounts = [
             {"mountpoint": "/mnt/a", "image": "a.hdf", "pid": 100,
@@ -458,7 +468,7 @@ class TestFindMountOwnerPidsRefactored:
         assert pids == []
 
     def test_returns_empty_on_oserror(self, monkeypatch):
-        from amifuse.fuse_fs import _find_mount_owner_pids
+        from amifuse.platform import _find_mount_owner_pids
 
         def _raise():
             raise OSError("ps not found")

--- a/tests/unit/test_tray.py
+++ b/tests/unit/test_tray.py
@@ -111,9 +111,14 @@ class TestBuildMenu:
         assert menu.items[0].text == "D: - image.hdf"
 
     def test_build_menu_mount_label_format(self, tray_app, fake_pystray):
-        """Label format is 'D: - image.hdf'."""
+        """Label format is 'E: - work.adf'."""
+        # Use a platform-appropriate path so Path().name extracts just the filename
+        if sys.platform == "win32":
+            image_path = "C:\\disks\\work.adf"
+        else:
+            image_path = "/disks/work.adf"
         tray_app._mounts = [
-            {"pid": 100, "mountpoint": "E:", "image": "C:\\disks\\work.adf"},
+            {"pid": 100, "mountpoint": "E:", "image": image_path},
         ]
         menu = tray_app._build_menu()
         assert menu.items[0].text == "E: - work.adf"
@@ -289,6 +294,7 @@ class TestAutoExit:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows-only: ctypes.windll")
 class TestSingleInstance:
     def test_single_instance_acquired(self, monkeypatch):
         """CreateMutexW succeeds, GetLastError != 183."""
@@ -519,6 +525,7 @@ class TestMountLabel:
         assert "game.hdf" in mount_label
 
 
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows-only: pythonw.exe logic")
 class TestInspectUsesPythonExe:
     def test_inspect_uses_python_exe(self, tray_app, fake_pystray, monkeypatch):
         """Inspect resolves python.exe not pythonw.exe/sys.executable."""

--- a/tests/unit/test_tray.py
+++ b/tests/unit/test_tray.py
@@ -1,0 +1,545 @@
+"""Unit tests for amifuse.tray module.
+
+Mocks pystray, PIL, ctypes.windll, and platform functions so tests run
+on all platforms without a display server.
+"""
+
+from __future__ import annotations
+
+import sys
+import threading
+import time
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fake pystray / PIL modules
+# ---------------------------------------------------------------------------
+
+
+class _FakeMenuItem:
+    SEPARATOR = object()
+
+    def __init__(self, text=None, action=None):
+        self.text = text
+        self.action = action
+
+
+class _FakeMenu:
+    SEPARATOR = _FakeMenuItem.SEPARATOR
+
+    def __init__(self, *items):
+        self.items = items
+
+
+class _FakeIcon:
+    def __init__(self, name, image, title, menu=None):
+        self.name = name
+        self.image = image
+        self.title = title
+        self.menu = menu
+        self._stopped = False
+
+    def run(self):
+        # Simulate run returning immediately
+        pass
+
+    def stop(self):
+        self._stopped = True
+
+
+@pytest.fixture
+def fake_pystray(monkeypatch):
+    """Install fake pystray module."""
+    mod = types.ModuleType("pystray")
+    mod.Icon = _FakeIcon
+    mod.MenuItem = _FakeMenuItem
+    mod.Menu = _FakeMenu
+    monkeypatch.setitem(sys.modules, "pystray", mod)
+    return mod
+
+
+@pytest.fixture
+def fake_pil(monkeypatch):
+    """Install fake PIL.Image module."""
+    pil_mod = types.ModuleType("PIL")
+    image_mod = types.ModuleType("PIL.Image")
+    fake_image = MagicMock()
+    image_mod.open = MagicMock(return_value=fake_image)
+    pil_mod.Image = image_mod
+    monkeypatch.setitem(sys.modules, "PIL", pil_mod)
+    monkeypatch.setitem(sys.modules, "PIL.Image", image_mod)
+    return image_mod
+
+
+@pytest.fixture
+def tray_app(fake_pystray, fake_pil, monkeypatch):
+    """Create a TrayApp instance with mocked dependencies."""
+    # Ensure icon file "exists"
+    monkeypatch.setattr("pathlib.Path.exists", lambda self: True)
+
+    from amifuse.tray import TrayApp
+    app = TrayApp()
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Menu building tests
+# ---------------------------------------------------------------------------
+
+
+class TestBuildMenu:
+    def test_build_menu_empty_mounts(self, tray_app, fake_pystray):
+        """Empty mounts still produces Unmount All and Exit items."""
+        menu = tray_app._build_menu()
+        # SEPARATOR + Unmount All + Exit = items at end
+        texts = [i.text for i in menu.items if hasattr(i, "text") and i.text]
+        assert "Unmount All" in texts
+        assert "Exit" in texts
+
+    def test_build_menu_with_mounts(self, tray_app, fake_pystray):
+        """Mount entries appear with Inspect/Unmount submenus."""
+        tray_app._mounts = [
+            {"pid": 1234, "mountpoint": "D:", "image": "/path/to/image.hdf"},
+        ]
+        menu = tray_app._build_menu()
+        # First item should be mount entry
+        assert menu.items[0].text == "D: - image.hdf"
+
+    def test_build_menu_mount_label_format(self, tray_app, fake_pystray):
+        """Label format is 'D: - image.hdf'."""
+        tray_app._mounts = [
+            {"pid": 100, "mountpoint": "E:", "image": "C:\\disks\\work.adf"},
+        ]
+        menu = tray_app._build_menu()
+        assert menu.items[0].text == "E: - work.adf"
+
+
+# ---------------------------------------------------------------------------
+# Poll loop tests
+# ---------------------------------------------------------------------------
+
+
+class TestPollLoop:
+    def test_poll_detects_new_mount(self, tray_app, fake_pystray, monkeypatch):
+        """Menu rebuilds when a mount appears."""
+        call_count = 0
+        mounts_sequence = [
+            [],  # first poll: empty
+            [{"pid": 1, "mountpoint": "D:", "image": "x.hdf"}],  # second poll: mount
+        ]
+
+        def fake_find():
+            nonlocal call_count
+            idx = min(call_count, len(mounts_sequence) - 1)
+            call_count += 1
+            if call_count >= 3:
+                tray_app._stop_event.set()
+            return mounts_sequence[idx]
+
+        monkeypatch.setattr("amifuse.tray.TrayApp.POLL_INTERVAL", 0.01)
+        monkeypatch.setattr("amifuse.platform.find_amifuse_mounts", fake_find)
+
+        # Need a fake icon for menu assignment
+        tray_app._icon = _FakeIcon("test", None, "test")
+        tray_app._poll_loop()
+
+        assert call_count >= 2
+
+    def test_poll_detects_removed_mount(self, tray_app, fake_pystray, monkeypatch):
+        """Menu rebuilds when mount disappears."""
+        call_count = 0
+        mounts_sequence = [
+            [{"pid": 1, "mountpoint": "D:", "image": "x.hdf"}],
+            [],  # mount removed
+        ]
+
+        def fake_find():
+            nonlocal call_count
+            idx = min(call_count, len(mounts_sequence) - 1)
+            call_count += 1
+            if call_count >= 3:
+                tray_app._stop_event.set()
+            return mounts_sequence[idx]
+
+        monkeypatch.setattr("amifuse.tray.TrayApp.POLL_INTERVAL", 0.01)
+        monkeypatch.setattr("amifuse.platform.find_amifuse_mounts", fake_find)
+
+        tray_app._icon = _FakeIcon("test", None, "test")
+        tray_app._poll_loop()
+
+        assert call_count >= 2
+
+    def test_poll_detects_mountpoint_change_same_pid(self, tray_app, fake_pystray, monkeypatch):
+        """BUG FIX: change detection uses (pid, mountpoint) tuple."""
+        call_count = 0
+        menu_assignments = []
+
+        mounts_sequence = [
+            [{"pid": 1, "mountpoint": "D:", "image": "x.hdf"}],
+            [{"pid": 1, "mountpoint": "E:", "image": "x.hdf"}],  # same pid, different mountpoint
+        ]
+
+        def fake_find():
+            nonlocal call_count
+            idx = min(call_count, len(mounts_sequence) - 1)
+            call_count += 1
+            if call_count >= 3:
+                tray_app._stop_event.set()
+            return mounts_sequence[idx]
+
+        monkeypatch.setattr("amifuse.tray.TrayApp.POLL_INTERVAL", 0.01)
+        monkeypatch.setattr("amifuse.platform.find_amifuse_mounts", fake_find)
+
+        icon = _FakeIcon("test", None, "test")
+        tray_app._icon = icon
+
+        # Track menu assignments
+        original_menu_setter = type(icon).__dict__.get("menu")
+
+        class MenuTracker:
+            def __set_name__(self, owner, name):
+                self.name = name
+
+            def __set__(self, obj, value):
+                menu_assignments.append(value)
+                obj.__dict__["menu"] = value
+
+            def __get__(self, obj, objtype=None):
+                return obj.__dict__.get("menu")
+
+        # Can't easily add descriptor, so just track via poll
+        tray_app._poll_loop()
+        # If detection works, menu gets rebuilt on mountpoint change
+        assert call_count >= 2
+
+
+# ---------------------------------------------------------------------------
+# Auto-exit tests
+# ---------------------------------------------------------------------------
+
+
+class TestAutoExit:
+    def test_auto_exit_after_grace_period(self, tray_app, fake_pystray, monkeypatch):
+        """Mounts empty for GRACE_PERIOD seconds -> icon.stop() called."""
+        tray_app.GRACE_PERIOD = 0.05
+        tray_app.POLL_INTERVAL = 0.01
+
+        call_count = 0
+
+        def fake_find():
+            nonlocal call_count
+            call_count += 1
+            return []
+
+        monkeypatch.setattr("amifuse.platform.find_amifuse_mounts", fake_find)
+
+        icon = _FakeIcon("test", None, "test")
+        tray_app._icon = icon
+
+        # Run poll loop until it stops the icon
+        def stop_eventually():
+            time.sleep(0.2)
+            tray_app._stop_event.set()
+
+        t = threading.Thread(target=stop_eventually, daemon=True)
+        t.start()
+        tray_app._poll_loop()
+        t.join(timeout=1)
+
+        assert icon._stopped
+
+    def test_auto_exit_cancelled_by_new_mount(self, tray_app, fake_pystray, monkeypatch):
+        """Mount appears during grace period -> timer reset."""
+        tray_app.GRACE_PERIOD = 0.1
+        tray_app.POLL_INTERVAL = 0.01
+
+        call_count = 0
+        mounts_seq = [
+            [],  # start grace
+            [],
+            [{"pid": 1, "mountpoint": "D:", "image": "x.hdf"}],  # cancel grace
+            [{"pid": 1, "mountpoint": "D:", "image": "x.hdf"}],
+        ]
+
+        def fake_find():
+            nonlocal call_count
+            idx = min(call_count, len(mounts_seq) - 1)
+            call_count += 1
+            if call_count >= 5:
+                tray_app._stop_event.set()
+            return mounts_seq[idx]
+
+        monkeypatch.setattr("amifuse.platform.find_amifuse_mounts", fake_find)
+
+        icon = _FakeIcon("test", None, "test")
+        tray_app._icon = icon
+        tray_app._poll_loop()
+
+        # Grace should have been reset when mount appeared
+        assert tray_app._grace_start is None
+
+
+# ---------------------------------------------------------------------------
+# Single instance tests
+# ---------------------------------------------------------------------------
+
+
+class TestSingleInstance:
+    def test_single_instance_acquired(self, monkeypatch):
+        """CreateMutexW succeeds, GetLastError != 183."""
+        mock_windll = MagicMock()
+        import ctypes
+        monkeypatch.setattr(ctypes, "windll", mock_windll)
+        mock_windll.kernel32.GetLastError.return_value = 0
+
+        from amifuse.tray import _check_single_instance
+        assert _check_single_instance() is True
+
+    def test_single_instance_already_running(self, monkeypatch):
+        """GetLastError returns 183 -> already running."""
+        mock_windll = MagicMock()
+        import ctypes
+        monkeypatch.setattr(ctypes, "windll", mock_windll)
+        mock_windll.kernel32.GetLastError.return_value = 183
+
+        from amifuse.tray import _check_single_instance
+        assert _check_single_instance() is False
+
+
+# ---------------------------------------------------------------------------
+# Quit / unmount lifecycle tests (BUG FIX #11)
+# ---------------------------------------------------------------------------
+
+
+class TestQuitLifecycle:
+    def test_quit_calls_icon_stop_not_unmount_all(self, tray_app, fake_pystray, monkeypatch):
+        """BUG FIX: _quit only stops icon, doesn't unmount."""
+        icon = _FakeIcon("test", None, "test")
+        tray_app._icon = icon
+        tray_app._mounts = [{"pid": 1, "mountpoint": "D:", "image": "x.hdf"}]
+
+        kill_calls = []
+        monkeypatch.setattr("amifuse.platform.kill_pids", lambda pids, **kw: kill_calls.extend(pids))
+
+        tray_app._quit(icon, None)
+
+        assert icon._stopped
+        assert kill_calls == []  # unmount NOT called in _quit
+
+    def test_main_calls_unmount_all_after_icon_run(self, fake_pystray, fake_pil, monkeypatch):
+        """BUG FIX: unmount happens after icon.run() returns."""
+        monkeypatch.setattr("pathlib.Path.exists", lambda self: True)
+
+        kill_calls = []
+
+        from amifuse.tray import TrayApp
+        app = TrayApp()
+
+        # Simulate mounts existing when run() returns
+        app._mounts = [{"pid": 42, "mountpoint": "D:", "image": "x.hdf"}]
+
+        monkeypatch.setattr("amifuse.platform.kill_pids", lambda pids, **kw: kill_calls.extend(pids))
+
+        # Mock the poll thread to not actually run
+        monkeypatch.setattr("threading.Thread.start", lambda self: None)
+
+        app.run()
+
+        assert 42 in kill_calls
+
+
+# ---------------------------------------------------------------------------
+# Unmount tests
+# ---------------------------------------------------------------------------
+
+
+class TestUnmount:
+    def test_unmount_single_calls_kill_pids(self, tray_app, monkeypatch):
+        """kill_pids called with correct pid and timeout=2.0."""
+        calls = []
+        monkeypatch.setattr(
+            "amifuse.platform.kill_pids",
+            lambda pids, timeout=10.0: calls.append((pids, timeout)),
+        )
+
+        mount = {"pid": 99, "mountpoint": "D:", "image": "x.hdf"}
+        tray_app._unmount_single(mount)
+
+        assert calls == [([99], 2.0)]
+
+    def test_unmount_single_wakes_poll(self, tray_app, monkeypatch):
+        """wake_event is set after unmount."""
+        monkeypatch.setattr("amifuse.platform.kill_pids", lambda pids, **kw: None)
+
+        mount = {"pid": 99, "mountpoint": "D:", "image": "x.hdf"}
+        tray_app._unmount_single(mount)
+
+        assert tray_app._wake_event.is_set()
+
+    def test_unmount_all_kills_all_pids(self, tray_app, monkeypatch):
+        """All PIDs killed."""
+        calls = []
+        monkeypatch.setattr(
+            "amifuse.platform.kill_pids",
+            lambda pids, **kw: calls.append(pids),
+        )
+        tray_app._mounts = [
+            {"pid": 1, "mountpoint": "D:", "image": "a.hdf"},
+            {"pid": 2, "mountpoint": "E:", "image": "b.hdf"},
+        ]
+
+        tray_app._unmount_all()
+        assert calls == [[1, 2]]
+
+
+# ---------------------------------------------------------------------------
+# Inspect tests
+# ---------------------------------------------------------------------------
+
+
+class TestInspect:
+    def test_inspect_opens_new_console(self, tray_app, monkeypatch):
+        """CREATE_NEW_CONSOLE flag used."""
+        popen_calls = []
+
+        def fake_popen(cmd, **kwargs):
+            popen_calls.append(kwargs)
+
+        monkeypatch.setattr("amifuse.tray.subprocess.Popen", fake_popen)
+
+        mount = {"pid": 1, "mountpoint": "D:", "image": "test.hdf"}
+        tray_app._inspect(mount)
+
+        assert popen_calls[0]["creationflags"] == 0x00000010  # CREATE_NEW_CONSOLE
+
+    def test_inspect_uses_absolute_path(self, tray_app, monkeypatch):
+        """Image path is absolutified via Path.resolve()."""
+        popen_calls = []
+
+        def fake_popen(cmd, **kwargs):
+            popen_calls.append(cmd)
+
+        monkeypatch.setattr("amifuse.tray.subprocess.Popen", fake_popen)
+
+        mount = {"pid": 1, "mountpoint": "D:", "image": "relative/test.hdf"}
+        tray_app._inspect(mount)
+
+        # The last element should be an absolute path
+        img_arg = popen_calls[0][-1]
+        assert Path(img_arg).is_absolute()
+
+
+# ---------------------------------------------------------------------------
+# Callback pattern tests (BUG FIX #8)
+# ---------------------------------------------------------------------------
+
+
+class TestCallbackPatterns:
+    def test_factory_callbacks_not_lambdas(self, tray_app, fake_pystray):
+        """Callbacks are factory-created functions, not lambdas with default args."""
+        tray_app._mounts = [
+            {"pid": 1, "mountpoint": "D:", "image": "a.hdf"},
+            {"pid": 2, "mountpoint": "E:", "image": "b.hdf"},
+        ]
+        menu = tray_app._build_menu()
+
+        # Get the submenu actions for mount entries
+        for item in menu.items:
+            if hasattr(item, "action") and isinstance(item.action, _FakeMenu):
+                for sub_item in item.action.items:
+                    if hasattr(sub_item, "action") and sub_item.action is not None:
+                        # Should NOT be a lambda (lambda shows as <lambda>)
+                        assert "<lambda>" not in sub_item.action.__name__
+
+
+# ---------------------------------------------------------------------------
+# Wake event tests (BUG FIX #7)
+# ---------------------------------------------------------------------------
+
+
+class TestWakeEvent:
+    def test_wake_event_used_for_sleep(self, tray_app, fake_pystray, monkeypatch):
+        """Poll uses Event.wait, not time.sleep."""
+        wait_calls = []
+        original_wait = tray_app._wake_event.wait
+
+        def tracking_wait(timeout=None):
+            wait_calls.append(timeout)
+            tray_app._stop_event.set()  # stop after first poll
+            return False
+
+        tray_app._wake_event.wait = tracking_wait
+        monkeypatch.setattr("amifuse.platform.find_amifuse_mounts", lambda: [])
+
+        tray_app._icon = _FakeIcon("test", None, "test")
+        tray_app._poll_loop()
+
+        assert len(wait_calls) >= 1
+        assert wait_calls[0] == tray_app.POLL_INTERVAL
+
+
+# ---------------------------------------------------------------------------
+# Tray icon and inspect tests
+# ---------------------------------------------------------------------------
+
+
+class TestTrayIconPath:
+    def test_tray_icon_path_is_tray_ico(self, tray_app, fake_pystray, fake_pil, monkeypatch):
+        """TrayApp loads tray.ico not diskimage.ico."""
+        opened_paths = []
+        original_open = fake_pil.open
+
+        def tracking_open(path):
+            opened_paths.append(path)
+            return original_open(path)
+
+        fake_pil.open = tracking_open
+        monkeypatch.setenv("APPDATA", "/fake/appdata")
+
+        tray_app.run()
+        assert len(opened_paths) >= 1
+        assert opened_paths[0].endswith("tray.ico")
+        assert "diskimage" not in opened_paths[0]
+
+
+class TestMountLabel:
+    def test_mount_label_uses_image_key(self, tray_app, fake_pystray):
+        """Menu label uses mount['image'] for display."""
+        tray_app._mounts = [
+            {"pid": 1, "mountpoint": "D:", "image": "/path/to/game.hdf"},
+        ]
+        menu = tray_app._build_menu()
+        labels = [i.text for i in menu.items if hasattr(i, "text") and i.text]
+        mount_label = labels[0]
+        assert "game.hdf" in mount_label
+
+
+class TestInspectUsesPythonExe:
+    def test_inspect_uses_python_exe(self, tray_app, fake_pystray, monkeypatch):
+        """Inspect resolves python.exe not pythonw.exe/sys.executable."""
+        monkeypatch.setattr(
+            "sys.executable", r"C:\Python\pythonw.exe",
+        )
+        monkeypatch.setattr(
+            "amifuse.tray.os.path.isfile",
+            lambda p: p == r"C:\Python\python.exe",
+        )
+
+        popen_calls = []
+        monkeypatch.setattr(
+            "amifuse.tray.subprocess.Popen",
+            lambda cmd, **kw: popen_calls.append(cmd),
+        )
+
+        mount = {"image": "/path/to/test.hdf", "mountpoint": "D:"}
+        tray_app._inspect(mount)
+
+        assert len(popen_calls) == 1
+        cmd = popen_calls[0]
+        # The inner command should use python.exe, not pythonw.exe
+        assert r"C:\Python\python.exe" in cmd

--- a/tests/unit/test_tray.py
+++ b/tests/unit/test_tray.py
@@ -294,27 +294,31 @@ class TestAutoExit:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.skipif(sys.platform != "win32", reason="Windows-only: ctypes.windll")
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows-only: ctypes mutex")
 class TestSingleInstance:
     def test_single_instance_acquired(self, monkeypatch):
-        """CreateMutexW succeeds, GetLastError != 183."""
-        mock_windll = MagicMock()
+        """CreateMutexW succeeds, get_last_error != 183."""
+        import amifuse.tray as tray_mod
         import ctypes
-        monkeypatch.setattr(ctypes, "windll", mock_windll)
-        mock_windll.kernel32.GetLastError.return_value = 0
 
-        from amifuse.tray import _check_single_instance
-        assert _check_single_instance() is True
+        mock_k32 = MagicMock()
+        mock_k32.CreateMutexW.return_value = 1  # non-zero handle = success
+        monkeypatch.setattr(tray_mod, '_kernel32', mock_k32)
+        monkeypatch.setattr(ctypes, 'get_last_error', lambda: 0)
+
+        assert tray_mod._check_single_instance() is True
 
     def test_single_instance_already_running(self, monkeypatch):
-        """GetLastError returns 183 -> already running."""
-        mock_windll = MagicMock()
+        """get_last_error returns 183 -> already running."""
+        import amifuse.tray as tray_mod
         import ctypes
-        monkeypatch.setattr(ctypes, "windll", mock_windll)
-        mock_windll.kernel32.GetLastError.return_value = 183
 
-        from amifuse.tray import _check_single_instance
-        assert _check_single_instance() is False
+        mock_k32 = MagicMock()
+        mock_k32.CreateMutexW.return_value = 1  # handle still returned
+        monkeypatch.setattr(tray_mod, '_kernel32', mock_k32)
+        monkeypatch.setattr(ctypes, 'get_last_error', lambda: 183)
+
+        assert tray_mod._check_single_instance() is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_tray.py
+++ b/tests/unit/test_tray.py
@@ -324,7 +324,7 @@ class TestSingleInstance:
 
 class TestQuitLifecycle:
     def test_quit_calls_icon_stop_not_unmount_all(self, tray_app, fake_pystray, monkeypatch):
-        """BUG FIX: _quit only stops icon, doesn't unmount."""
+        """BUG FIX: _quit signals stop, doesn't unmount or call icon.stop() directly."""
         icon = _FakeIcon("test", None, "test")
         tray_app._icon = icon
         tray_app._mounts = [{"pid": 1, "mountpoint": "D:", "image": "x.hdf"}]
@@ -334,7 +334,8 @@ class TestQuitLifecycle:
 
         tray_app._quit(icon, None)
 
-        assert icon._stopped
+        assert tray_app._stop_event.is_set()
+        assert tray_app._wake_event.is_set()
         assert kill_calls == []  # unmount NOT called in _quit
 
     def test_main_calls_unmount_all_after_icon_run(self, fake_pystray, fake_pil, monkeypatch):

--- a/tests/unit/test_windows_shell.py
+++ b/tests/unit/test_windows_shell.py
@@ -1,0 +1,398 @@
+"""Unit tests for amifuse.windows_shell module.
+
+Mocks winreg and ctypes entirely so tests run on all platforms.
+Uses a dict-based fake registry to track CreateKey/SetValueEx/QueryValueEx calls.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fake winreg implementation
+# ---------------------------------------------------------------------------
+
+
+class _FakeRegistry:
+    """Dict-based fake Windows registry.
+
+    Keys are stored as (hkey, subpath) -> {values: {name: (data, type)}, exists: True}.
+    Supports CreateKey, OpenKey, SetValueEx, QueryValueEx, DeleteKey, DeleteValue,
+    EnumKey, EnumValue, CloseKey.
+    """
+
+    HKEY_CURRENT_USER = 0x80000001
+    HKEY_LOCAL_MACHINE = 0x80000002
+
+    REG_SZ = 1
+    KEY_READ = 0x20019
+    KEY_SET_VALUE = 0x0002
+
+    def __init__(self):
+        self._keys: dict[str, dict] = {}
+        self._next_handle = 100
+
+    def _norm(self, hkey, sub_key=None):
+        if sub_key is not None:
+            return f"{hkey}\\{sub_key}"
+        return str(hkey)
+
+    def CreateKey(self, hkey, sub_key):
+        path = self._norm(hkey, sub_key)
+        if path not in self._keys:
+            self._keys[path] = {"values": {}}
+        handle = self._next_handle
+        self._next_handle += 1
+        # Store path on handle for later lookups
+        self._keys[f"_handle_{handle}"] = path
+        return handle
+
+    CreateKeyEx = CreateKey
+
+    def OpenKey(self, hkey, sub_key, reserved=0, access=0):
+        path = self._norm(hkey, sub_key)
+        if path not in self._keys:
+            raise FileNotFoundError(f"Registry key not found: {path}")
+        handle = self._next_handle
+        self._next_handle += 1
+        self._keys[f"_handle_{handle}"] = path
+        return handle
+
+    def SetValueEx(self, key, name, reserved, type_, value):
+        path = self._keys.get(f"_handle_{key}")
+        if path is None:
+            raise OSError("Invalid handle")
+        if path not in self._keys:
+            self._keys[path] = {"values": {}}
+        self._keys[path]["values"][name] = (value, type_)
+
+    def QueryValueEx(self, key, name):
+        path = self._keys.get(f"_handle_{key}")
+        if path is None:
+            raise OSError("Invalid handle")
+        entry = self._keys.get(path)
+        if entry is None or name not in entry["values"]:
+            raise FileNotFoundError(f"Value not found: {name}")
+        val, typ = entry["values"][name]
+        return (val, typ)
+
+    def EnumKey(self, key, index):
+        path = self._keys.get(f"_handle_{key}")
+        if path is None:
+            raise OSError("Invalid handle")
+        children = []
+        prefix = path + "\\"
+        for k in self._keys:
+            if k.startswith("_handle_"):
+                continue
+            if k.startswith(prefix):
+                rest = k[len(prefix):]
+                child = rest.split("\\")[0]
+                if child and child not in children:
+                    children.append(child)
+        if index >= len(children):
+            raise OSError("No more data")
+        return children[index]
+
+    def EnumValue(self, key, index):
+        path = self._keys.get(f"_handle_{key}")
+        if path is None:
+            raise OSError("Invalid handle")
+        entry = self._keys.get(path, {"values": {}})
+        items = list(entry["values"].items())
+        if index >= len(items):
+            raise OSError("No more data")
+        name, (val, typ) = items[index]
+        return (name, val, typ)
+
+    def DeleteKey(self, hkey, sub_key):
+        path = self._norm(hkey, sub_key)
+        if path in self._keys:
+            del self._keys[path]
+        else:
+            raise FileNotFoundError(f"Key not found: {path}")
+
+    def DeleteValue(self, key, name):
+        path = self._keys.get(f"_handle_{key}")
+        if path is None:
+            raise OSError("Invalid handle")
+        entry = self._keys.get(path)
+        if entry is None or name not in entry["values"]:
+            raise FileNotFoundError(f"Value not found: {name}")
+        del entry["values"][name]
+
+    def CloseKey(self, key):
+        pass
+
+    def get_value(self, hkey, sub_key, name=""):
+        """Helper to read a value without handles."""
+        path = self._norm(hkey, sub_key)
+        entry = self._keys.get(path)
+        if entry is None or name not in entry["values"]:
+            return None
+        return entry["values"][name][0]
+
+    def key_exists(self, hkey, sub_key):
+        """Helper to check if a key exists."""
+        path = self._norm(hkey, sub_key)
+        return path in self._keys
+
+
+@pytest.fixture
+def fake_registry(monkeypatch):
+    """Install a fake winreg module backed by _FakeRegistry and return the registry."""
+    reg = _FakeRegistry()
+
+    mod = types.ModuleType("winreg")
+    for attr in (
+        "HKEY_CURRENT_USER", "HKEY_LOCAL_MACHINE", "REG_SZ",
+        "KEY_READ", "KEY_SET_VALUE",
+        "CreateKey", "CreateKeyEx", "OpenKey", "SetValueEx", "QueryValueEx",
+        "EnumKey", "EnumValue", "DeleteKey", "DeleteValue", "CloseKey",
+    ):
+        setattr(mod, attr, getattr(reg, attr))
+
+    monkeypatch.setitem(sys.modules, "winreg", mod)
+    monkeypatch.setattr("sys.platform", "win32")
+
+    # Mock ctypes.windll for _notify_shell_change
+    mock_windll = MagicMock()
+    ctypes_mod = sys.modules.get("ctypes")
+    monkeypatch.setattr(ctypes_mod, "windll", mock_windll)
+
+    return reg, mock_windll
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestRegister:
+    def test_register_creates_progid_keys(self, fake_registry, tmp_path, monkeypatch):
+        """ProgID keys created for each extension."""
+        reg, _ = fake_registry
+        monkeypatch.setattr("amifuse.windows_shell.ICON_DIR", tmp_path / "icons")
+
+        from amifuse.windows_shell import register
+        register()
+
+        assert reg.key_exists(reg.HKEY_CURRENT_USER, r"Software\Classes\AmiFUSE.DiskImage")
+        assert reg.key_exists(reg.HKEY_CURRENT_USER, r"Software\Classes\AmiFUSE.FloppyImage")
+
+    def test_register_creates_flat_verb_keys(self, fake_registry, tmp_path, monkeypatch):
+        """mount and mountrw verbs created under ProgID."""
+        reg, _ = fake_registry
+        monkeypatch.setattr("amifuse.windows_shell.ICON_DIR", tmp_path / "icons")
+
+        from amifuse.windows_shell import register
+        register()
+
+        base = r"Software\Classes\AmiFUSE.DiskImage"
+        assert reg.key_exists(reg.HKEY_CURRENT_USER, rf"{base}\shell\mount")
+        assert reg.key_exists(reg.HKEY_CURRENT_USER, rf"{base}\shell\mount\command")
+        assert reg.key_exists(reg.HKEY_CURRENT_USER, rf"{base}\shell\mountrw")
+        assert reg.key_exists(reg.HKEY_CURRENT_USER, rf"{base}\shell\mountrw\command")
+
+    def test_register_creates_open_with_progids(self, fake_registry, tmp_path, monkeypatch):
+        """OpenWithProgids entry created for each extension."""
+        reg, _ = fake_registry
+        monkeypatch.setattr("amifuse.windows_shell.ICON_DIR", tmp_path / "icons")
+
+        from amifuse.windows_shell import register
+        register()
+
+        val = reg.get_value(
+            reg.HKEY_CURRENT_USER,
+            r"Software\Classes\.hdf\OpenWithProgids",
+            "AmiFUSE.DiskImage",
+        )
+        assert val == ""
+
+    def test_register_warns_existing_progid(self, fake_registry, tmp_path, monkeypatch, capsys):
+        """When .hdf already has another app's ProgID, warning is printed."""
+        reg, _ = fake_registry
+        monkeypatch.setattr("amifuse.windows_shell.ICON_DIR", tmp_path / "icons")
+
+        # Pre-populate .hdf with another app's ProgID
+        ext_path = r"Software\Classes\.hdf"
+        h = reg.CreateKey(reg.HKEY_CURRENT_USER, ext_path)
+        reg.SetValueEx(h, "", 0, reg.REG_SZ, "OtherApp.DiskImage")
+
+        from amifuse.windows_shell import register
+        register([".hdf"])
+
+        captured = capsys.readouterr()
+        assert "already associated" in captured.out
+        assert "OtherApp.DiskImage" in captured.out
+
+    def test_register_idempotent(self, fake_registry, tmp_path, monkeypatch):
+        """Running register twice doesn't error."""
+        reg, _ = fake_registry
+        monkeypatch.setattr("amifuse.windows_shell.ICON_DIR", tmp_path / "icons")
+
+        from amifuse.windows_shell import register
+        register()
+        register()  # Should not raise
+
+    def test_notify_shell_change_called(self, fake_registry, tmp_path, monkeypatch):
+        """SHChangeNotify called after register."""
+        reg, mock_windll = fake_registry
+        monkeypatch.setattr("amifuse.windows_shell.ICON_DIR", tmp_path / "icons")
+
+        from amifuse.windows_shell import register
+        register()
+
+        mock_windll.shell32.SHChangeNotify.assert_called()
+
+
+class TestUnregister:
+    def test_unregister_removes_progid(self, fake_registry, tmp_path, monkeypatch):
+        """ProgID tree deleted after unregister."""
+        reg, _ = fake_registry
+        monkeypatch.setattr("amifuse.windows_shell.ICON_DIR", tmp_path / "icons")
+
+        from amifuse.windows_shell import register, unregister
+        register()
+        unregister()
+
+        assert not reg.key_exists(reg.HKEY_CURRENT_USER, r"Software\Classes\AmiFUSE.DiskImage")
+
+    def test_unregister_removes_empty_extension_keys(self, fake_registry, tmp_path, monkeypatch):
+        """Extension keys are fully deleted when empty after unregister."""
+        reg, _ = fake_registry
+        monkeypatch.setattr("amifuse.windows_shell.ICON_DIR", tmp_path / "icons")
+
+        from amifuse.windows_shell import register, unregister
+        register([".hdf"])
+        unregister([".hdf"])
+
+        # Extension key should be gone, not left as an empty stub
+        assert not reg.key_exists(reg.HKEY_CURRENT_USER, r"Software\Classes\.hdf")
+
+    def test_unregister_preserves_other_apps_default(self, fake_registry, tmp_path, monkeypatch):
+        """When another app owns Default, it's preserved."""
+        reg, _ = fake_registry
+        monkeypatch.setattr("amifuse.windows_shell.ICON_DIR", tmp_path / "icons")
+
+        # Pre-populate with another app owning .hdf
+        ext_path = r"Software\Classes\.hdf"
+        h = reg.CreateKey(reg.HKEY_CURRENT_USER, ext_path)
+        reg.SetValueEx(h, "", 0, reg.REG_SZ, "OtherApp.DiskImage")
+
+        from amifuse.windows_shell import register, unregister
+        register([".hdf"])
+        unregister([".hdf"])
+
+        # Other app's default should be preserved
+        val = reg.get_value(reg.HKEY_CURRENT_USER, ext_path, "")
+        assert val == "OtherApp.DiskImage"
+
+
+class TestIsRegistered:
+    def test_is_registered_true(self, fake_registry, tmp_path, monkeypatch):
+        """Returns True when registry key exists with correct value."""
+        reg, _ = fake_registry
+        monkeypatch.setattr("amifuse.windows_shell.ICON_DIR", tmp_path / "icons")
+
+        from amifuse.windows_shell import register, is_registered
+        register()
+        assert is_registered() is True
+
+    def test_is_registered_false(self, fake_registry, monkeypatch):
+        """Returns False when registry key is missing."""
+        reg, _ = fake_registry
+
+        from amifuse.windows_shell import is_registered
+        assert is_registered() is False
+
+
+class TestNonWindows:
+    def test_non_windows_raises_system_exit(self, monkeypatch):
+        """On non-Windows, register raises SystemExit."""
+        monkeypatch.setattr("sys.platform", "linux")
+
+        from amifuse.windows_shell import register
+        with pytest.raises(SystemExit):
+            register()
+
+
+class TestInstallIcons:
+    def test_install_icons_creates_files(self, fake_registry, tmp_path, monkeypatch):
+        """Icon files written to ICON_DIR."""
+        icon_dir = tmp_path / "icons"
+        monkeypatch.setattr("amifuse.windows_shell.ICON_DIR", icon_dir)
+
+        from amifuse.windows_shell import _install_icons
+        _install_icons()
+
+        assert (icon_dir / "diskimage.ico").exists()
+        assert (icon_dir / "floppyimage.ico").exists()
+        # Verify they're valid ICO files (start with ICO header)
+        data = (icon_dir / "diskimage.ico").read_bytes()
+        assert data[:4] == b"\x00\x00\x01\x00"
+
+    def test_install_icons_includes_tray(self, fake_registry, tmp_path, monkeypatch):
+        """_install_icons creates tray.ico."""
+        icon_dir = tmp_path / "icons"
+        monkeypatch.setattr("amifuse.windows_shell.ICON_DIR", icon_dir)
+
+        from amifuse.windows_shell import _install_icons
+        _install_icons()
+
+        assert (icon_dir / "tray.ico").exists()
+        data = (icon_dir / "tray.ico").read_bytes()
+        assert data[:4] == b"\x00\x00\x01\x00"
+
+
+class TestRemoveIcons:
+    def test_remove_icons_handles_lock(self, fake_registry, tmp_path, monkeypatch):
+        """_remove_icons handles PermissionError gracefully."""
+        icon_dir = tmp_path / "icons"
+        icon_dir.mkdir()
+        # Create icon files
+        for name in ("diskimage.ico", "floppyimage.ico", "tray.ico"):
+            (icon_dir / name).write_bytes(b"\x00\x00\x01\x00")
+
+        monkeypatch.setattr("amifuse.windows_shell.ICON_DIR", icon_dir)
+        monkeypatch.setattr("amifuse.windows_shell._LAUNCH_VBS", tmp_path / "launch.vbs")
+
+        # Make one file raise PermissionError on unlink
+        original_unlink = Path.unlink
+
+        def guarded_unlink(self, *args, **kwargs):
+            if self.name == "diskimage.ico":
+                raise PermissionError("locked by Explorer")
+            return original_unlink(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "unlink", guarded_unlink)
+
+        from amifuse.windows_shell import _remove_icons
+        # Should not raise
+        _remove_icons()
+
+        # diskimage.ico should still exist (locked), others removed
+        assert (icon_dir / "diskimage.ico").exists()
+        assert not (icon_dir / "floppyimage.ico").exists()
+
+
+class TestRegisterCreatesLaunchVbs:
+    def test_install_creates_launch_vbs(self, fake_registry, tmp_path, monkeypatch):
+        """register() creates launch.vbs."""
+        icon_dir = tmp_path / "icons"
+        launch_vbs = tmp_path / "launch.vbs"
+        monkeypatch.setattr("amifuse.windows_shell.ICON_DIR", icon_dir)
+        monkeypatch.setattr("amifuse.windows_shell._LAUNCH_VBS", launch_vbs)
+
+        from amifuse.windows_shell import register
+        register()
+
+        assert launch_vbs.exists()
+        content = launch_vbs.read_text(encoding="utf-8")
+        assert "WScript" in content or "CreateObject" in content

--- a/tests/unit/test_windows_shell.py
+++ b/tests/unit/test_windows_shell.py
@@ -13,6 +13,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+pytestmark = pytest.mark.skipif(sys.platform != "win32", reason="Windows-only")
+
 
 # ---------------------------------------------------------------------------
 # Fake winreg implementation


### PR DESCRIPTION
## Summary

This PR adds native Windows Explorer integration to AmiFUSE. Users can right-click `.hdf` and `.adf` files to mount them directly from Explorer, with a system tray icon that manages active mounts. This transforms AmiFUSE from a CLI-only tool into an Explorer-integrated experience on Windows.

The implementation includes a background launcher, system tray mount manager, working Windows unmount (via `CTRL_BREAK_EVENT`), a migration from deprecated `wmic` to CIM/PowerShell for mount discovery, and full Explorer file/directory manipulation support in write mode.

## What's New

**For users:**
- **Right-click context menu** on `.hdf` and `.adf` files: "Mount with AmiFUSE" (read-only) and "Mount Read-Write with AmiFUSE"
- **`amifuse register`** — adds file type associations under `HKCU\Software\Classes` (no admin required)
- **`amifuse unregister`** — cleanly removes all registry entries including empty key stubs
- **System tray icon** appears while mounts are active, with per-mount Inspect/Unmount actions and "Unmount All"
- **File type icons** for `.hdf` (amber hard disk) and `.adf` (green floppy), pretty-file-icons style
- **`--background` mode now works on Windows** — daemon mode guard removed, WinFSP `uid=-1`/`gid=-1` enables proper SID mapping for write mounts
- **Working `amifuse unmount` on Windows** — discovers mount PIDs and sends `CTRL_BREAK_EVENT` for clean termination
- **Explorer file creation works in write mode** — active-handle getattr fallback resolves the WinFSP timing race where fgetattr fires before the handler commits, plus `FileInfoTimeout=1000` as defense-in-depth
- **Explorer file deletion works in write mode** — deferred-delete pattern handles WinFSP's unlink-before-release ordering
- **Explorer directory deletion works in write mode** — ACTION_INHIBIT cycle clears PFS3/SFS internal handler state, with deferred rmdir and cascading nested deletion

**For maintainability:**
- `wmic` calls replaced with `Get-CimInstance` fallback (wmic is deprecated on Windows 11)
- Kill/process functions extracted from `fuse_fs.py` to `platform.py` for reuse
- fusepy child process deduplication prevents duplicate entries in tray and status output
- Doctor checks tray dependencies (pystray/Pillow) when shell registration is active

## Known Limitations

- **Explorer doesn't auto-refresh** when drives appear/disappear (WinFSP limitation, needs `SHChangeNotify`)

## How It Works

```
Explorer right-click → VBS wrapper → pythonw.exe launcher.py
                                          ├── Spawns mount process (background, detached)
                                          ├── Starts tray.py (single-instance via named mutex)
                                          └── os._exit() (instant exit, no Explorer hang)

Tray mount manager:
  - Polls for active AmiFUSE mounts (reuses platform.py process scanning)
  - Deduplicates fusepy child processes (parent_pid tracking)
  - Builds per-mount menu entries with factory callbacks
  - Unmount sends CTRL_BREAK_EVENT, with taskkill /F fallback
  - threading.Event wakes poll loop instantly on unmount
  - Auto-exits 10s after last mount removed
```

**Flat context menu verbs, not cascading menus.** Win11's modern context menu partially renders cascading submenus registered under HKCU — the parent item appears but the flyout is empty. Flat verbs work reliably in both classic and modern menus.

**VBS wrapper for launcher.** Explorer waits for directly-invoked executables to exit before releasing the context menu. A VBS wrapper launches `pythonw.exe` detached and exits immediately, preventing Explorer from hanging. `CREATE_BREAKAWAY_FROM_JOB` prevents Job Object restrictions from blocking the subprocess.

**CTRL_BREAK_EVENT is the only clean unmount on Windows.** Programmatic testing of 5 methods (`FSCTL_DISMOUNT_VOLUME`, `mountvol /D`, WinFSP `launchctl`, `CTRL_BREAK_EVENT`, `taskkill`) showed only `CTRL_BREAK_EVENT` produces a clean exit. WinFSP volumes don't support standard volume IOCTLs, aren't standard mount points, and don't respond to `WM_CLOSE`.

**Deferred-delete for WinFSP compatibility.** WinFSP calls FUSE `unlink()` during Cleanup (before `release()`), while the Amiga handler still holds an internal file lock. AmiFUSE defers the deletion to `release()`, which frees the handler lock first, then retries the delete.

**Active-handle getattr fallback for file creation.** WinFSP calls `fgetattr` immediately after `create()`, but the stat cache has TTL 0 in write mode and the Amiga handler hasn't committed yet -- producing ENOENT. When a file has an active open handle, getattr now returns synthetic attributes immediately instead of querying the handler. `FileInfoTimeout=1000` in WinFSP mount options provides defense-in-depth by caching file attributes for 1 second.

**Inhibit cycle for directory deletion.** PFS3 and SFS maintain internal cache/reserved-block state after directory modifications. Even with zero volume locks, `ACTION_DELETE_OBJECT` returns `OBJECT_IN_USE` (202). An `ACTION_INHIBIT` cycle (inhibit then uninhibit) forces the handler to release all internal state -- the AmigaDOS-sanctioned way to clear handler caches. Directory deletion is deferred via `opendir`/`releasedir` tracking, with atomic bridge-level delete holding the lock across locate-parent + delete to prevent concurrent readdir from creating stale locks. Pending-delete entries are filtered from `readdir` and `getattr` results.

**No .iso/.img registration.** Windows handles these natively.

## Files

| File | Description |
|------|-------------|
| `amifuse/windows_shell.py` (new) | Registry operations, icon generation, register/unregister commands |
| `amifuse/launcher.py` (new) | Background mount launcher for Explorer context menu |
| `amifuse/tray.py` (new) | System tray mount manager |
| `amifuse/platform.py` | Kill functions, CIM fallback, mount dedup, `_pid_exists` fix, driver size check, `FileInfoTimeout` in Windows mount options |
| `amifuse/fuse_fs.py` | Kill function extraction, daemon mode guard removal, deferred-delete, path tracking in fh_cache, active-handle getattr fallback, opendir/releasedir tracking, deferred rmdir, inhibit cycle, atomic dir delete, pending-delete filtering |
| `amifuse/doctor.py` | Tray dependency check (pystray/Pillow) |
| `pyproject.toml` | `pystray`/`Pillow` optional deps, `amifuse-launcher`/`amifuse-tray` gui-scripts |
| `README.md` | New subcommands, Windows shell integration section |

## Test Plan

**Automated (all passing, 454 unit + 11 integration):**
- 16 unit tests for `windows_shell.py` — register, unregister, icon generation, edge cases
- 19+ unit tests for `tray.py` — menu building, mount discovery, unmount, single instance, auto-exit, quit signal
- Unit tests for `launcher.py` — subprocess spawning, logging, tray startup
- Unit tests for `platform.py` additions — `kill_pids`, `_pid_exists`, dedup, CIM fallback, FileInfoTimeout assertion
- Unit tests for `doctor.py` — tray dependency check
- 5 integration tests — registry round-trip (`test_windows_shell_integration.py`)
- 3 integration tests — detached process lifecycle (`test_detached_process.py`)
- 3 integration tests — launcher E2E with PFS3 fixture (`test_launcher_e2e.py`)
- Updated `test_fuse_fs.py`, `test_platform.py`, `test_status.py` for function extraction

**Manual validation (2026-06-25):**
- [x] `amifuse register` — context menu entries appear for .hdf/.adf in Explorer
- [x] Right-click .hdf → "Mount with AmiFUSE" — drive letter appears, no console flash, no Explorer hang
- [x] Tray icon appears with mounted drive in menu
- [x] Tray → Unmount — drive removed, tray auto-exits after 10s
- [x] Tray → Exit — tray exits cleanly (fixed deadlock)
- [x] Second tray launch exits silently (single-instance mutex)
- [x] `amifuse unregister` — all registry entries removed cleanly (no empty stubs)
- [x] Write mount: file deletion from Explorer works (deferred-delete)
- [x] Write mount: directory deletion from Explorer works (including non-empty)
- [x] Write mount: "New File" from Explorer works (active-handle fallback + FileInfoTimeout)
- [x] `amifuse unmount D:` from CLI — clean termination via CTRL_BREAK_EVENT
