### PR TITLE
fix: pin stat cache across create→release window in write mode

### DIFF
--- a/amifuse/fuse_fs.py
+++ b/amifuse/fuse_fs.py
@@ -21,7 +21,7 @@ import time
 # signal available.
 _SIGKILL = getattr(signal, "SIGKILL", signal.SIGTERM)
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Set, Tuple
 
 try:
     from fuse import FUSE, FuseOSError, LoggingMixIn, Operations  # type: ignore
@@ -1461,6 +1461,13 @@ class AmigaFuseFS(Operations):
         self._neg_cache_ttl = 3600.0  # Cache negative results for 1 hour
         self._dir_cache: Dict[str, Tuple[float, List[str]]] = {}  # path -> (timestamp, entries)
         self._dir_cache_ttl = 3600.0  # Cache directory listings for 1 hour
+        # Paths whose stat cache entry must survive even at TTL=0. libfuse2's
+        # high-level API calls getattr immediately after create() to fill the
+        # entry reply; if that probe hit PFS3 it would get ERROR_OBJECT_IN_USE
+        # while the new file's handle is still open, and the kernel would
+        # return ENOENT to userspace. Populated by create(), cleared by
+        # release()/unlink().
+        self._pinned_stats: Set[str] = set()
         if self.bridge._write_enabled:
             self._cache_ttl = 0.0
             self._neg_cache_ttl = 0.0
@@ -1542,7 +1549,7 @@ class AmigaFuseFS(Operations):
         """Return cached stat result if still valid, else None."""
         if path in self._stat_cache:
             ts, result = self._stat_cache[path]
-            if time.time() - ts < self._cache_ttl:
+            if (time.time() - ts < self._cache_ttl) or path in self._pinned_stats:
                 return result
             del self._stat_cache[path]
         return None
@@ -1883,6 +1890,18 @@ class AmigaFuseFS(Operations):
                 raise FuseOSError(errno.EIO)
             entry["pos"] = offset + written
             entry["dirty"] = True  # Mark as needing flush on close
+        # Keep pinned stat cache in sync so a mid-write getattr (e.g. cp -v
+        # checking progress) sees the growing size rather than the size=0
+        # baseline written by create().
+        if path in self._pinned_stats:
+            cached = self._stat_cache.get(path)
+            if cached is not None:
+                ts, stat = cached
+                new_size = max(stat["st_size"], offset + written)
+                if new_size != stat["st_size"]:
+                    stat = dict(stat)
+                    stat["st_size"] = new_size
+                    self._stat_cache[path] = (ts, stat)
         return written
 
     def truncate(self, path, length, fh=None):
@@ -1941,6 +1960,9 @@ class AmigaFuseFS(Operations):
                     "dirty": True,  # New files are always dirty
                 }
             # Prime stat/dir cache so immediate getattr after create doesn't fail.
+            # Pin the entry: in write mode _cache_ttl is 0, so without pinning
+            # libfuse2's post-create getattr probe would fall through to PFS3
+            # and get ERROR_OBJECT_IN_USE on the still-open handle.
             now = time.time()
             self._stat_cache[path] = (
                 now,
@@ -1955,6 +1977,7 @@ class AmigaFuseFS(Operations):
                     "st_gid": self._gid,
                 },
             )
+            self._pinned_stats.add(path)
             parent_path, _ = self._split_path(path)
             self._dir_cache.pop(parent_path, None)
             self._log_op("create", path, f"SUCCESS handle={handle} fh_addr=0x{fh_addr:x}")
@@ -1987,6 +2010,7 @@ class AmigaFuseFS(Operations):
         if res1 == 0:
             raise FuseOSError(errno.EIO)
         self._stat_cache.pop(path, None)
+        self._pinned_stats.discard(path)
         self._dir_cache.pop(dir_path, None)
         for l in reversed(locks):
             self.bridge.free_lock(l)
@@ -2033,6 +2057,8 @@ class AmigaFuseFS(Operations):
             raise FuseOSError(errno.EIO)
         self._stat_cache.pop(old, None)
         self._stat_cache.pop(new, None)
