### PR TITLE
fix: remap PDS\1/PDS\3 dostypes to PFS\1/PFS\3 at mount (Option B)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,12 @@ Downloads/
 **/__pycache__/
 attic/
 mnt/
+mnt-*/
+dh[0-9]*/
 *.hdf
 *.adf
+*.egg-info/
+.venv/
 BFFSFilesystem
 FastFileSystem
 SmartFileSystem

--- a/amifuse/bootstrap.py
+++ b/amifuse/bootstrap.py
@@ -20,6 +20,33 @@ def _scalar_field(struct, name: str):
     return field
 
 
+# PFS/PDS family share an identical on-disk layout — the dostype only steers
+# pfs3aio's I/O access mode at mount (see PDS3_MOUNT_BUG.md).
+_PFS_FAMILY_PREFIX = 0x50465300  # 'PFS\0'
+_PDS_FAMILY_PREFIX = 0x50445300  # 'PDS\0'
+_PFS_PDS_VERSIONS = (0x01, 0x03)  # \1 and \3 — versions known to share format
+
+
+def _remap_pds_to_pfs(dostype: int) -> int:
+    """Return ``dostype`` with the family prefix rewritten from ``PDS`` to
+    ``PFS`` for known-compatible versions (\\1 and \\3).
+
+    Other dostypes — including unknown PDS\\? versions, AFS, OFS, SFS — are
+    returned unchanged.
+    """
+    if (dostype & 0xFFFFFF00) != _PDS_FAMILY_PREFIX:
+        return dostype
+    version = dostype & 0xFF
+    if version not in _PFS_PDS_VERSIONS:
+        return dostype
+    return _PFS_FAMILY_PREFIX | version
+
+
+def is_remapped_dostype(dostype: int) -> bool:
+    """True iff ``_remap_pds_to_pfs`` would change ``dostype``."""
+    return _remap_pds_to_pfs(dostype) != dostype
+
+
 class SyntheticDosEnv:
     """Synthetic DosEnvec-like object for ADF (floppy) images."""
     def __init__(self, adf_info: ADFInfo):
@@ -93,7 +120,7 @@ class SyntheticIsoPartition:
 class BootstrapAllocator:
     def __init__(self, vh, image_path: Path, block_size=512, partition=None,
                  adf_info: Optional[ADFInfo] = None, iso_info: Optional[ISOInfo] = None,
-                 mbr_partition_index=None):
+                 mbr_partition_index=None, strict_dostype: bool = False):
         self.vh = vh
         self.alloc = vh.alloc
         self.mem = vh.alloc.get_mem()
@@ -103,6 +130,8 @@ class BootstrapAllocator:
         self.adf_info = adf_info  # Pre-detected ADF info, if any
         self.iso_info = iso_info  # Pre-detected ISO info, if any
         self.mbr_partition_index = mbr_partition_index  # For MBR disks with multiple 0x76 partitions
+        self.strict_dostype = strict_dostype  # If False, PDS\1/\3 dostypes are remapped to PFS\1/\3
+        self.remapped_dostype: Optional[tuple] = None  # (original, remapped) iff remap fired
 
     def _read_partition_env(self):
         from .rdb_inspect import open_rdisk
@@ -167,7 +196,10 @@ class BootstrapAllocator:
         # Relax mask: allow any address to avoid handler memorymask complaints
         _scalar_field(env, "de_Mask").val = 0xFFFFFFFF
         _scalar_field(env, "de_BootPri").val = de.boot_pri
-        _scalar_field(env, "de_DosType").val = de.dos_type
+        effective_dostype = de.dos_type if self.strict_dostype else _remap_pds_to_pfs(de.dos_type)
+        if effective_dostype != de.dos_type:
+            self.remapped_dostype = (de.dos_type, effective_dostype)
+        _scalar_field(env, "de_DosType").val = effective_dostype
         _scalar_field(env, "de_Baud").val = de.baud
         _scalar_field(env, "de_Control").val = de.control
         _scalar_field(env, "de_BootBlocks").val = de.boot_blocks