+        self._pinned_stats.discard(old)
+        self._pinned_stats.discard(new)
         self._dir_cache.pop(src_dir, None)
         self._dir_cache.pop(dst_dir, None)
         for l in reversed(src_locks):
@@ -2288,6 +2314,10 @@ class AmigaFuseFS(Operations):
             parent_lock = entry.get("parent_lock", 0)
             if parent_lock:
                 self.bridge.free_lock(parent_lock)
+        # Unpin stat cache so future getattr re-queries PFS3 for current size.
+        self._pinned_stats.discard(path)
+        if self._cache_ttl <= 0:
+            self._stat_cache.pop(path, None)
         return 0
 
     def destroy(self, path):

--- a/tests/unit/test_fuse_fs.py
+++ b/tests/unit/test_fuse_fs.py
@@ -3828,3 +3828,170 @@ class TestCreateBridgeReadOnlyParam:
         )
         fuse_fs_mod._create_bridge_from_args(args, "test", read_only=False)
         assert captured.get("read_only") is False
+
+
+# ---------------------------------------------------------------------------
+# TestPinnedStatCache -- regression tests for the create -> getattr race
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def write_fs(fuse_mock):
+    """Write-enabled AmigaFuseFS over a MagicMock bridge.
+
+    Returns (fs, bridge). The bridge has _write_enabled=True so cache TTLs
+    are set to 0 in __init__, which is the configuration where the
+    create -> getattr race manifested.
+    """
+    from amifuse.fuse_fs import AmigaFuseFS
+
+    bridge = MagicMock()
+    bridge._write_enabled = True
+    bridge.state = None  # _check_handler_alive treats this as "not crashed"
+    fs = AmigaFuseFS(bridge, debug=False, icons=False)
+    return fs, bridge
+
+
+class TestPinnedStatCache:
+    """Stat cache must survive the create() -> getattr() -> release() window
+    in write mode. Without pinning, libfuse2's post-create getattr probe
+    falls through to the handler, which returns ERROR_OBJECT_IN_USE on the
+    still-open FINDOUTPUT handle. The kernel then translates that to ENOENT
+    and cp on Linux fails with "No such file or directory" while leaving a
+    zero-byte stub on disk.
+    """
+
+    def test_write_mode_uses_zero_cache_ttls(self, write_fs):
+        """Precondition: write mode does set _cache_ttl to 0 (the trigger)."""
+        fs, _ = write_fs
+        assert fs._cache_ttl == 0.0
+        assert fs._neg_cache_ttl == 0.0
+        assert fs._dir_cache_ttl == 0.0
+
+    def test_create_populates_stat_cache_and_pins_path(self, write_fs):
+        """create() must seed _stat_cache AND add the path to _pinned_stats
+        so the entry survives the TTL=0 check.
+        """
+        fs, bridge = write_fs
+        # bridge.open_file returns (fh_addr, parent_lock)
+        bridge.open_file.return_value = (0x4abbc, 0)
+
+        fh = fs.create("/Makefile", 0o100664)
+
+        assert fh > 0
+        assert "/Makefile" in fs._stat_cache
+        assert "/Makefile" in fs._pinned_stats
+        bridge.open_file.assert_called_once()
+
+    def test_get_cached_stat_returns_pinned_entry_despite_zero_ttl(self, write_fs):
+        """The bug: _get_cached_stat used to return None for entries set
+        in write mode (TTL=0) even when they had just been written. With
+        pinning, the entry survives.
+        """
+        fs, bridge = write_fs
+        bridge.open_file.return_value = (0x4abbc, 0)
+        fs.create("/Makefile", 0o100664)
+
+        cached = fs._get_cached_stat("/Makefile")
+
+        assert cached is not None, (
+            "create()-primed entry must be visible to the immediate "
+            "follow-up getattr; without pinning libfuse2 returns ENOENT "
+            "to userspace and cp errors out."
+        )
+        assert cached["st_mode"] == 0o100644
+
+    def test_getattr_after_create_does_not_hit_handler(self, write_fs):
+        """Whole-stack reproduction: getattr right after create() must be
+        served from the pinned cache, not from bridge.stat_path() (which
+        would return ERROR_OBJECT_IN_USE on the still-open handle).
+        """
+        fs, bridge = write_fs
+        bridge.open_file.return_value = (0x4abbc, 0)
+        fs.create("/Makefile", 0o100664)
+
+        # Tripwire: any call to stat_path means the cache miss happened
+        # and the bug is back. The actual bug path returned None here.
+        bridge.stat_path.side_effect = AssertionError(
+            "post-create getattr fell through to handler instead of "
+            "hitting the pinned stat cache"
+        )
+
+        attrs = fs.getattr("/Makefile")
+
+        assert attrs["st_mode"] == 0o100644
+        bridge.stat_path.assert_not_called()
+
+    def test_release_unpins_path(self, write_fs):
+        """After release(), the file handle is closed and PFS3 can serve
+        fresh stats again; the pinned entry must be dropped so subsequent
+        getattr re-queries the handler (and sees real size, mtime, etc.).
+        """
+        fs, bridge = write_fs
+        bridge.open_file.return_value = (0x4abbc, 0)
+        bridge.close_file.return_value = None
+        fh = fs.create("/Makefile", 0o100664)
+
+        fs.release("/Makefile", fh)
+
+        assert "/Makefile" not in fs._pinned_stats
+        # In write mode (TTL=0) the entry itself is also dropped, so the
+        # next getattr will go to the handler.
+        assert "/Makefile" not in fs._stat_cache
+        bridge.close_file.assert_called_once_with(0x4abbc)
+
+    def test_write_keeps_pinned_size_in_sync(self, write_fs):
+        """While a file is pinned (created but not yet released), write()
+        must update the cached size so a concurrent getattr does not
+        observe size=0 after data has been written.
+        """
+        fs, bridge = write_fs
+        bridge.open_file.return_value = (0x4abbc, 0)
+        # write() picks write_handle_at when entry["pos"] is None (which it
+        # is right after create()).
+        bridge.write_handle_at.return_value = 100
+        fh = fs.create("/Makefile", 0o100664)
+        # Initial primed size is 0.
+        assert fs._stat_cache["/Makefile"][1]["st_size"] == 0
+
+        fs.write("/Makefile", b"x" * 100, 0, fh)
+
+        assert fs._stat_cache["/Makefile"][1]["st_size"] == 100
+
+    def test_unlink_discards_pin(self, write_fs):
+        """unlink() must clean up _pinned_stats so a later create() of the
+        same name starts from a fresh slate.
+        """
+        fs, bridge = write_fs
+        bridge.open_file.return_value = (0x4abbc, 0)
+        bridge.close_file.return_value = None
+        bridge.locate_path.return_value = (0x6855, 0, [])
+        bridge.delete_object.return_value = (-1, 0)  # res1=-1 means success
+        fh = fs.create("/Makefile", 0o100664)
+        fs.release("/Makefile", fh)
+        # Manually re-pin to simulate the "pinned but not yet released" case
+        # so we can prove unlink scrubs it.
+        fs._pinned_stats.add("/Makefile")
+
+        fs.unlink("/Makefile")
+
+        assert "/Makefile" not in fs._pinned_stats
+        assert "/Makefile" not in fs._stat_cache
+
+    def test_rename_discards_pins_on_both_paths(self, write_fs):
+        """rename() must clean both source and destination pin entries to
+        avoid stale stat being served under the new name.
+        """
+        fs, bridge = write_fs
+        bridge.locate_path.return_value = (0x6855, 0, [])
+        bridge.rename_object.return_value = (-1, 0)
+        fs._pinned_stats.update({"/old", "/new"})
+        fs._stat_cache["/old"] = (0.0, {"st_size": 1})
+        fs._stat_cache["/new"] = (0.0, {"st_size": 2})
+
+        fs.rename("/old", "/new")
+
+        assert "/old" not in fs._pinned_stats
+        assert "/new" not in fs._pinned_stats
+        assert "/old" not in fs._stat_cache
+        assert "/new" not in fs._stat_cache