--- a/amifuse/fuse_fs.py
+++ b/amifuse/fuse_fs.py
@@ -115,6 +115,7 @@ class HandlerBridge:
         partition: Optional[str] = None,
         adf_info=None,
         iso_info=None,
+        strict_dostype: bool = False,
     ):
         self._lock = threading.RLock()  # Reentrant lock for thread safety
         self._debug = debug
@@ -141,6 +142,7 @@ class HandlerBridge:
         ba = BootstrapAllocator(
             self.vh, image, partition=partition, adf_info=adf_info,
             iso_info=iso_info, mbr_partition_index=mbr_idx,
+            strict_dostype=strict_dostype,
         )
         if adf_info:
             handler_name = "DF0:"
@@ -150,6 +152,15 @@ class HandlerBridge:
             handler_name = "DH0:"
         boot = ba.alloc_all(handler_seglist_baddr=seg_baddr, handler_seglist_bptr=seg_baddr, handler_name=handler_name)
         self._partition_index = boot["part"].num if boot.get("part") else 0
+        self._dostype_remap = ba.remapped_dostype
+        if ba.remapped_dostype is not None:
+            orig, new = ba.remapped_dostype
+            import amitools.fs.DosType as _DosType
+            print(
+                f"[amifuse] dostype remap: {_DosType.num_to_tag_str(orig)} "
+                f"(0x{orig:08x}) -> {_DosType.num_to_tag_str(new)} (0x{new:08x}) "
+                f"for compatibility (pass --strict-dostype to keep the original)"
+            )
 
         # Log partition geometry for debugging.
         if boot.get("part") and debug:
@@ -2394,6 +2405,7 @@ def mount_fuse(
     partition: Optional[str] = None,
     icons: bool = False,
     foreground: Optional[bool] = None,
+    strict_dostype: bool = False,
 ):
     _require_fuse()
     import amitools.fs.DosType as DosType
@@ -2534,6 +2546,7 @@ def mount_fuse(
         partition=partition,
         adf_info=adf_info,
         iso_info=iso_info,
+        strict_dostype=strict_dostype,
     )
     if _handler_has_crashed(bridge):
         bridge.close()
@@ -2599,6 +2612,7 @@ def format_volume(
     partition: str,
     volname: str = "Empty",
     debug: bool = False,
+    strict_dostype: bool = False,
 ):
     import amitools.fs.DosType as DosType
     bridge = None
@@ -2642,6 +2656,7 @@ def format_volume(
             read_only=False,
             debug=debug,
             partition=partition,
+            strict_dostype=strict_dostype,
         )
         _raise_if_handler_crashed(bridge, "format startup")
 
@@ -2701,8 +2716,23 @@ __version__ = "v0.5.0"
 __banner__ = f"amifuse {__version__} - Copyright (C) 2025-2026 by Stefan Reinauer"
 
 
-def _inspect_rdisk(rdisk, full=False):
+def _remap_candidates(rdisk):
+    """Return ``(part, original, remapped)`` tuples for partitions whose
+    dostype would be remapped at mount time.
+    """
+    from .bootstrap import _remap_pds_to_pfs
+    out = []
+    for part in rdisk.parts:
+        dt = part.part_blk.dos_env.dos_type
+        new = _remap_pds_to_pfs(dt)
+        if new != dt:
+            out.append((part, dt, new))
+    return out
+
+
+def _inspect_rdisk(rdisk, full=False, strict_dostype=False):
     """Print RDB info, filesystem drivers, and warnings for a single RDisk."""
+    import amitools.fs.DosType as DosType
     from .rdb_inspect import format_fs_summary
     for line in rdisk.get_info(full=full):
         print(line)
@@ -2716,6 +2746,24 @@ def _inspect_rdisk(rdisk, full=False):
         print("\nWarnings:")
         for w in warnings:
             print(f"  {w}")
+    candidates = _remap_candidates(rdisk)
+    if candidates:
+        print()
+        if strict_dostype:
+            for part, orig, new in candidates:
+                print(
+                    f"Note: partition {part.get_drive_name()} uses "
+                    f"{DosType.num_to_tag_str(orig)} (0x{orig:08x}); "
+                    f"--strict-dostype will keep this dostype at mount."
+                )
+        else:
+            for part, orig, new in candidates:
+                print(
+                    f"Note: partition {part.get_drive_name()} "
+                    f"({DosType.num_to_tag_str(orig)}/0x{orig:08x}) "
+                    f"will mount as {DosType.num_to_tag_str(new)}/0x{new:08x} "
+                    f"for compatibility (pass --strict-dostype to keep the original)."
+                )
 
 
 def _json_error(command: str, code: str, message: str, details: dict = None) -> dict:
@@ -2865,6 +2913,7 @@ def _create_bridge_from_args(args, command: str, read_only: bool = True):
                 driver = temp_driver
 
     # Create the bridge
+    strict_dostype = getattr(args, "strict_dostype", False)
     try:
         bridge = HandlerBridge(
             image,
@@ -2875,6 +2924,7 @@ def _create_bridge_from_args(args, command: str, read_only: bool = True):
             partition=partition,
             adf_info=adf_info,
             iso_info=iso_info,
+            strict_dostype=strict_dostype,
         )
     except SystemExit as e:
         if temp_driver is not None:
@@ -3655,6 +3705,21 @@ def cmd_inspect(args):
                 warnings = getattr(rdisk, 'rdb_warnings', [])
                 if warnings:
                     desc["warnings"] = warnings
+                remap_list = _remap_candidates(rdisk)
+                if remap_list:
+                    desc["dostype_remap"] = {
+                        "strict": bool(getattr(args, "strict_dostype", False)),
+                        "partitions": [
+                            {
+                                "name": str(p.get_drive_name()),
+                                "original": DosType.num_to_tag_str(orig),
+                                "original_raw": f"0x{orig:08x}",
+                                "remapped": DosType.num_to_tag_str(new),
+                                "remapped_raw": f"0x{new:08x}",
+                            }
+                            for p, orig, new in remap_list
+                        ],
+                    }
                 all_rdbs.append(desc)
             finally:
                 rdisk.close()
@@ -3698,7 +3763,7 @@ def cmd_inspect(args):
             try:
                 print(f"\n=== Amiga RDB in MBR partition [{mbr_ctx.mbr_partition.index}]"
                       f" (offset: {mbr_ctx.offset_blocks} sectors) ===\n")
-                _inspect_rdisk(rdisk, full=args.full)
+                _inspect_rdisk(rdisk, full=args.full, strict_dostype=getattr(args, "strict_dostype", False))
             finally:
                 rdisk.close()
                 blkdev.close()
@@ -3716,7 +3781,7 @@ def cmd_inspect(args):
                 for line in format_mbr_info(mbr_ctx):
                     print(line)
                 print()
-            _inspect_rdisk(rdisk, full=args.full)
+            _inspect_rdisk(rdisk, full=args.full, strict_dostype=getattr(args, "strict_dostype", False))
         finally:
             if rdisk is not None:
                 rdisk.close()
@@ -3744,6 +3809,7 @@ def cmd_mount(args):
         partition=args.partition,
         icons=args.icons,
         foreground=foreground,
+        strict_dostype=getattr(args, "strict_dostype", False),
     )
 
     if args.profile:
@@ -3763,6 +3829,7 @@ def cmd_format(args):
         partition=args.partition,
         volname=args.volname,
         debug=args.debug,
+        strict_dostype=getattr(args, "strict_dostype", False),
     )
 
 