### PR DESCRIPTION
## Summary

`cp file mnt/` into a writable AmiFUSE mount on Linux errors out with `ENOENT` while leaving a zero-byte stub of the file on disk. The handler write path itself is fine — same shape of bug as 9a8c9f5 ("darwin: keep xattrs enabled for mounted volumes"), but on a different downstream FUSE op.

## Root cause

In write mode `_cache_ttl` / `_neg_cache_ttl` / `_dir_cache_ttl` are unconditionally `0.0` so listings stay fresh after writes. That has an unintended consequence for `create()`:

1. Kernel sends `FUSE_CREATE` → `AmigaFuseFS.create` runs, opens a `FINDOUTPUT` handle via the handler, primes `_stat_cache[path]` with the new file's attrs.
2. libfuse2's high-level API then calls `lookup_path` internally to fill `fuse_entry_out` for the kernel reply, which dispatches to `AmigaFuseFS.getattr`.
3. `_get_cached_stat` rejects the just-primed entry because `time.time() - ts < 0.0` is never true. Falls through to `bridge.stat_path` → `LOCATE_OBJECT` against the handler.
4. Handler returns `res2=202` (`ERROR_OBJECT_IN_USE`) because the `FINDOUTPUT` from step 1 is still holding the file.
5. `getattr` raises `ENOENT`. libfuse2 calls `release` on the open handle and returns `-ENOENT` to the kernel. cp sees `ENOENT` from `openat(O_CREAT|O_EXCL)`, exits 1, the partial file stays on disk.