@@ -4161,6 +4228,19 @@ commands:
     )
     subparsers = parser.add_subparsers(dest="command", required=True)
 
+    def _add_strict_dostype(p):
+        p.add_argument(
+            "--strict-dostype",
+            dest="strict_dostype",
+            action="store_true",
+            help=(
+                "Keep the partition's original dostype when mounting. By default "
+                "PDS\\1 and PDS\\3 are remapped to PFS\\1/PFS\\3 because they share "
+                "an identical on-disk format and avoid the unimplemented "
+                "Direct-SCSI (ACCESS_DS) code path."
+            ),
+        )
+
     # inspect subcommand
     inspect_parser = subparsers.add_parser(
         "inspect", help="Inspect RDB partitions and filesystems."
@@ -4175,6 +4255,7 @@ commands:
     inspect_parser.add_argument(
         "--json", action="store_true", help="Output machine-readable JSON instead of text."
     )
+    _add_strict_dostype(inspect_parser)
     inspect_parser.set_defaults(func=cmd_inspect)
 
     # mount subcommand
@@ -4227,6 +4308,7 @@ commands:
         "--icons", action="store_true",
         help="Convert Amiga .info icons to native macOS icons (experimental)."
     )
+    _add_strict_dostype(mount_parser)
     mount_parser.set_defaults(func=cmd_mount, foreground=None)
 
     # unmount subcommand
@@ -4270,6 +4352,7 @@ commands:
     format_parser.add_argument(
         "--debug", action="store_true", help="Enable debug logging."
     )
+    _add_strict_dostype(format_parser)
     format_parser.set_defaults(func=cmd_format)
 
     # ls subcommand
@@ -4305,6 +4388,7 @@ commands:
         "--debug", action="store_true",
         help="Enable debug logging.",
     )
+    _add_strict_dostype(ls_parser)
     ls_parser.set_defaults(func=cmd_ls)
 
     # verify subcommand
@@ -4340,6 +4424,7 @@ commands:
         "--debug", action="store_true",
         help="Enable debug logging.",
     )
+    _add_strict_dostype(verify_parser)
     verify_parser.set_defaults(func=cmd_verify)
 
     # hash subcommand
@@ -4376,6 +4461,7 @@ commands:
         "--debug", action="store_true",
         help="Enable debug logging.",
     )
+    _add_strict_dostype(hash_parser)
     hash_parser.set_defaults(func=cmd_hash)
 
     # read subcommand
@@ -4412,6 +4498,7 @@ commands:
         "--debug", action="store_true",
         help="Enable debug logging.",
     )
+    _add_strict_dostype(read_parser)
     read_parser.set_defaults(func=cmd_read)
 
     # write subcommand
@@ -4447,6 +4534,7 @@ commands:
         "--debug", action="store_true",
         help="Enable debug logging.",
     )
+    _add_strict_dostype(write_parser)
     write_parser.set_defaults(func=cmd_write)
 
     args = parser.parse_args(argv)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,7 +52,12 @@ def fuse_mock(monkeypatch):
 
     _stub_module("amifuse.driver_runtime", BlockDeviceBackend=dummy_cls)
     _stub_module("amifuse.vamos_runner", VamosHandlerRuntime=dummy_cls)
-    _stub_module("amifuse.bootstrap", BootstrapAllocator=dummy_cls)
+    _stub_module(
+        "amifuse.bootstrap",
+        BootstrapAllocator=dummy_cls,
+        _remap_pds_to_pfs=lambda dt: dt,
+        is_remapped_dostype=lambda dt: False,
+    )
     _stub_module("amifuse.process_mgr", ProcessManager=dummy_cls)
     _stub_module(
         "amifuse.startup_runner",

--- a/tests/integration/test_pds3_dostype_remap.py
+++ b/tests/integration/test_pds3_dostype_remap.py
@@ -1,0 +1,122 @@
+"""End-to-end test for the PDS\\3 -> PFS\\3 dostype remap.
+
+Skip-gated on the presence of ``testdisk.hdf`` in the repository root. That
+image uses ``PDS\\3`` dostype for its DH0 partition; without the remap,
+``amifuse ls`` returns an empty entry list (see PDS3_MOUNT_BUG.md).
+
+When the test fixture is missing the tests skip cleanly, so CI without
+the test image stays green.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TESTDISK_HDF = REPO_ROOT / "testdisk.hdf"
+
+
+def _require_testdisk():
+    if not TESTDISK_HDF.exists():
+        pytest.skip(f"testdisk.hdf not present at {TESTDISK_HDF}; "
+                    "drop a PDS\\3 image there to enable this test")
+
+
+def _run_amifuse(*args: str, timeout: float = 60.0) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-m", "amifuse", *args],
+        capture_output=True, text=True, timeout=timeout, check=False,
+    )
+
+
+def _parse_json_stdout(proc: subprocess.CompletedProcess) -> dict:
+    text = proc.stdout
+    idx = text.find("{")
+    assert idx != -1, (
+        f"No JSON object found in stdout.\nstdout: {text!r}\nstderr: {proc.stderr!r}"
+    )
+    return json.loads(text[idx:])
+
+
+class TestPds3DostypeRemap:
+    """Validates the PDS\\3 -> PFS\\3 remap path on a real image."""
+
+    def test_inspect_reports_remap(self):
+        _require_testdisk()
+        proc = _run_amifuse("inspect", "--json", str(TESTDISK_HDF))
+        assert proc.returncode == 0, (
+            f"inspect failed: stdout={proc.stdout!r} stderr={proc.stderr!r}"
+        )
+        data = _parse_json_stdout(proc)
+        assert data["status"] == "ok"
+        remap = data.get("dostype_remap")
+        assert remap is not None, (
+            "Expected dostype_remap envelope on inspect of testdisk.hdf "
+            "(its DH0 partition uses PDS\\3)."
+        )
+        assert remap["strict"] is False
+        parts = remap["partitions"]
+        assert any(p["original"].startswith("PDS\\") for p in parts)
+        assert all(p["remapped"].startswith("PFS\\") for p in parts)
+
+    def test_inspect_strict_flag_changes_envelope(self):
+        _require_testdisk()
+        proc = _run_amifuse(
+            "inspect", "--json", "--strict-dostype", str(TESTDISK_HDF)
+        )
+        assert proc.returncode == 0
+        data = _parse_json_stdout(proc)
+        remap = data.get("dostype_remap")
+        assert remap is not None
+        assert remap["strict"] is True
+
+    def test_ls_dh0_lists_entries(self, pfs3_driver):
+        _require_testdisk()
+        proc = _run_amifuse(
+            "ls", "--json",
+            "--driver", str(pfs3_driver),
+            "--partition", "DH0",
+            str(TESTDISK_HDF),
+        )
+        assert proc.returncode == 0, (
+            f"ls failed: stdout={proc.stdout!r} stderr={proc.stderr!r}"
+        )
+        data = _parse_json_stdout(proc)
+        assert data["status"] == "ok"
+        entries = data.get("entries", [])
+        assert len(entries) > 0, (
+            "Empty entry list on testdisk.hdf DH0 — the PDS\\3 -> PFS\\3 "
+            "remap did not take effect (see PDS3_MOUNT_BUG.md)."
+        )
+
+    def test_ls_dh0_strict_dostype_fails_or_empty(self, pfs3_driver):
+        """--strict-dostype reverts to the broken ACCESS_DS path.
+
+        Until Option A lands (proper HD_SCSICMD fix), mounting PDS\\3 with
+        --strict-dostype either hangs the handler or yields an empty listing.
+        We accept either outcome here — this test exists to lock in the
+        regression direction (strict-on => degraded, strict-off => works).
+        """
+        _require_testdisk()
+        proc = _run_amifuse(
+            "ls", "--json", "--strict-dostype",
+            "--driver", str(pfs3_driver),
+            "--partition", "DH0",
+            str(TESTDISK_HDF),
+            timeout=45.0,
+        )
+        if proc.returncode != 0:
+            return  # acceptable: handler refused / crashed under ACCESS_DS
+        data = _parse_json_stdout(proc)
+        entries = data.get("entries", [])
+        assert len(entries) == 0, (
+            "Strict-dostype mount of PDS\\3 unexpectedly listed entries. "
+            "If ACCESS_DS now works, update this test and revisit the "
+            "Option A follow-up in PDS3_MOUNT_BUG.md."
+        )

--- a/tests/unit/test_bootstrap.py
+++ b/tests/unit/test_bootstrap.py
@@ -4,6 +4,170 @@ import inspect
 import pytest
 
 
+class TestRemapPdsToPfs:
+    """Verify _remap_pds_to_pfs covers exactly PDS\\1 / PDS\\3 → PFS\\1 / PFS\\3."""
+
+    @pytest.mark.parametrize("dt,expected", [
+        (0x50445301, 0x50465301),  # PDS\1 -> PFS\1
+        (0x50445303, 0x50465303),  # PDS\3 -> PFS\3
+    ])
+    def test_known_pds_versions_remap_to_pfs(self, dt, expected):
+        from amifuse.bootstrap import _remap_pds_to_pfs, is_remapped_dostype
+        assert _remap_pds_to_pfs(dt) == expected
+        assert is_remapped_dostype(dt) is True
+
+    @pytest.mark.parametrize("dt", [
+        0x50465301,  # PFS\1 — already PFS, untouched
+        0x50465303,  # PFS\3
+        0x50445300,  # PDS\0 — unknown version, untouched
+        0x50445302,  # PDS\2 — unknown version, untouched
+        0x504453FF,  # PDS\xff — unknown version, untouched
+        0x41465301,  # AFS\1 — different family
+        0x444F5301,  # DOS\1 — different family
+        0x53465300,  # SFS\0
+        0x00000000,
+        0xFFFFFFFF,
+    ])
+    def test_passthrough_for_non_matching_dostypes(self, dt):
+        from amifuse.bootstrap import _remap_pds_to_pfs, is_remapped_dostype
+        assert _remap_pds_to_pfs(dt) == dt
+        assert is_remapped_dostype(dt) is False
+
+
+class TestBootstrapAllocatorDosTypeWrite:
+    """Verify alloc_all writes the (possibly remapped) dostype into de_DosType
+    and that strict_dostype=True disables the remap.
+
+    We mock the DosEnvecStruct field write to capture the value the allocator
+    writes, without spinning up the real vamos runtime.
+    """
+
+    def _make_allocator(self, dos_type, strict_dostype, monkeypatch):
+        """Build a BootstrapAllocator + run alloc_all far enough to capture
+        the de_DosType write. Returns (allocator, captured_dostype)."""
+        from amifuse import bootstrap
+
+        captured = {}
+
+        class _FakeField:
+            def __init__(self, name):
+                self._name = name
+                self.val = None  # last write wins
+
+            def __setattr__(self, attr, value):
+                if attr == "val" and self._name == "de_DosType":
+                    captured["de_DosType"] = value
+                object.__setattr__(self, attr, value)
+
+        class _SFields:
+            def get_field_by_name(self, name):
+                return _FakeField(name)
+
+        class _FakeStruct:
+            def __init__(self, *a, **kw):
+                self.sfields = _SFields()
+
+            @staticmethod
+            def get_size():
+                return 64
+
+        class _FakeAllocMem:
+            def __init__(self, addr):
+                self.addr = addr
+
+        class _FakeMem:
+            def w_block(self, *a, **kw):
+                pass
+
+        class _FakeAlloc:
+            def __init__(self):
+                self._mem = _FakeMem()
+                self._next = 0x1000
+
+            def alloc_memory(self, size, label=None):
+                addr = self._next
+                self._next += 0x100
+                return _FakeAllocMem(addr)
+
+            def get_mem(self):
+                return self._mem
+
+        class _FakeVh:
+            def __init__(self):
+                self.alloc = _FakeAlloc()
+
+        # Replace the three real structs with _FakeStruct.
+        monkeypatch.setattr(bootstrap, "DosEnvecStruct", _FakeStruct)
+        monkeypatch.setattr(bootstrap, "FileSysStartupMsgStruct", _FakeStruct)
+        monkeypatch.setattr(bootstrap, "DeviceNodeStruct", _FakeStruct)
+
+        # Synthesize a `de` with the requested dos_type.
+        class _De:
+            pass
+
+        de = _De()
+        de.size = 16
+        de.block_size = 128
+        de.sec_org = 0
+        de.surfaces = 1
+        de.sec_per_blk = 1
+        de.blk_per_trk = 32
+        de.reserved = 2
+        de.pre_alloc = 0
+        de.interleave = 0
+        de.low_cyl = 0
+        de.high_cyl = 79
+        de.num_buffer = 5
+        de.buf_mem_type = 0
+        de.max_transfer = 0xFFFFFFFF
+        de.mask = 0xFFFFFFFF
+        de.boot_pri = 0
+        de.dos_type = dos_type
+        de.baud = 0
+        de.control = 0
+        de.boot_blocks = 2
+
+        class _Part:
+            num = 0
+
+            def get_num_blocks(self):
+                return 1000
+
+        ba = bootstrap.BootstrapAllocator(
+            _FakeVh(), image_path=None,
+            strict_dostype=strict_dostype,
+        )
+        # Bypass the disk read; feed the synthesized envelope directly.
+        ba._read_partition_env = lambda: (de, None, None, _Part())
+        ba.alloc_all(handler_seglist_baddr=0, handler_seglist_bptr=0)
+        return ba, captured["de_DosType"]
+
+    def test_pds3_is_remapped_to_pfs3_by_default(self, monkeypatch):
+        ba, written = self._make_allocator(0x50445303, strict_dostype=False, monkeypatch=monkeypatch)
+        assert written == 0x50465303
+        assert ba.remapped_dostype == (0x50445303, 0x50465303)
+
+    def test_pds1_is_remapped_to_pfs1_by_default(self, monkeypatch):
+        ba, written = self._make_allocator(0x50445301, strict_dostype=False, monkeypatch=monkeypatch)
+        assert written == 0x50465301
+        assert ba.remapped_dostype == (0x50445301, 0x50465301)
+
+    def test_pfs3_is_unchanged(self, monkeypatch):
+        ba, written = self._make_allocator(0x50465303, strict_dostype=False, monkeypatch=monkeypatch)
+        assert written == 0x50465303
+        assert ba.remapped_dostype is None
+
+    def test_sfs_is_unchanged(self, monkeypatch):
+        ba, written = self._make_allocator(0x53465300, strict_dostype=False, monkeypatch=monkeypatch)
+        assert written == 0x53465300
+        assert ba.remapped_dostype is None
+
+    def test_strict_dostype_preserves_pds3(self, monkeypatch):
+        ba, written = self._make_allocator(0x50445303, strict_dostype=True, monkeypatch=monkeypatch)
+        assert written == 0x50445303
+        assert ba.remapped_dostype is None
+
+
 class TestAllocMsgport:
     """Verify alloc_msgport() initializes mp_MsgList correctly.
 


### PR DESCRIPTION
## Summary

- testdisk.hdf and other RDB images partitioned for >4 GiB use ``PDS\3`` so pfs3aio takes the Direct-SCSI (ACCESS_DS) path. Our ``scsi_device`` shim half-implements that path (sets ``IOF_QUICK`` unconditionally, never ``ReplyMsg``), so post-mount packets stall — ``amifuse ls --partition DH0 testdisk.hdf`` returns an empty entry list.
- ``PFS\?`` and ``PDS\?`` share an identical on-disk format; the dostype only steers pfs3aio's I/O access mode (``Amigadriver/src/disk.c:2134-2141``). This PR remaps ``PDS\1``/``PDS\3`` → ``PFS\1``/``PFS\3`` when filling ``de_DosType`` so the handler takes the working ``ACCESS_STD``/``ACCESS_NSD`` path.
- Adds ``--strict-dostype`` on ``inspect`` / ``mount`` / ``ls`` / ``read`` / ``write`` / ``verify`` / ``hash`` / ``format`` for users who need the original dostype once the ACCESS_DS path is fixed.
- This is Option B from ``PDS3_MOUNT_BUG.md``. The proper HD_SCSICMD fix (Option A) is a follow-up.

## What changed

- ``amifuse/bootstrap.py``: new ``_remap_pds_to_pfs()`` helper + ``is_remapped_dostype()``; ``BootstrapAllocator`` accepts ``strict_dostype=False`` and records ``remapped_dostype`` when it fires.
- ``amifuse/fuse_fs.py``: ``HandlerBridge`` / ``mount_fuse`` / ``format_volume`` / ``_create_bridge_from_args`` thread ``strict_dostype`` through; ``cmd_mount``, ``cmd_format``, and read/write/ls/verify/hash/inspect parsers gain ``--strict-dostype``; ``cmd_inspect`` surfaces the remap in text (per-partition Note: lines) and JSON (``dostype_remap`` envelope with ``strict`` + ``partitions``); a single ``[amifuse] dostype remap: …`` line prints at bridge construction when the remap fires.
- ``tests/unit/test_bootstrap.py``: parametrized coverage for the helper across all four family magics plus AFS/DOS/SFS/zero/0xffffffff; bootstrap-level test verifies ``alloc_all`` writes the remapped value into ``de_DosType`` and that ``strict_dostype=True`` preserves the original.
- ``tests/integration/test_pds3_dostype_remap.py``: end-to-end coverage skip-gated on ``testdisk.hdf`` presence at the repo root — asserts inspect surfaces the remap, ``ls --partition DH0`` returns non-empty entries, and ``--strict-dostype`` either errors or returns empty (locks in the regression direction).
- ``tests/conftest.py``: ``fuse_mock`` stub now exports the helper symbols.

## Test plan

- [x] Unit tests pass: 362 passed, 1 skipped
- [x] ``amifuse inspect testdisk.hdf`` reports the remap for DH0 + DH1 (text and JSON)
- [x] ``amifuse inspect --strict-dostype testdisk.hdf`` flips the Note: language and ``dostype_remap.strict=true``
- [x] ``amifuse inspect pfs.hdf`` shows no remap notice / no JSON key (PFS\3 untouched)
- [ ] ``amifuse ls --partition DH0 testdisk.hdf`` lists real entries (needs machine68k env)
- [ ] ``amifuse ls --partition DH1 testdisk.hdf`` lists real entries
- [ ] ``amifuse ls pfs.hdf`` unchanged

Local verification of the live ``ls`` paths is limited because this sandbox doesn't have a working ``machine68k`` install. The integration test skips automatically in that case; run it on a box with the m68k emulator to confirm. PDS3_MOUNT_BUG.md documents the underlying bug and the recommended approach in full.

## Follow-up

Open an issue for Option A — ``ACCESS_DS / HD_SCSICMD path drops post-mount packets`` — referencing ``PDS3_MOUNT_BUG.md`` and the Z3660 driver evidence (``Amigadriver/z3660-drivers/scsi/z3660_scsi.c:214,232-234,509-732``).