Debug log from a `cp Makefile dh0/` reproduction on a fresh PFS3 partition:

```
[FUSE][create] /Makefile SUCCESS handle=1 fh_addr=0x4abbc
[FUSE][release] /Makefile fh=1                          ← libfuse2 aborts post-getattr
[poll_replies] ... res1=0x0 res2=202                    ← OBJECT_IN_USE on the followup locate
```

## Fix

Introduce `_pinned_stats: Set[str]` — paths whose `_stat_cache` entry survives even when `_cache_ttl == 0`. `create()` pins on success; `release()`, `unlink()`, and `rename()` clear the pin. `release()` also drops the cache entry in write mode so subsequent `getattr`s go back to the handler and see current size, mtime, etc. `write()` updates the pinned cached size so a `getattr` between create and release reports the growing file rather than the size=0 baseline.

## Tests

New `TestPinnedStatCache` class in `tests/unit/test_fuse_fs.py` — 8 unit tests with a `MagicMock` bridge. No FUSE, no fixtures, no `pytest.mark.fuse` — runs in the existing `unit-tests` CI job across all platforms × Python versions.

Verified to catch the regression: reverting just the pinning logic in `fuse_fs.py` makes **7 of the 8 new tests fail** (the 8th covers the existing `TTL=0` precondition). Full unit suite (170 tests) stays green.

## Manual verification

On Linux with libfuse2 (Ubuntu Resolute, fusepy 3.0.1):

```
$ amifuse format workdisk.hdf DH0 os32
$ amifuse mount workdisk.hdf --write --partition DH0 --mountpoint dh0
$ cp Makefile dh0/ && echo OK
OK
$ diff Makefile dh0/Makefile && echo matches
matches
```

Pre-fix: `cp` exits 1 with `ENOENT` and `ls dh0` shows a 0-byte `Makefile` stub.

## Test plan

- [x] `pytest tests/unit/` — 170 passed (8 new, all in `TestPinnedStatCache`)
- [x] Manual `cp` into PFS3 mount on Linux — exit 0, content roundtrips
- [ ] macOS / Windows CI — no behaviour change expected (the pinning only adds a survival check on a cache that was previously evicted immediately; on platforms where libfuse2's post-create getattr doesn't fire, the pin sits unused until `release()` clears it)

## Out of scope (possible follow-up)

A writable-mount end-to-end test in `tests/integration/test_mount_lifecycle_write.py` — real mount, real `cp` subprocess, assert exit-0 and content roundtrip — would catch this class of bug at the FUSE wire level instead of mock-level. That's a larger cross-platform scope (Linux `O_EXCL`, macOS xattrs, Windows path semantics) and the `-m fuse` CI job is still being shaken out per [e62cf4b](https://github.com/reinauer/AmiFUSE/commit/e62cf4b), so I left it out of this PR. Happy to follow up separately if useful.