### PR TITLE
Improve Explorer experience with disk space, shell notifications, and double-click mount

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,10 +186,10 @@ Mount lifecycle:
 - `--interactive` / `--foreground` keeps AmiFUSE attached to the terminal.
   Use this for debugging or when you want `Ctrl+C` to unmount from the same
   shell.
-- Windows defaults to daemon mode. You can mount via the Explorer context
-  menu (`amifuse register`), unmount from the system tray icon, or use
-  `amifuse unmount <mountpoint>` from the CLI. Note: the WinFSP "Eject"
-  action does not perform a clean unmount — use the tray or CLI instead.
+- Windows defaults to daemon mode. Double-click `.hdf`/`.adf` files to mount
+  and open Explorer (requires `amifuse register`). Unmount from the system
+  tray icon or with `amifuse unmount <drive>:`. The WinFSP "Eject" action
+  does not perform a clean unmount — use the tray or CLI instead.
 - `--profile` implies interactive mode.
 
 ### Diagnosing Issues
@@ -319,8 +319,8 @@ The `--icons` flag enables conversion of Amiga `.info` icon files to native Find
 
 ## Windows Shell Integration
 
-On Windows, AmiFUSE can integrate with Explorer for a right-click mount
-experience and a system tray mount manager.
+On Windows, AmiFUSE can integrate with Explorer for double-click mounting,
+right-click context menus, and a system tray mount manager.
 
 ### Context menu registration
 
@@ -332,14 +332,34 @@ amifuse unregister    # Remove the context menu entries
 Registration writes to `HKCU` (current user only) — no administrator privileges
 are required.
 
+After registering:
+
+- **Double-click** an `.hdf` or `.adf` file to mount it and open Explorer at the
+  mounted drive
+- **Right-click** for "Mount with AmiFUSE" (read-only) or "Mount Read-Write with
+  AmiFUSE"
+
 ### Tray mount manager
 
 When a filesystem is mounted in daemon mode on Windows, the `amifuse-tray`
 helper appears in the system tray. From the tray icon you can see active mounts
-and unmount them cleanly.
+and unmount them cleanly. Each mount shows its drive letter, image name, and
+provides Inspect/Unmount actions.
 
 The tray requires optional dependencies: install them with
 `pip install amifuse[windows]` (provides pystray and Pillow).
+
+### Removing shell integration
+
+```bash
+amifuse unregister
+```
+
+Or use the installer's uninstall mode:
+
+```powershell
+.\tools\install-windows.ps1 -Uninstall
+```
 
 ## Notes
 

--- a/amifuse/fuse_fs.py
+++ b/amifuse/fuse_fs.py
@@ -2705,6 +2705,12 @@ class AmigaFuseFS(Operations):
                 self._resolve_pending_dir_deletes(resolved_path)
         return 0
 
+    def init(self, path):
+        """Called when filesystem is mounted. Notify shell on Windows."""
+        if sys.platform.startswith("win") and self._mountpoint:
+            from .platform import notify_shell_drive_change
+            notify_shell_drive_change(str(self._mountpoint), added=True)
+
     def destroy(self, path):
         """Called when filesystem is unmounted. Flush and release all resources."""
         print("[amifuse] Unmounting - flushing volume...", flush=True)
@@ -2728,6 +2734,10 @@ class AmigaFuseFS(Operations):
             print(f"[amifuse] WARNING: backend close failed: {e}", flush=True)
         # Mark bridge as closed so close() becomes a no-op if called after destroy()
         self.bridge._closed = True
+        # Notify Explorer that drive was removed
+        if sys.platform.startswith("win") and self._mountpoint:
+            from .platform import notify_shell_drive_change
+            notify_shell_drive_change(str(self._mountpoint), added=False)
         print("[amifuse] Unmount complete.", flush=True)
 
     def statfs(self, path):

--- a/amifuse/fuse_fs.py
+++ b/amifuse/fuse_fs.py
@@ -47,7 +47,7 @@ from .startup_runner import (
     _snapshot_block_state,
     _restore_block_state,
 )
-from amitools.vamos.libstructs.dos import FileInfoBlockStruct, FileHandleStruct, DosPacketStruct  # type: ignore
+from amitools.vamos.libstructs.dos import FileInfoBlockStruct, FileHandleStruct, DosPacketStruct, InfoDataStruct  # type: ignore
 from amitools.vamos.lib.dos.DosProtection import DosProtection  # type: ignore
 
 
@@ -1197,6 +1197,40 @@ class HandlerBridge:
                 self.free_lock(l)
             return info
 
+    def get_disk_info(self) -> Optional[Dict]:
+        """Query filesystem geometry via ACTION_DISK_INFO.
+
+        Returns dict with keys: num_blocks, num_blocks_used, bytes_per_block.
+        Returns None if the handler doesn't respond.
+        """
+        with self._lock:
+            # Allocate InfoDataStruct (9 LONGs = 36 bytes)
+            info_mem = self.vh.alloc.alloc_memory(InfoDataStruct.get_size(), label="InfoData")
+            self.mem.w_block(info_mem.addr, b"\x00" * InfoDataStruct.get_size())
+
+            # send_disk_info takes the buffer address (passes as BPTR internally)
+            self.launcher.send_disk_info(self.state, info_mem.addr)
+            replies = self._run_until_replies()
+
+            if not replies or replies[-1][2] == 0:
+                self.vh.alloc.free_memory(info_mem)
+                return None
+
+            # Read InfoDataStruct fields (all LONGs at known offsets):
+            # id_NumBlocks: offset 12
+            # id_NumBlocksUsed: offset 16
+            # id_BytesPerBlock: offset 20
+            num_blocks = self.mem.r32(info_mem.addr + 12)
+            num_blocks_used = self.mem.r32(info_mem.addr + 16)
+            bytes_per_block = self.mem.r32(info_mem.addr + 20)
+
+            self.vh.alloc.free_memory(info_mem)
+            return {
+                "num_blocks": num_blocks,
+                "num_blocks_used": num_blocks_used,
+                "bytes_per_block": bytes_per_block,
+            }
+
     def volume_name(self) -> str:
         """Best-effort name: RDB drive name, else first dir entry, else fallback."""
         with self._lock:
@@ -1523,6 +1557,12 @@ class AmigaFuseFS(Operations):
             self._cache_ttl = 0.0
             self._neg_cache_ttl = 0.0
             self._dir_cache_ttl = 0.0
+        # Disk info cache: infinite for read-only (geometry never changes),
+        # 30s for writable (free space changes as files are written)
+        self._disk_info_ttl = -1  # -1 means infinite (cache forever)
+        self._disk_info_cache = None  # (timestamp, result) tuple
+        if self.bridge._write_enabled:
+            self._disk_info_ttl = 30.0
         self._cache_lock = threading.RLock()  # Protects _stat_cache, _dir_cache, _neg_cache
         self._fh_lock = threading.Lock()
         self._fh_cache: Dict[int, Dict[str, object]] = {}
@@ -2689,6 +2729,56 @@ class AmigaFuseFS(Operations):
         # Mark bridge as closed so close() becomes a no-op if called after destroy()
         self.bridge._closed = True
         print("[amifuse] Unmount complete.", flush=True)
+
+    def statfs(self, path):
+        """Return filesystem statistics (disk space info).
+
+        Maps Amiga InfoData to POSIX statvfs fields for Explorer/df.
+        """
+        # Check disk info cache
+        now = time.time()
+        cached = self._disk_info_cache
+        if cached is not None:
+            cache_ts, cache_result = cached
+            ttl = self._disk_info_ttl
+            if ttl < 0 or (now - cache_ts < ttl):
+                return cache_result
+
+        info = self.bridge.get_disk_info()
+        if info is None:
+            # Fallback: return zeros (better than raising an error)
+            result = {
+                'f_bsize': 512,
+                'f_frsize': 512,
+                'f_blocks': 0,
+                'f_bfree': 0,
+                'f_bavail': 0,
+                'f_files': 0,
+                'f_ffree': 0,
+                'f_favail': 0,
+                'f_namemax': 107,  # Amiga FFS/PFS3 max filename length
+            }
+        else:
+            bsize = info['bytes_per_block']
+            total = info['num_blocks']
+            used = info['num_blocks_used']
+            free = total - used
+
+            result = {
+                'f_bsize': bsize,
+                'f_frsize': bsize,
+                'f_blocks': total,
+                'f_bfree': free,
+                'f_bavail': free,  # No reserved blocks concept in AmigaOS
+                'f_files': 0,      # Amiga FS doesn't have inode limits
+                'f_ffree': 0,
+                'f_favail': 0,
+                'f_namemax': 107,  # BSTR max: 255 minus length byte, but FFS uses 30, PFS3 uses 107
+            }
+
+        # Cache the result
+        self._disk_info_cache = (now, result)
+        return result
 
 
 def get_partition_info(image: Path, block_size: Optional[int], partition: Optional[str]) -> dict:

--- a/amifuse/fuse_fs.py
+++ b/amifuse/fuse_fs.py
@@ -1523,6 +1523,7 @@ class AmigaFuseFS(Operations):
             self._cache_ttl = 0.0
             self._neg_cache_ttl = 0.0
             self._dir_cache_ttl = 0.0
+        self._cache_lock = threading.RLock()  # Protects _stat_cache, _dir_cache, _neg_cache
         self._fh_lock = threading.Lock()
         self._fh_cache: Dict[int, Dict[str, object]] = {}
         self._next_fh = 1
@@ -1600,32 +1601,36 @@ class AmigaFuseFS(Operations):
 
     def _get_cached_stat(self, path: str) -> Optional[Dict]:
         """Return cached stat result if still valid, else None."""
-        if path in self._stat_cache:
-            ts, result = self._stat_cache[path]
-            if (time.time() - ts < self._cache_ttl) or path in self._pinned_stats:
-                return result
-            del self._stat_cache[path]
+        with self._cache_lock:
+            if path in self._stat_cache:
+                ts, result = self._stat_cache[path]
+                if (time.time() - ts < self._cache_ttl) or path in self._pinned_stats:
+                    return result
+                del self._stat_cache[path]
         return None
 
     def _set_cached_stat(self, path: str, result: Dict):
         """Cache a stat result."""
-        self._stat_cache[path] = (time.time(), result)
+        with self._cache_lock:
+            self._stat_cache[path] = (time.time(), result)
 
     def _is_neg_cached(self, path: str) -> bool:
         """Return True if path is in negative cache (known non-existent)."""
         if self._neg_cache_ttl <= 0:
             return False
-        if path in self._neg_cache:
-            if time.time() - self._neg_cache[path] < self._neg_cache_ttl:
-                return True
-            del self._neg_cache[path]
+        with self._cache_lock:
+            if path in self._neg_cache:
+                if time.time() - self._neg_cache[path] < self._neg_cache_ttl:
+                    return True
+                del self._neg_cache[path]
         return False
 
     def _set_neg_cached(self, path: str):
         """Cache a negative (ENOENT) result."""
         if self._neg_cache_ttl <= 0:
             return
-        self._neg_cache[path] = time.time()
+        with self._cache_lock:
+            self._neg_cache[path] = time.time()
 
     def _track_op(self, op: str, path: str, cached: bool = False):
         """Track operations for debugging."""
@@ -1839,9 +1844,10 @@ class AmigaFuseFS(Operations):
                     self._pending_deletes.add(resolved_path)
                 self._log_op("releasedir", resolved_path, "deferred delete failed permanently, path hidden until unmount")
             else:
-                self._stat_cache.pop(resolved_path, None)
-                parent_path = resolved_path.rsplit("/", 1)[0] or "/"
-                self._dir_cache.pop(parent_path, None)
+                with self._cache_lock:
+                    self._stat_cache.pop(resolved_path, None)
+                    parent_path = resolved_path.rsplit("/", 1)[0] or "/"
+                    self._dir_cache.pop(parent_path, None)
         except Exception as e:
             self._log_op("releasedir", resolved_path, f"deferred delete exception: {type(e).__name__}: {e}")
             with self._fh_lock:
@@ -1854,22 +1860,23 @@ class AmigaFuseFS(Operations):
     def readdir(self, path, fh):
         self._check_handler_alive()
         # Check directory cache first
-        if path in self._dir_cache:
-            ts, cached_entries = self._dir_cache[path]
-            if time.time() - ts < self._dir_cache_ttl:
-                self._track_op("readdir", path, cached=True)
-                # Filter pending deletes from cached results
-                with self._fh_lock:
-                    if self._pending_deletes:
-                        cached_entries = [
-                            e for e in cached_entries
-                            if e in (".", "..") or (
-                                (path.rstrip("/") + "/" + e if path != "/" else "/" + e)
-                                not in self._pending_deletes
-                            )
-                        ]
-                return cached_entries
-            del self._dir_cache[path]
+        with self._cache_lock:
+            if path in self._dir_cache:
+                ts, cached_entries = self._dir_cache[path]
+                if time.time() - ts < self._dir_cache_ttl:
+                    self._track_op("readdir", path, cached=True)
+                    # Filter pending deletes from cached results
+                    with self._fh_lock:
+                        if self._pending_deletes:
+                            cached_entries = [
+                                e for e in cached_entries
+                                if e in (".", "..") or (
+                                    (path.rstrip("/") + "/" + e if path != "/" else "/" + e)
+                                    not in self._pending_deletes
+                                )
+                            ]
+                    return cached_entries
+                del self._dir_cache[path]
 
         self._track_op("readdir", path, cached=False)
         entries = [".", ".."]
@@ -1903,7 +1910,8 @@ class AmigaFuseFS(Operations):
             # Set UF_HIDDEN on .info files when icons mode is enabled
             if self._icons_enabled and (name.endswith(".info") or name.lower().endswith(".info")):
                 stat_result["st_flags"] = 0x8000  # UF_HIDDEN
-            self._stat_cache[child_path] = (now, stat_result)
+            with self._cache_lock:
+                self._stat_cache[child_path] = (now, stat_result)
 
         # Add virtual icon files if this directory has a custom icon
         if self._icon_handler and self._has_valid_icon(path):
@@ -1931,7 +1939,8 @@ class AmigaFuseFS(Operations):
                 ]
 
         # Cache the directory listing
-        self._dir_cache[path] = (now, entries)
+        with self._cache_lock:
+            self._dir_cache[path] = (now, entries)
         return entries
 
     def open(self, path, flags):
@@ -2050,14 +2059,15 @@ class AmigaFuseFS(Operations):
         # checking progress) sees the growing size rather than the size=0
         # baseline written by create().
         if path in self._pinned_stats:
-            cached = self._stat_cache.get(path)
-            if cached is not None:
-                ts, stat = cached
-                new_size = max(stat["st_size"], offset + written)
-                if new_size != stat["st_size"]:
-                    stat = dict(stat)
-                    stat["st_size"] = new_size
-                    self._stat_cache[path] = (ts, stat)
+            with self._cache_lock:
+                cached = self._stat_cache.get(path)
+                if cached is not None:
+                    ts, stat = cached
+                    new_size = max(stat["st_size"], offset + written)
+                    if new_size != stat["st_size"]:
+                        stat = dict(stat)
+                        stat["st_size"] = new_size
+                        self._stat_cache[path] = (ts, stat)
         return written
 
     def truncate(self, path, length, fh=None):
@@ -2121,22 +2131,23 @@ class AmigaFuseFS(Operations):
             # libfuse2's post-create getattr probe would fall through to PFS3
             # and get ERROR_OBJECT_IN_USE on the still-open handle.
             now = time.time()
-            self._stat_cache[path] = (
-                now,
-                {
-                    "st_mode": 0o100644,
-                    "st_nlink": 1,
-                    "st_size": 0,
-                    "st_ctime": int(now),
-                    "st_mtime": int(now),
-                    "st_atime": int(now),
-                    "st_uid": self._uid,
-                    "st_gid": self._gid,
-                },
-            )
-            self._pinned_stats.add(path)
-            parent_path, _ = self._split_path(path)
-            self._dir_cache.pop(parent_path, None)
+            with self._cache_lock:
+                self._stat_cache[path] = (
+                    now,
+                    {
+                        "st_mode": 0o100644,
+                        "st_nlink": 1,
+                        "st_size": 0,
+                        "st_ctime": int(now),
+                        "st_mtime": int(now),
+                        "st_atime": int(now),
+                        "st_uid": self._uid,
+                        "st_gid": self._gid,
+                    },
+                )
+                self._pinned_stats.add(path)
+                parent_path, _ = self._split_path(path)
+                self._dir_cache.pop(parent_path, None)
             self._log_op("create", path, f"SUCCESS handle={handle} fh_addr=0x{fh_addr:x}")
             return handle
         except FuseOSError:
@@ -2173,8 +2184,9 @@ class AmigaFuseFS(Operations):
                     if has_handle:
                         self._pending_deletes.add(path)
                 if has_handle:
-                    self._stat_cache.pop(path, None)
-                    self._dir_cache.pop(dir_path, None)
+                    with self._cache_lock:
+                        self._stat_cache.pop(path, None)
+                        self._dir_cache.pop(dir_path, None)
                     for l in reversed(locks):
                         self.bridge.free_lock(l)
                     return 0
@@ -2182,9 +2194,10 @@ class AmigaFuseFS(Operations):
             for l in reversed(locks):
                 self.bridge.free_lock(l)
             raise FuseOSError(errno.EIO)
-        self._stat_cache.pop(path, None)
+        with self._cache_lock:
+            self._stat_cache.pop(path, None)
+            self._dir_cache.pop(dir_path, None)
         self._pinned_stats.discard(path)
-        self._dir_cache.pop(dir_path, None)
         for l in reversed(locks):
             self.bridge.free_lock(l)
         return 0
@@ -2209,9 +2222,10 @@ class AmigaFuseFS(Operations):
                 # OBJECT_IN_USE — defer unconditionally; releasedir will retry
                 with self._fh_lock:
                     self._pending_deletes.add(path)
-                self._stat_cache.pop(path, None)
-                self._dir_cache.pop(dir_path, None)
-                self._dir_cache.pop(path, None)
+                with self._cache_lock:
+                    self._stat_cache.pop(path, None)
+                    self._dir_cache.pop(dir_path, None)
+                    self._dir_cache.pop(path, None)
                 return 0
             if res2 == 216:
                 # DIRECTORY_NOT_EMPTY — defer only if pending children exist
@@ -2227,9 +2241,10 @@ class AmigaFuseFS(Operations):
                         self._pending_dir_deletes[path] = pending_children.copy()
                         self._pending_deletes.add(path)
                 if pending_children:
-                    self._stat_cache.pop(path, None)
-                    self._dir_cache.pop(dir_path, None)
-                    self._dir_cache.pop(path, None)
+                    with self._cache_lock:
+                        self._stat_cache.pop(path, None)
+                        self._dir_cache.pop(dir_path, None)
+                        self._dir_cache.pop(path, None)
                     self._log_op("rmdir", path, "deferred (pending child deletes)")
                     return 0
                 # No pending children — genuinely not empty
@@ -2237,9 +2252,10 @@ class AmigaFuseFS(Operations):
             # Unrecognized error
             raise FuseOSError(errno.EIO)
         # Immediate success
-        self._stat_cache.pop(path, None)
-        self._dir_cache.pop(dir_path, None)
-        self._dir_cache.pop(path, None)
+        with self._cache_lock:
+            self._stat_cache.pop(path, None)
+            self._dir_cache.pop(dir_path, None)
+            self._dir_cache.pop(path, None)
         return 0
 
     def mkdir(self, path, mode):
@@ -2256,7 +2272,8 @@ class AmigaFuseFS(Operations):
         if new_lock == 0:
             raise FuseOSError(errno.EIO)
         self.bridge.free_lock(new_lock)
-        self._dir_cache.pop(dir_path, None)
+        with self._cache_lock:
+            self._dir_cache.pop(dir_path, None)
         for l in reversed(locks):
             self.bridge.free_lock(l)
         return 0
@@ -2278,12 +2295,13 @@ class AmigaFuseFS(Operations):
         res1, _ = self.bridge.rename_object(src_lock, src_name, dst_lock, dst_name)
         if res1 == 0:
             raise FuseOSError(errno.EIO)
-        self._stat_cache.pop(old, None)
-        self._stat_cache.pop(new, None)
+        with self._cache_lock:
+            self._stat_cache.pop(old, None)
+            self._stat_cache.pop(new, None)
+            self._dir_cache.pop(src_dir, None)
+            self._dir_cache.pop(dst_dir, None)
         self._pinned_stats.discard(old)
         self._pinned_stats.discard(new)
-        self._dir_cache.pop(src_dir, None)
-        self._dir_cache.pop(dst_dir, None)
         for l in reversed(src_locks):
             self.bridge.free_lock(l)
         for l in reversed(dst_locks):
@@ -2562,8 +2580,9 @@ class AmigaFuseFS(Operations):
                 # Delete succeeded - now remove from _pending_deletes
                 with self._fh_lock:
                     self._pending_deletes.discard(parent_dir)
-                self._stat_cache.pop(parent_dir, None)
-                self._dir_cache.pop(dir_path, None)
+                with self._cache_lock:
+                    self._stat_cache.pop(parent_dir, None)
+                    self._dir_cache.pop(dir_path, None)
             except Exception:
                 self._log_op("release", parent_dir, "deferred rmdir exception, discarding")
                 # Delete failed - _pending_deletes still has it, just stop
@@ -2595,7 +2614,8 @@ class AmigaFuseFS(Operations):
         # Unpin stat cache so future getattr re-queries PFS3 for current size.
         self._pinned_stats.discard(path)
         if self._cache_ttl <= 0:
-            self._stat_cache.pop(path, None)
+            with self._cache_lock:
+                self._stat_cache.pop(path, None)
         # Resolve path: use FUSE-provided path, fall back to cached path
         resolved_path = path if path else entry.get("path")
         # Check for deferred deletes (WinFSP unlink-before-release pattern)
@@ -2633,8 +2653,9 @@ class AmigaFuseFS(Operations):
                 for l in reversed(locks):
                     self.bridge.free_lock(l)
                 if delete_succeeded:
-                    self._stat_cache.pop(resolved_path, None)
-                    self._dir_cache.pop(dir_path, None)
+                    with self._cache_lock:
+                        self._stat_cache.pop(resolved_path, None)
+                        self._dir_cache.pop(dir_path, None)
             except Exception as e:
                 self._log_op("release", resolved_path, f"deferred delete exception: {type(e).__name__}: {e}")
                 with self._fh_lock:

--- a/amifuse/fuse_fs.py
+++ b/amifuse/fuse_fs.py
@@ -1563,7 +1563,14 @@ class AmigaFuseFS(Operations):
         self._disk_info_cache = None  # (timestamp, result) tuple
         if self.bridge._write_enabled:
             self._disk_info_ttl = 30.0
-        self._cache_lock = threading.RLock()  # Protects _stat_cache, _dir_cache, _neg_cache
+        # Protects _stat_cache, _dir_cache, _neg_cache.
+        # Note: _disk_info_cache is intentionally excluded -- it uses a simpler
+        # atomic-assignment pattern (single tuple pointer write under CPython GIL,
+        # acceptable since statfs is a single-value cache with no compound
+        # read-modify-write).
+        # Lock ordering invariant: _cache_lock must always be acquired before
+        # _fh_lock, never in reverse, to prevent deadlocks.
+        self._cache_lock = threading.RLock()
         self._fh_lock = threading.Lock()
         self._fh_cache: Dict[int, Dict[str, object]] = {}
         self._next_fh = 1
@@ -2745,6 +2752,7 @@ class AmigaFuseFS(Operations):
 
         Maps Amiga InfoData to POSIX statvfs fields for Explorer/df.
         """
+        self._check_handler_alive()
         # Check disk info cache
         now = time.time()
         cached = self._disk_info_cache
@@ -2772,7 +2780,7 @@ class AmigaFuseFS(Operations):
             bsize = info['bytes_per_block']
             total = info['num_blocks']
             used = info['num_blocks_used']
-            free = total - used
+            free = max(0, total - used)
 
             result = {
                 'f_bsize': bsize,

--- a/amifuse/launcher.py
+++ b/amifuse/launcher.py
@@ -141,7 +141,7 @@ def _do_open(args) -> None:
     if not os.path.isfile(python_exe):
         python_exe = sys.executable
 
-    cmd = [python_exe, "-m", "amifuse", "mount", "--mountpoint", drive_letter, "--daemon", args.image]
+    cmd = [python_exe, "-m", "amifuse", "mount", "--write", "--mountpoint", drive_letter, "--daemon", args.image]
 
     _log(f"Launching open-mount: {cmd}")
     try:

--- a/amifuse/launcher.py
+++ b/amifuse/launcher.py
@@ -184,7 +184,7 @@ def _do_open(args) -> None:
 def _show_error(title: str, message: str) -> None:
     """Show a Windows MessageBox error. Best-effort; never raises."""
     try:
-        ctypes.windll.user32.MessageBoxW(0, message, title, 0x10)  # MB_ICONERROR
+        ctypes.windll.user32.MessageBoxW(0, ctypes.c_wchar_p(message), ctypes.c_wchar_p(title), 0x10)  # MB_ICONERROR
     except Exception:
         pass
 

--- a/amifuse/launcher.py
+++ b/amifuse/launcher.py
@@ -11,6 +11,7 @@ import ctypes
 import os
 import subprocess
 import sys
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Optional
@@ -84,98 +85,289 @@ def main(argv=None) -> None:
     os._exit(0)
 
 
+# Drive letters A:/B:/C: are reserved (floppy / system), so auto-selection
+# starts at D:. Shared by _select_drive_letter and _select_drive_letters so the
+# single-letter and multi-letter paths iterate one identical alphabet -- an A-Z
+# alphabet would hand back A:/B:/C: and over-count the free total.
+_DRIVE_LETTER_ALPHABET = "DEFGHIJKLMNOPQRSTUVWXYZ"
+
+
+def _select_drive_letters(n: int) -> tuple[list[str], int]:
+    """Return up to ``n`` free drive letters plus the total number available.
+
+    Selection uses ``platform._windows_allocated_drive_letters()`` (the Win32
+    GetLogicalDrives bitmask -- the *allocation* probe) rather than
+    ``os.path.exists`` (the *arrival* probe) so an assigned-but-empty removable
+    slot (e.g. an empty card-reader D:) is correctly treated as taken. The
+    helper returns bare uppercase letters, so candidates are compared as
+    uppercase and formatted back into ``"X:"`` strings.
+
+    Args:
+        n: Maximum number of free letters to return.
+
+    Returns:
+        A ``(chosen, total_free)`` tuple where ``chosen`` is up to ``n`` free
+        letters as ``"X:"`` strings in ``_DRIVE_LETTER_ALPHABET`` order, and
+        ``total_free`` is the total count of free letters in that alphabet. When
+        ``total_free < n`` the caller has more partitions than free letters and
+        can mount ``chosen`` best-effort while reporting the shortfall.
+    """
+    allocated = platform._windows_allocated_drive_letters()
+    free = [f"{c}:" for c in _DRIVE_LETTER_ALPHABET if c not in allocated]
+    return free[:n], len(free)
+
+
 def _select_drive_letter() -> Optional[str]:
     """Return the first unallocated drive letter as an ``"X:"`` string, or None.
 
-    Selection uses ``platform._windows_allocated_drive_letters()`` (the Win32
-    GetLogicalDrives bitmask) rather than ``os.path.exists`` so an
-    assigned-but-empty removable slot (e.g. an empty card-reader D:) is
-    correctly treated as taken -- the launcher and the core mount path share
-    one correct implementation. The helper returns bare uppercase letters, so
-    compare against uppercase candidates.
+    Thin N=1 wrapper over :func:`_select_drive_letters`; returns ``None`` when no
+    letter is free, preserving the original no-free-letter contract. Both share
+    ``_DRIVE_LETTER_ALPHABET`` so the single- and multi-letter paths never drift.
     """
-    allocated = platform._windows_allocated_drive_letters()
-    for letter in "DEFGHIJKLMNOPQRSTUVWXYZ":
-        if letter not in allocated:
-            return f"{letter}:"
-    return None
+    chosen, _ = _select_drive_letters(1)
+    return chosen[0] if chosen else None
 
 
-def _do_mount(args) -> None:
+@dataclass
+class _MountUnit:
+    """One drive to mount in a fan-out.
+
+    ``name`` is the ``--partition`` key (the RDB drive name). It is ``None`` for
+    the degenerate single-unit case -- an ADF/ISO, a single-partition RDB, the
+    duplicate-name fallback, or an un-enumerable image -- so the spawned command
+    omits ``--partition`` and is byte-for-byte the legacy single-partition path
+    (a lone partition IS index 0, which the no-``--partition`` default resolves
+    to). ``label`` is the human name used in the summary dialog.
+    """
+    name: Optional[str]
+    label: str
+
+
+def _python_exe() -> str:
+    """Return the console-free ``pythonw.exe`` beside the interpreter, or the
+    interpreter itself when it is absent. Same resolution the handlers used
+    before the fan-out."""
+    python_exe = str(Path(sys.executable).parent / "pythonw.exe")
+    if not os.path.isfile(python_exe):
+        python_exe = sys.executable
+    return python_exe
+
+
+def _aggregate_timeout(n: int) -> float:
+    """Seconds to wait for ``n`` concurrently-spawned mounts to all appear.
+
+    N=1 stays at exactly ``MOUNT_POLL_TIMEOUT`` (15.0) so the single-partition
+    path is unchanged. For N>1 the fan-out spawns all mounts first and then
+    polls a SINGLE shared deadline (not 15s x N); each extra partition adds 5s
+    of headroom for its concurrent vamos + m68k cold-init, capped at 45s:
+    ``min(15 + 5*(n - 1), 45)``. N=3 -> 25s; N>=7 -> 45s.
+    """
+    if n <= 1:
+        return MOUNT_POLL_TIMEOUT
+    return float(min(15 + 5 * (n - 1), 45))
+
+
+def _enumerate_mount_units(image: str) -> tuple[list[_MountUnit], Optional[str]]:
+    """Return ``(units, fallback_reason)`` describing what to mount.
+
+    Mirrors ``fuse_fs.mount_fuse``'s detection order: an ADF or an ISO is a
+    single logical unit (no fan-out); otherwise the RDB partitions are
+    enumerated by name via :func:`rdb_inspect.list_partitions`.
+
+    A lone partition (single-partition RDB, or the duplicate-name fallback where
+    ``list_partitions`` returns index 0 of the first RDB) collapses to a single
+    ``_MountUnit`` with ``name=None`` so the spawn is byte-for-byte the legacy
+    single-partition command.
+
+    Any enumeration failure (non-RDB / unreadable image, IOError from
+    ``open_rdisk``) degrades to a single no-``--partition`` unit -- exactly the
+    legacy behavior: spawn one mount and let the mount process itself surface a
+    failure via the poll timeout. The launcher never crashes on enumeration.
+    """
+    try:
+        from amifuse import rdb_inspect
+        img = Path(image)
+        if rdb_inspect.detect_adf(img) is not None:
+            return [_MountUnit(name=None, label="floppy disk")], None
+        if rdb_inspect.detect_iso(img) is not None:
+            return [_MountUnit(name=None, label="disc")], None
+        result = rdb_inspect.list_partitions(img)
+    except Exception as exc:
+        _log(
+            f"Partition enumeration failed for {image}: {exc!r}; "
+            "falling back to a single-partition mount"
+        )
+        return [_MountUnit(name=None, label="disk image")], None
+
+    parts = result.partitions
+    if len(parts) <= 1:
+        label = parts[0].name if parts else "disk image"
+        return [_MountUnit(name=None, label=label)], result.fallback_reason
+    units = [_MountUnit(name=p.name, label=p.name) for p in parts]
+    return units, result.fallback_reason
+
+
+def _report_summary(succeeded, skipped, spawn_failed, failed, fallback_reason) -> None:
+    """Show at most ONE summary dialog for the whole fan-out.
+
+    No dialog on a clean full success (Explorer opening the drive(s) is the
+    confirmation) -- this preserves the pre-fan-out single-partition behavior.
+    Otherwise a single ``_show_error`` names, in one composed body, the mounted
+    drives, the skipped (no free letter) partitions, the ``spawn_failed`` ones
+    (the process never started -- DEFINITE wording), and the ``failed`` ones (the
+    process spawned but its drive never appeared -- SOFT wording, may be a slow
+    cold mount), plus any ``fallback_reason``. Never one dialog per partition.
+    """
+    if not skipped and not spawn_failed and not failed and not fallback_reason:
+        return
+
+    parts = []
+    if succeeded:
+        got = ", ".join(f"{u.label} ({letter})" for u, letter in succeeded)
+        parts.append(f"Mounted {got}.")
+    if skipped:
+        names = ", ".join(u.label for u in skipped)
+        parts.append(f"Could not mount {names}: no free drive letter.")
+    if spawn_failed:
+        # Definite wording: the mount process never launched, so this is a hard
+        # failure -- do NOT soften it into "may still be starting".
+        for u, letter, reason in spawn_failed:
+            parts.append(
+                f"Could not start mount for {u.label} ({letter}): {reason}"
+            )
+    if failed:
+        names = ", ".join(f"{u.label} ({letter})" for u, letter in failed)
+        # Soft wording: a timed-out drive may be a slow cold mount, not a
+        # genuine failure -- do not assert failure.
+        parts.append(
+            f"{names} did not appear yet -- may still be starting; "
+            "check Explorer for the drive, or see the log if it doesn't appear."
+        )
+    if fallback_reason:
+        parts.append(fallback_reason)
+
+    _show_error("AmiFUSE", "\n\n".join(parts))
+
+
+def mount_image_all(image: str, *, write: bool, explorer: str) -> None:
+    """Mount every partition of ``image``, one per free drive letter (fan-out).
+
+    Shared core behind both shell paths: ``_do_open`` calls it with
+    ``write=True, explorer="per_drive"`` (one Explorer window per confirmed
+    drive) and ``_do_mount`` with ``write=False, explorer="refresh"`` (no
+    windows; each mount's FUSE ``init()`` refreshes its own drive via
+    ``platform.notify_shell_drive_change`` at fuse_fs.py:2715-2719, so the
+    launcher adds no refresh code).
+
+    Steps: enumerate units; allocate up to N free letters (best-effort partial
+    on exhaustion); spawn all mounts FIRST; poll a single aggregate deadline for
+    every drive to appear; start the tray once; show at most one summary dialog.
+
+    N=1 is the identity case -- a single unit reproduces the pre-fan-out path
+    exactly: one spawn (no ``--partition``), a 15s poll, one Explorer window on
+    ``open``, and no dialog on success.
+    """
     import time
 
-    # Select the drive letter here (via the shared helper) so we know which
-    # letter to poll for after spawning the detached mount.
-    drive_letter = _select_drive_letter()
-    if drive_letter is None:
+    units, fallback_reason = _enumerate_mount_units(image)
+    if fallback_reason:
+        _log(fallback_reason)
+
+    chosen, total_free = _select_drive_letters(len(units))
+    if total_free == 0:
         _log("No available drive letter found")
         _show_error("AmiFUSE", "No available drive letter found. Cannot mount.")
         return
 
-    python_dir = Path(sys.executable).parent
-    python_exe = str(python_dir / "pythonw.exe")
-    if not os.path.isfile(python_exe):
-        python_exe = sys.executable
+    # Best-effort partial: mount as many partitions as there are free letters,
+    # in stable RDB order; the rest are skipped (never abort the ones that fit).
+    pairs = list(zip(units, chosen))
+    skipped = units[len(pairs):]
 
-    cmd = [python_exe, "-m", "amifuse", "mount"]
-    if args.write:
-        cmd.append("--write")
-    cmd.append("--mountpoint")
-    cmd.append(drive_letter)
-    cmd.append("--daemon")
-    cmd.append(args.image)
+    python_exe = _python_exe()
 
-    _log(f"Launching mount: {cmd}")
-    try:
-        _spawn_detached(
-            cmd,
-            stdin=subprocess.DEVNULL,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            close_fds=True,
-        )
-    except Exception as exc:
-        _log(f"Failed to launch mount subprocess: {exc}")
-        _show_error("AmiFUSE", f"Failed to launch mount process:\n{exc}")
-        return
+    # Spawn ALL mounts first (they are independent processes -- verified N=2
+    # concurrent RW), then poll a single shared deadline below.
+    pending: dict[str, _MountUnit] = {}   # letter -> unit awaiting arrival
+    # Two distinct failure buckets. spawn_failed: the process NEVER launched
+    # (_spawn_detached raised) -- a definite, hard failure. failed (below): the
+    # process spawned but its drive never appeared by the deadline -- a SOFT
+    # timeout that may still be a slow cold mount. Folding the two together would
+    # mislabel a never-started mount as "may still be starting".
+    spawn_failed: list[tuple[_MountUnit, str, str]] = []  # (unit, letter, reason)
+    failed: list[tuple[_MountUnit, str]] = []
+    for unit, letter in pairs:
+        cmd = [python_exe, "-m", "amifuse", "mount"]
+        if unit.name is not None:
+            cmd += ["--partition", unit.name]
+        if write:
+            cmd.append("--write")
+        cmd += ["--mountpoint", letter, "--daemon", image]
 
-    # Poll for the mount to appear, surfacing failures via a dialog instead of
-    # exiting silently. os.path.exists is the CORRECT probe here for "did my
-    # mount appear" -- a live WinFSP mount has media, so the path becomes
-    # reachable -- but it is WRONG for "is a letter allocated" (that is the bug
-    # _select_drive_letter avoids by using the GetLogicalDrives bitmask). Do
-    # not consolidate the two probes.
-    #
-    # This intentionally blocks up to MOUNT_POLL_TIMEOUT before main() reaches
-    # os._exit(0). Safe because the mountro verb is launched hidden and
-    # non-waiting via `WScript.Shell.Run cmd, 0, False`, so Explorer's UI
-    # thread is not blocked by this wait. Do not "optimize" the poll away -- it
-    # is what surfaces mount failures instead of re-silencing them.
-    mount_path = f"{drive_letter}\\"
-    poll_interval = 0.25
-    elapsed = 0.0
-    while elapsed < MOUNT_POLL_TIMEOUT:
-        time.sleep(poll_interval)
-        elapsed += poll_interval
-        if os.path.exists(mount_path):
-            _log(f"Mount ready at {drive_letter} after {elapsed:.1f}s")
-            _ensure_tray_running()
-            return
+        _log(f"Launching mount: {cmd}")
+        try:
+            _spawn_detached(
+                cmd,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                close_fds=True,
+            )
+        except Exception as exc:
+            _log(f"Failed to launch mount for {letter}: {exc}")
+            spawn_failed.append((unit, letter, str(exc)))
+            continue
+        pending[letter] = unit
 
-    _log(f"Mount timed out after {MOUNT_POLL_TIMEOUT}s for {drive_letter}")
-    # Start the tray on the timeout path too: a slow cold mount (vamos + m68k
-    # init on a large multi-partition HDF) may still be initializing, so this
-    # may be a slow success rather than a failure. The tray self-manages and
-    # auto-exits shortly if no mounts are present, so starting it here is
-    # harmless even on a genuine failure.
+    # Single aggregate-deadline poll. os.path.exists("<letter>\\") is the CORRECT
+    # "did my mount appear" probe (a live WinFSP mount has media) and is distinct
+    # from the GetLogicalDrives allocation bitmask used to SELECT letters -- do
+    # not merge the two probes. This blocks up to the aggregate deadline before
+    # main() reaches os._exit(0); safe because both shell verbs launch hidden and
+    # non-waiting via `WScript.Shell.Run cmd, 0, False`, so Explorer's UI thread
+    # is not blocked. Do not "optimize" the poll away -- it is what surfaces
+    # mount failures instead of re-silencing them.
+    succeeded: list[tuple[_MountUnit, str]] = []
+    if pending:
+        timeout = _aggregate_timeout(len(pending))
+        poll_interval = 0.25
+        elapsed = 0.0
+        while pending and elapsed < timeout:
+            time.sleep(poll_interval)
+            elapsed += poll_interval
+            for letter in list(pending):
+                if os.path.exists(letter + "\\"):
+                    unit = pending.pop(letter)
+                    succeeded.append((unit, letter))
+                    _log(f"Mount ready at {letter} after {elapsed:.1f}s")
+                    if explorer == "per_drive":
+                        # One Explorer window per confirmed drive, opened only
+                        # once the drive is present (skipped/failed get none).
+                        try:
+                            os.startfile(letter + "\\")
+                        except OSError as exc:
+                            _log(f"Could not open Explorer for {letter}: {exc}")
+
+        # Whatever is still pending timed out -- report softly (may be a slow
+        # cold mount, an unformatted/no-driver partition that SystemExited in its
+        # own process, or a TOCTOU-lost letter). The good drives are unaffected.
+        if pending:
+            _log(f"Mounts did not appear within {timeout:.0f}s: {list(pending)}")
+            failed.extend((unit, letter) for letter, unit in pending.items())
+
+    # Start the tray exactly ONCE after the poll (idempotent via the
+    # Local\AmiFUSE_Tray_Mutex). A slow cold mount may still be initializing, so
+    # start it even on a timeout; the tray auto-exits if no mounts are present.
     _ensure_tray_running()
-    _show_error(
-        "AmiFUSE",
-        f"Drive {drive_letter} did not appear within "
-        f"{MOUNT_POLL_TIMEOUT:.0f} seconds.\n\n"
-        "It may still be starting up -- check Explorer for the drive, or see "
-        "the log if it doesn't appear.",
-    )
+
+    _report_summary(succeeded, skipped, spawn_failed, failed, fallback_reason)
+
+
+def _do_mount(args) -> None:
+    """Read-only fan-out (the ``mountro`` shell verb). Opens no windows -- each
+    mount's ``init()`` refreshes its own drive. The only shell verb routing here
+    is ``mountro``, which passes no ``--write``, so ``args.write`` is False."""
+    mount_image_all(args.image, write=args.write, explorer="refresh")
 
 
 def _do_inspect(args) -> None:
@@ -192,74 +384,10 @@ def _do_inspect(args) -> None:
 
 
 def _do_open(args) -> None:
-    """Mount an image and open Explorer to the mounted drive."""
-    import time
-
-    # Select an available drive letter via the shared helper (GetLogicalDrives
-    # bitmask), so the launcher and the core mount path agree on which letters
-    # are free -- see _select_drive_letter for why os.path.exists is wrong here.
-    drive_letter = _select_drive_letter()
-
-    if drive_letter is None:
-        _log("No available drive letter found")
-        _show_error("AmiFUSE", "No available drive letter found. Cannot mount.")
-        return
-
-    # Launch mount with explicit mountpoint
-    python_dir = Path(sys.executable).parent
-    python_exe = str(python_dir / "pythonw.exe")
-    if not os.path.isfile(python_exe):
-        python_exe = sys.executable
-
-    cmd = [python_exe, "-m", "amifuse", "mount", "--write", "--mountpoint", drive_letter, "--daemon", args.image]
-
-    _log(f"Launching open-mount: {cmd}")
-    try:
-        _spawn_detached(
-            cmd,
-            stdin=subprocess.DEVNULL,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            close_fds=True,
-        )
-    except Exception as exc:
-        _log(f"Failed to launch mount: {exc}")
-        _show_error("AmiFUSE", f"Failed to launch mount process:\n{exc}")
-        return
-
-    # Poll for mount to become ready. os.path.exists is the CORRECT probe here
-    # for "did my mount appear" (a live WinFSP mount has media) but WRONG for
-    # "is a letter allocated" -- selection above uses the GetLogicalDrives
-    # bitmask via _select_drive_letter instead. Do not merge the two probes.
-    mount_path = f"{drive_letter}\\"
-    timeout = MOUNT_POLL_TIMEOUT
-    poll_interval = 0.25
-    elapsed = 0.0
-
-    while elapsed < timeout:
-        time.sleep(poll_interval)
-        elapsed += poll_interval
-        if os.path.exists(mount_path):
-            _log(f"Mount ready at {drive_letter} after {elapsed:.1f}s, opening Explorer")
-            os.startfile(mount_path)
-            _ensure_tray_running()
-            return
-
-    # Timeout — the drive may still be initializing (slow cold mount)
-    _log(f"Mount timed out after {timeout}s for {drive_letter}")
-    # Start the tray on the timeout path too: a slow cold mount (vamos + m68k
-    # init on a large multi-partition HDF) may still be initializing, so this
-    # may be a slow success rather than a failure. The tray self-manages and
-    # auto-exits shortly if no mounts are present, so starting it here is
-    # harmless even on a genuine failure.
-    _ensure_tray_running()
-    _show_error(
-        "AmiFUSE",
-        f"Drive {drive_letter} did not appear within "
-        f"{timeout:.0f} seconds.\n\n"
-        "It may still be starting up -- check Explorer for the drive, or see "
-        "the log if it doesn't appear.",
-    )
+    """Read-write fan-out (the ``open`` shell verb -- double-click and "Mount &&
+    Open"). Mounts every partition ``--write`` and opens one Explorer window per
+    confirmed drive."""
+    mount_image_all(args.image, write=True, explorer="per_drive")
 
 
 def _show_error(title: str, message: str) -> None:

--- a/amifuse/launcher.py
+++ b/amifuse/launcher.py
@@ -13,6 +13,9 @@ import subprocess
 import sys
 from datetime import datetime
 from pathlib import Path
+from typing import Optional
+
+import amifuse.platform as platform
 
 DETACHED_PROCESS = 0x00000008
 CREATE_NEW_PROCESS_GROUP = 0x00000200
@@ -21,6 +24,10 @@ CREATE_NEW_CONSOLE = 0x00000010
 CREATE_BREAKAWAY_FROM_JOB = 0x01000000
 
 _DETACHED_FLAGS = DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW
+
+# Seconds to wait for a mount to appear before surfacing an error dialog.
+# Shared by _do_open and _do_mount so both poll loops stay in sync.
+MOUNT_POLL_TIMEOUT = 15.0
 
 _LOG_DIR = Path(os.environ.get("APPDATA", "")) / "AmiFUSE"
 
@@ -77,7 +84,34 @@ def main(argv=None) -> None:
     os._exit(0)
 
 
+def _select_drive_letter() -> Optional[str]:
+    """Return the first unallocated drive letter as an ``"X:"`` string, or None.
+
+    Selection uses ``platform._windows_allocated_drive_letters()`` (the Win32
+    GetLogicalDrives bitmask) rather than ``os.path.exists`` so an
+    assigned-but-empty removable slot (e.g. an empty card-reader D:) is
+    correctly treated as taken -- the launcher and the core mount path share
+    one correct implementation. The helper returns bare uppercase letters, so
+    compare against uppercase candidates.
+    """
+    allocated = platform._windows_allocated_drive_letters()
+    for letter in "DEFGHIJKLMNOPQRSTUVWXYZ":
+        if letter not in allocated:
+            return f"{letter}:"
+    return None
+
+
 def _do_mount(args) -> None:
+    import time
+
+    # Select the drive letter here (via the shared helper) so we know which
+    # letter to poll for after spawning the detached mount.
+    drive_letter = _select_drive_letter()
+    if drive_letter is None:
+        _log("No available drive letter found")
+        _show_error("AmiFUSE", "No available drive letter found. Cannot mount.")
+        return
+
     python_dir = Path(sys.executable).parent
     python_exe = str(python_dir / "pythonw.exe")
     if not os.path.isfile(python_exe):
@@ -86,6 +120,8 @@ def _do_mount(args) -> None:
     cmd = [python_exe, "-m", "amifuse", "mount"]
     if args.write:
         cmd.append("--write")
+    cmd.append("--mountpoint")
+    cmd.append(drive_letter)
     cmd.append("--daemon")
     cmd.append(args.image)
 
@@ -100,9 +136,46 @@ def _do_mount(args) -> None:
         )
     except Exception as exc:
         _log(f"Failed to launch mount subprocess: {exc}")
+        _show_error("AmiFUSE", f"Failed to launch mount process:\n{exc}")
         return
 
+    # Poll for the mount to appear, surfacing failures via a dialog instead of
+    # exiting silently. os.path.exists is the CORRECT probe here for "did my
+    # mount appear" -- a live WinFSP mount has media, so the path becomes
+    # reachable -- but it is WRONG for "is a letter allocated" (that is the bug
+    # _select_drive_letter avoids by using the GetLogicalDrives bitmask). Do
+    # not consolidate the two probes.
+    #
+    # This intentionally blocks up to MOUNT_POLL_TIMEOUT before main() reaches
+    # os._exit(0). Safe because the mountro verb is launched hidden and
+    # non-waiting via `WScript.Shell.Run cmd, 0, False`, so Explorer's UI
+    # thread is not blocked by this wait. Do not "optimize" the poll away -- it
+    # is what surfaces mount failures instead of re-silencing them.
+    mount_path = f"{drive_letter}\\"
+    poll_interval = 0.25
+    elapsed = 0.0
+    while elapsed < MOUNT_POLL_TIMEOUT:
+        time.sleep(poll_interval)
+        elapsed += poll_interval
+        if os.path.exists(mount_path):
+            _log(f"Mount ready at {drive_letter} after {elapsed:.1f}s")
+            _ensure_tray_running()
+            return
+
+    _log(f"Mount timed out after {MOUNT_POLL_TIMEOUT}s for {drive_letter}")
+    # Start the tray on the timeout path too: a slow cold mount (vamos + m68k
+    # init on a large multi-partition HDF) may still be initializing, so this
+    # may be a slow success rather than a failure. The tray self-manages and
+    # auto-exits shortly if no mounts are present, so starting it here is
+    # harmless even on a genuine failure.
     _ensure_tray_running()
+    _show_error(
+        "AmiFUSE",
+        f"Drive {drive_letter} did not appear within "
+        f"{MOUNT_POLL_TIMEOUT:.0f} seconds.\n\n"
+        "It may still be starting up -- check Explorer for the drive, or see "
+        "the log if it doesn't appear.",
+    )
 
 
 def _do_inspect(args) -> None:
@@ -122,13 +195,10 @@ def _do_open(args) -> None:
     """Mount an image and open Explorer to the mounted drive."""
     import time
 
-    # Find an available drive letter
-    drive_letter = None
-    for letter in "DEFGHIJKLMNOPQRSTUVWXYZ":
-        candidate = f"{letter}:"
-        if not os.path.exists(candidate + "\\"):
-            drive_letter = candidate
-            break
+    # Select an available drive letter via the shared helper (GetLogicalDrives
+    # bitmask), so the launcher and the core mount path agree on which letters
+    # are free -- see _select_drive_letter for why os.path.exists is wrong here.
+    drive_letter = _select_drive_letter()
 
     if drive_letter is None:
         _log("No available drive letter found")
@@ -157,9 +227,12 @@ def _do_open(args) -> None:
         _show_error("AmiFUSE", f"Failed to launch mount process:\n{exc}")
         return
 
-    # Poll for mount to become ready
+    # Poll for mount to become ready. os.path.exists is the CORRECT probe here
+    # for "did my mount appear" (a live WinFSP mount has media) but WRONG for
+    # "is a letter allocated" -- selection above uses the GetLogicalDrives
+    # bitmask via _select_drive_letter instead. Do not merge the two probes.
     mount_path = f"{drive_letter}\\"
-    timeout = 15.0
+    timeout = MOUNT_POLL_TIMEOUT
     poll_interval = 0.25
     elapsed = 0.0
 
@@ -172,12 +245,20 @@ def _do_open(args) -> None:
             _ensure_tray_running()
             return
 
-    # Timeout — mount may have failed
+    # Timeout — the drive may still be initializing (slow cold mount)
     _log(f"Mount timed out after {timeout}s for {drive_letter}")
+    # Start the tray on the timeout path too: a slow cold mount (vamos + m68k
+    # init on a large multi-partition HDF) may still be initializing, so this
+    # may be a slow success rather than a failure. The tray self-manages and
+    # auto-exits shortly if no mounts are present, so starting it here is
+    # harmless even on a genuine failure.
+    _ensure_tray_running()
     _show_error(
         "AmiFUSE",
-        f"Mount timed out waiting for {drive_letter}.\n\n"
-        "The image may be invalid or the filesystem handler failed to start.",
+        f"Drive {drive_letter} did not appear within "
+        f"{timeout:.0f} seconds.\n\n"
+        "It may still be starting up -- check Explorer for the drive, or see "
+        "the log if it doesn't appear.",
     )
 
 

--- a/amifuse/launcher.py
+++ b/amifuse/launcher.py
@@ -56,6 +56,9 @@ def main(argv=None) -> None:
     mount_p.add_argument("image")
     mount_p.add_argument("--write", action="store_true")
 
+    open_p = sub.add_parser("open", help="Mount and open in Explorer")
+    open_p.add_argument("image")
+
     inspect_p = sub.add_parser("inspect", help="Open inspect in a new console")
     inspect_p.add_argument("image")
 
@@ -63,6 +66,8 @@ def main(argv=None) -> None:
 
     if args.command == "mount":
         _do_mount(args)
+    elif args.command == "open":
+        _do_open(args)
     elif args.command == "inspect":
         _do_inspect(args)
 
@@ -111,6 +116,77 @@ def _do_inspect(args) -> None:
         args.image,
     ]
     subprocess.Popen(wrapper, creationflags=CREATE_NEW_CONSOLE)
+
+
+def _do_open(args) -> None:
+    """Mount an image and open Explorer to the mounted drive."""
+    import time
+
+    # Find an available drive letter
+    drive_letter = None
+    for letter in "DEFGHIJKLMNOPQRSTUVWXYZ":
+        candidate = f"{letter}:"
+        if not os.path.exists(candidate + "\\"):
+            drive_letter = candidate
+            break
+
+    if drive_letter is None:
+        _log("No available drive letter found")
+        _show_error("AmiFUSE", "No available drive letter found. Cannot mount.")
+        return
+
+    # Launch mount with explicit mountpoint
+    python_dir = Path(sys.executable).parent
+    python_exe = str(python_dir / "pythonw.exe")
+    if not os.path.isfile(python_exe):
+        python_exe = sys.executable
+
+    cmd = [python_exe, "-m", "amifuse", "mount", "--mountpoint", drive_letter, "--daemon", args.image]
+
+    _log(f"Launching open-mount: {cmd}")
+    try:
+        _spawn_detached(
+            cmd,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            close_fds=True,
+        )
+    except Exception as exc:
+        _log(f"Failed to launch mount: {exc}")
+        _show_error("AmiFUSE", f"Failed to launch mount process:\n{exc}")
+        return
+
+    # Poll for mount to become ready
+    mount_path = f"{drive_letter}\\"
+    timeout = 15.0
+    poll_interval = 0.25
+    elapsed = 0.0
+
+    while elapsed < timeout:
+        time.sleep(poll_interval)
+        elapsed += poll_interval
+        if os.path.exists(mount_path):
+            _log(f"Mount ready at {drive_letter} after {elapsed:.1f}s, opening Explorer")
+            os.startfile(mount_path)
+            _ensure_tray_running()
+            return
+
+    # Timeout — mount may have failed
+    _log(f"Mount timed out after {timeout}s for {drive_letter}")
+    _show_error(
+        "AmiFUSE",
+        f"Mount timed out waiting for {drive_letter}.\n\n"
+        "The image may be invalid or the filesystem handler failed to start.",
+    )
+
+
+def _show_error(title: str, message: str) -> None:
+    """Show a Windows MessageBox error. Best-effort; never raises."""
+    try:
+        ctypes.windll.user32.MessageBoxW(0, message, title, 0x10)  # MB_ICONERROR
+    except Exception:
+        pass
 
 
 def _ensure_tray_running() -> None:

--- a/amifuse/platform.py
+++ b/amifuse/platform.py
@@ -1345,3 +1345,34 @@ def _get_file_version_win(filepath: str) -> Optional[str]:
         return f"{(ms >> 16) & 0xFFFF}.{ms & 0xFFFF}.{(ls >> 16) & 0xFFFF}.{ls & 0xFFFF}"
     except Exception:
         return None
+
+
+def notify_shell_drive_change(drive_letter: str, added: bool) -> None:
+    """Notify Windows Explorer that a drive was added or removed.
+
+    Uses SHChangeNotify to trigger immediate Explorer sidebar refresh.
+    No-op on non-Windows platforms.
+
+    Args:
+        drive_letter: Drive letter with colon (e.g., "D:" or "D:\\")
+        added: True for mount (SHCNE_DRIVEADD), False for unmount (SHCNE_DRIVEREMOVED)
+    """
+    if not sys.platform.startswith("win"):
+        return
+
+    import ctypes
+
+    # SHChangeNotify constants
+    SHCNE_DRIVEADD = 0x00000100
+    SHCNE_DRIVEREMOVED = 0x00000080
+    SHCNF_PATH = 0x0005
+
+    event = SHCNE_DRIVEADD if added else SHCNE_DRIVEREMOVED
+    # SHChangeNotify expects a null-terminated path string
+    # Normalize to "X:\" format
+    path = drive_letter.rstrip("\\") + "\\"
+
+    try:
+        ctypes.windll.shell32.SHChangeNotify(event, SHCNF_PATH, path, None)
+    except Exception:
+        pass  # Best-effort; don't crash if shell notification fails

--- a/amifuse/platform.py
+++ b/amifuse/platform.py
@@ -563,6 +563,22 @@ def find_amifuse_mounts():
     return mounts
 
 
+def _strip_matched_quotes(value):
+    """Strip a single matched pair of surrounding double quotes.
+
+    On Windows, mount discovery tokenizes the command line with
+    ``shlex.split(cmdline, posix=False)``, which retains the surrounding quote
+    characters that ``subprocess.list2cmdline`` adds around paths containing
+    spaces. This leaks literal quotes into the reported image/mountpoint. Strip
+    only a *matched* leading+trailing ``"`` pair; leave unbalanced input (a quote
+    on one side only) untouched. On the Unix path (posix=True) tokens carry no
+    surrounding quotes, so this is a no-op there.
+    """
+    if value and len(value) >= 2 and value[0] == '"' and value[-1] == '"':
+        return value[1:-1]
+    return value
+
+
 def _parse_mount_tokens(tokens):
     """Extract image path and --mountpoint value from amifuse command tokens.
 
@@ -604,7 +620,7 @@ def _parse_mount_tokens(tokens):
             image = tok
         i += 1
 
-    return image, mountpoint
+    return _strip_matched_quotes(image), _strip_matched_quotes(mountpoint)
 
 
 def _find_amifuse_mounts_unix():

--- a/amifuse/platform.py
+++ b/amifuse/platform.py
@@ -21,7 +21,7 @@ import subprocess
 import sys
 import time
 from pathlib import Path
-from typing import List, Optional, TYPE_CHECKING
+from typing import List, Optional, Set, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from .icon_darwin import DarwinIconHandler
@@ -112,6 +112,50 @@ def get_primary_driver_dir() -> Path:
     return Path.home() / ".local" / "share" / "amifuse" / "drivers"
 
 
+def _windows_allocated_drive_letters() -> Set[str]:
+    """Return the set of drive letters currently allocated on Windows.
+
+    Uses the Win32 ``GetLogicalDrives`` bitmask, which reports letter
+    *allocation* regardless of whether media is present. This is the correct
+    probe for "is this drive letter taken" -- unlike ``os.path.exists``, which
+    false-negatives on an assigned-but-empty removable slot (e.g. an empty
+    card-reader ``D:``) and led AmiFUSE to auto-select a letter that WinFsp
+    then refused with "mount point in use".
+
+    Returns:
+        A set of bare, uppercase, single-character letters (e.g. ``{"C", "D"}``
+        -- not ``"C:"`` strings). On non-Windows platforms returns an empty set
+        without ever touching ``windll``.
+
+    Bitmask decode: bit 0 = A:, bit 1 = B:, ... bit 25 = Z:.
+    """
+    if not sys.platform.startswith("win"):
+        return set()
+
+    # Conservative fallback for API failure. ``GetLogicalDrives`` returns 0
+    # only when the call fails (a real system always has at least C: allocated).
+    # Decoding 0 naively would yield an empty set, making *every* letter look
+    # free and re-selecting the empty D: this fix removes. Instead we treat
+    # every letter as allocated, so auto-selection declines to pick a letter
+    # rather than picking a bad one, and validation rejects rather than
+    # waving through. Callers must handle the "no free letter" outcome.
+    all_letters = set("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+    try:
+        # windll is Windows-only; keep the reference inside the function body so
+        # merely importing this module never touches it on macOS/Linux. Matches
+        # the ctypes idiom used elsewhere in this file (e.g. _pid_exists).
+        import ctypes
+        mask = ctypes.windll.kernel32.GetLogicalDrives()
+    except Exception:
+        return all_letters
+
+    if not mask:
+        return all_letters
+
+    return {chr(ord("A") + i) for i in range(26) if mask & (1 << i)}
+
+
 def get_default_mountpoint(volname: str) -> Optional[Path]:
     """Get the default mountpoint for the current platform.
 
@@ -124,11 +168,13 @@ def get_default_mountpoint(volname: str) -> Optional[Path]:
     if sys.platform.startswith("darwin"):
         return Path(f"/Volumes/{volname}")
     elif sys.platform.startswith("win"):
-        # Find first available drive letter (skip A/B floppy and C system)
+        # Find first unallocated drive letter (skip A/B floppy and C system).
+        # Use the GetLogicalDrives bitmask, not os.path.exists: the latter
+        # false-negatives on assigned-but-empty removable slots (e.g. D:).
+        allocated = _windows_allocated_drive_letters()
         for letter in "DEFGHIJKLMNOPQRSTUVWXYZ":
-            drive = f"{letter}:"
-            if not os.path.exists(drive):
-                return Path(drive)
+            if letter not in allocated:
+                return Path(f"{letter}:")
         return None  # No available drive letter
     else:
         # Linux requires explicit mountpoint
@@ -272,11 +318,14 @@ def validate_mountpoint(mountpoint: Path) -> Optional[str]:
     """
     mp_str = str(mountpoint)
     if sys.platform.startswith("win") and len(mp_str) == 2 and mp_str[1] == ":":
-        # Drive letter mountpoint -- check if drive exists (i.e., is assigned)
-        if os.path.exists(mp_str + "\\"):
+        # Drive letter mountpoint -- reject if the letter is already allocated.
+        # Use the GetLogicalDrives bitmask (via the shared helper), not
+        # os.path.exists, which false-negatives on assigned-but-empty removable
+        # slots. Normalize case so an explicit lowercase "d:" is still caught.
+        if mp_str[0].upper() in _windows_allocated_drive_letters():
             return (
-                f"Drive {mp_str} is already in use; choose a different drive letter "
-                f"or free it first."
+                f"Drive {mp_str} is already allocated; choose a different drive "
+                f"letter or free it first."
             )
     else:
         try:

--- a/amifuse/platform.py
+++ b/amifuse/platform.py
@@ -1373,6 +1373,6 @@ def notify_shell_drive_change(drive_letter: str, added: bool) -> None:
     path = drive_letter.rstrip("\\") + "\\"
 
     try:
-        ctypes.windll.shell32.SHChangeNotify(event, SHCNF_PATH, path, None)
+        ctypes.windll.shell32.SHChangeNotify(event, SHCNF_PATH, ctypes.c_wchar_p(path), None)
     except Exception:
         pass  # Best-effort; don't crash if shell notification fails

--- a/amifuse/rdb_inspect.py
+++ b/amifuse/rdb_inspect.py
@@ -83,6 +83,41 @@ class MBRContext:
     scheme: str = "emu68"       # "emu68" or "parceiro"
 
 
+@dataclass
+class PartInfo:
+    """One RDB partition, as surfaced by ``list_partitions``.
+
+    ``index`` is the amitools ``Partition.num`` -- the per-RDB positional index.
+    It restarts at 0 within each RDB, so it is NOT unique across a multi-RDB
+    image; use ``name`` (the drive name) as the stable fan-out key
+    (``--partition <name>``), never the index.
+    """
+    index: int          # Partition.num (per-RDB positional index; collides across RDBs)
+    name: str           # drive name -- the --partition key for the fan-out
+    dostype: int        # dos_env.dos_type
+    dostype_str: str    # DosType tag string (e.g. "DOS1")
+
+
+@dataclass
+class PartitionList:
+    """Result of ``list_partitions``: the partitions plus an optional fallback signal.
+
+    ``partitions`` is the stable-ordered list of :class:`PartInfo` the caller
+    should fan out over (one drive per entry). Normally it holds every partition
+    across the image's RDB(s).
+
+    ``fallback_reason`` is ``None`` in the normal case. It is set to a
+    human-readable string ONLY when a partition name collided across multiple
+    RDBs (which would make name-keyed ``--partition`` routing ambiguous), forcing
+    a fall back to first-partition-only: in that case ``partitions`` holds exactly
+    ONE ``PartInfo`` (index 0 of the first RDB) and ``fallback_reason`` explains
+    why. The caller is responsible for logging it and naming it in the summary
+    dialog; ``list_partitions`` performs no I/O of its own.
+    """
+    partitions: List[PartInfo]
+    fallback_reason: Optional[str] = None
+
+
 def detect_mbr(image: Path) -> Optional[MBRInfo]:
     """Detect and parse MBR partition table.
 
@@ -654,6 +689,120 @@ def find_partition_mbr_index(
         except IOError:
             continue
     return None
+
+
+def _part_info(p) -> PartInfo:
+    """Build a :class:`PartInfo` from an amitools ``Partition``.
+
+    Reads only already-parsed, in-memory fields (``num``, the drive-name BSTR,
+    and ``dos_env.dos_type``), so it is safe to call after the block device is
+    closed. ``str(p.get_drive_name())`` matches the existing name idiom in
+    ``fuse_fs.get_partition_info``.
+    """
+    dos_type = p.part_blk.dos_env.dos_type
+    return PartInfo(
+        index=p.num,
+        name=str(p.get_drive_name()),
+        dostype=dos_type,
+        dostype_str=DosType.num_to_tag_str(dos_type),
+    )
+
+
+def list_partitions(
+    image: Path, block_size: Optional[int] = None
+) -> PartitionList:
+    """Enumerate every partition in an RDB image, keyed by drive name.
+
+    Opens the image via :func:`open_rdisk`, walks ``rdisk.parts``, and returns
+    one :class:`PartInfo` per partition, then closes BOTH the rdisk and the
+    underlying block device (``rdisk.close(); blkdev.close()`` -- the established
+    pattern; ``RDisk.close()`` only nulls its state, so the block device must be
+    closed separately or the image handle leaks).
+
+    For multi-RDB images (Emu68/Parceiro disks with more than one ``0x76`` MBR
+    partition, each carrying its own RDB) it enumerates across ALL ``0x76`` RDBs,
+    mirroring the multi-RDB loop in ``rdb_inspect.main`` / ``fuse_fs.cmd_inspect``.
+    Names -- not indices -- are the fan-out key, because ``Partition.num``
+    restarts at 0 in each RDB and so collides across RDBs; every emitted name
+    re-resolves through the existing, tested ``find_partition_mbr_index`` name
+    path when the caller spawns ``--partition <name>``.
+
+    RDB-ONLY: the caller performs the non-RDB short-circuit (``detect_adf`` /
+    ``detect_iso``) BEFORE calling this. ``list_partitions`` does not probe for
+    ADF/ISO and propagates :class:`IOError` from :func:`open_rdisk` on a non-RDB
+    image.
+
+    Duplicate-name guard (narrow): amitools does not enforce drive-name
+    uniqueness across RDBs, and ``--partition`` resolves name-first, so two RDBs
+    each holding e.g. ``DH0`` would be ambiguous to route. When (and only when) a
+    name collides ACROSS RDBs, this falls back to first-partition-only (index 0
+    of the first RDB) and sets ``PartitionList.fallback_reason``. The guard never
+    fires for a plain RDB or for a multi-RDB image whose names are all distinct.
+
+    Args:
+        image: Path to the RDB disk image.
+        block_size: Force a specific block size (default: auto-detect).
+
+    Returns:
+        A :class:`PartitionList`. ``.partitions`` is in stable RDB order
+        (normally >= 1 entry); ``.fallback_reason`` is ``None`` normally and, on
+        the duplicate-name fallback, a string with ``.partitions`` holding a
+        single entry. The caller logs and surfaces ``.fallback_reason``.
+    """
+    mbr_info = detect_mbr(image)
+    amiga_parts = []
+    if mbr_info is not None and mbr_info.has_amiga_partitions:
+        amiga_parts = [
+            p for p in mbr_info.partitions if p.partition_type == MBR_TYPE_AMIGA_RDB
+        ]
+
+    # Plain RDB (or a single 0x76 RDB): open once, enumerate, close both handles.
+    if len(amiga_parts) <= 1:
+        blkdev, rdisk, _mbr_ctx = open_rdisk(image, block_size=block_size)
+        try:
+            parts = [_part_info(p) for p in rdisk.parts]
+        finally:
+            rdisk.close()
+            blkdev.close()
+        return PartitionList(partitions=parts)
+
+    # Multi-RDB: enumerate across every 0x76 RDB, keyed by name. Each iteration
+    # opens its own (blkdev, rdisk) and MUST close both inside the loop or N
+    # block-device handles leak.
+    all_parts: List[PartInfo] = []
+    seen_names: dict = {}   # lower-cased names from previously-processed RDBs
+    first_part: Optional[PartInfo] = None
+    for rdb_idx in range(len(amiga_parts)):
+        try:
+            blkdev, rdisk, _mbr_ctx = open_rdisk(
+                image, block_size=block_size, mbr_partition_index=rdb_idx
+            )
+        except IOError:
+            continue
+        try:
+            rdb_parts = [_part_info(p) for p in rdisk.parts]
+        finally:
+            rdisk.close()
+            blkdev.close()
+
+        if first_part is None and rdb_parts:
+            first_part = rdb_parts[0]
+
+        # A name shared with a PRIOR RDB makes name-keyed fan-out unsafe ->
+        # fall back to first-partition-only for the whole image.
+        for info in rdb_parts:
+            if info.name.lower() in seen_names:
+                reason = (
+                    "multiple RDBs with colliding partition names "
+                    "(%r); mounted first only" % info.name
+                )
+                return PartitionList(partitions=[first_part], fallback_reason=reason)
+
+        for info in rdb_parts:
+            seen_names[info.name.lower()] = info
+            all_parts.append(info)
+
+    return PartitionList(partitions=all_parts)
 
 
 def format_fs_summary(rdisk: RDisk):

--- a/amifuse/scsi_device.py
+++ b/amifuse/scsi_device.py
@@ -233,6 +233,7 @@ class ScsiDevice(LibImpl):
             cdb_bytes = mem.r_block(cdb_ptr, cdb_len) if cdb_ptr and cdb_len else b""
             actual = 0
             status = 0
+            sense_actual = 0
             # default: no sense data
             if sense_ptr:
                 mem.w_block(sense_ptr, b"\x00" * min(sense_len, 18))
@@ -290,21 +291,33 @@ class ScsiDevice(LibImpl):
             elif opcode == 0x2A:  # WRITE(10)
                 lba = mem.r32(cdb_ptr + 2)
                 xfer_blocks = mem.r16(cdb_ptr + 7)
+                expected_len = xfer_blocks * self.backend.block_size
                 if not self._check_block_bounds(lba, xfer_blocks):
                     status = 2  # check condition
+                elif expected_len > 0 and data_len < expected_len:
+                    # Buffer too short for requested transfer
+                    status = 2  # check condition
+                    if sense_ptr and sense_len >= 18:
+                        sense_data = bytearray(18)
+                        sense_data[0] = 0x70  # current errors, fixed format
+                        sense_data[2] = 0x05  # ILLEGAL_REQUEST
+                        sense_data[7] = 0x0A  # additional sense length
+                        sense_data[12] = 0x24  # ASC: INVALID FIELD IN CDB
+                        sense_data[13] = 0x00  # ASCQ
+                        mem.w_block(sense_ptr, bytes(sense_data))
+                        sense_actual = 18
                 else:
-                    data = mem.r_block(
-                        data_ptr, min(data_len, xfer_blocks * self.backend.block_size)
-                    )
-                    self.backend.write_blocks(lba, data, xfer_blocks)
-                    actual = len(data)
+                    if xfer_blocks > 0:
+                        data = mem.r_block(data_ptr, expected_len)
+                        self.backend.write_blocks(lba, data, xfer_blocks)
+                        actual = len(data)
             else:
                 # Unsupported command: report check condition
                 status = 2  # check condition
             scsi.scsi_CmdActual.val = cdb_len
             scsi.scsi_Status.val = status
             scsi.scsi_Actual.val = actual
-            scsi.scsi_SenseActual.val = 0
+            scsi.scsi_SenseActual.val = sense_actual
             ior.actual.val = actual
         elif cmd == CMD_READ:
             block_num = offset // self.backend.block_size

--- a/amifuse/startup_runner.py
+++ b/amifuse/startup_runner.py
@@ -704,6 +704,100 @@ class HandlerLauncher:
 
         return True
 
+    def _finalize_burst_blocked(
+        self,
+        state: HandlerLaunchState,
+        block_state: dict,
+        blocked_sp: int,
+        blocked_ret,  # Optional[int]
+        wait_mask,  # Optional[int]
+        waitport_sp,  # Optional[int]
+        ram_end: int,
+        debug: bool = False,
+    ) -> None:
+        """Handle post-burst state when handler is blocked in Wait()/WaitPort().
+
+        Extracted from the near-identical logic in both run_state.error and
+        run_state.done branches. Sets state.pc/sp and D0 based on whether
+        pending messages/signals can wake the handler immediately.
+        """
+        cpu = self.vh.machine.cpu
+        mem = self.vh.alloc.get_mem()
+
+        def _pc_valid(pc: int) -> bool:
+            return 0x800 <= pc < ram_end
+
+        ret_addr = blocked_ret if blocked_ret is not None else mem.r32(blocked_sp)
+        # Save as main loop PC if not yet initialized
+        if (not state.initialized or state.main_loop_pc == 0) and _pc_valid(ret_addr):
+            state.main_loop_pc = ret_addr
+            state.main_loop_sp = blocked_sp + 4
+            state.initialized = True
+            if wait_mask is not None and not state.wait_mask:
+                state.wait_mask = wait_mask
+        # Determine if there's something pending that would wake the handler
+        if wait_mask is not None:
+            # Wait() blocked - check for ANY pending signals (messages OR IO completion)
+            pending = self._compute_pending_signals(wait_mask)
+            has_pending = pending != 0
+            if debug:
+                all_pending = self._compute_pending_signals(0xFFFFFFFF)
+                print(f"[run_burst] Wait block: ret=0x{ret_addr:x} mask=0x{wait_mask:x} pending_masked=0x{pending:x} pending_all=0x{all_pending:x} has_pending={has_pending}")
+        else:
+            # WaitPort blocked - check for message on the port
+            has_pending = self.exec_impl.port_mgr.has_msg(state.port_addr)
+        if has_pending:
+            # Resume from blocking call return address (saved on stack)
+            if _pc_valid(ret_addr):
+                state.pc = ret_addr
+                state.sp = blocked_sp + 4
+            elif state.main_loop_pc and _pc_valid(state.main_loop_pc):
+                state.pc = state.main_loop_pc
+                state.sp = state.main_loop_sp
+            # CRITICAL: Set D0 before resuming from Wait() or WaitPort()
+            if wait_mask is not None:
+                # Wait() resume - set D0 to pending signals
+                if wait_mask == 0:
+                    pending = self._compute_pending_signals(0xFFFFFFFF)
+                else:
+                    pending = self._compute_pending_signals(wait_mask)
+                cpu.w_reg(REG_D0, pending)
+                self._set_saved_reg(state, REG_D0, pending)
+                if debug:
+                    print(f"[run_burst] Wait resume: D0=0x{pending:x}")
+                # Clear returned signals from tc_SigRecvd (like Wait() would)
+                self._clear_signals_from_task(pending)
+            elif waitport_sp is not None:
+                # WaitPort()/WaitPkt() resume - set D0 appropriately
+                waitport_port = block_state.get("waitport_blocked_port")
+                if waitport_port is not None:
+                    # CRITICAL: use get_msg (not peek_msg) to dequeue.
+                    msg_addr = self.exec_impl.port_mgr.get_msg(waitport_port)
+                    if msg_addr:
+                        _unlink_msg_from_m68k_list(self.mem, msg_addr, debug=debug)
+                    if block_state.get("waitpkt_blocked", False) and msg_addr:
+                        # WaitPkt() resume - extract packet from message
+                        msg = MessageStruct(self.mem, msg_addr)
+                        pkt_addr = msg.node.name.aptr
+                        d0_val = pkt_addr if pkt_addr else 0
+                    else:
+                        # WaitPort() resume - return message address
+                        d0_val = msg_addr if msg_addr else 0
+                    cpu.w_reg(REG_D0, d0_val)
+                    self._set_saved_reg(state, REG_D0, d0_val)
+            # Clear both blocking states
+            _clear_all_block_state()
+            state.block_state = None
+            state.exit_count = 0
+        else:
+            # No message pending - save restart point for later
+            if _pc_valid(ret_addr):
+                state.pc = ret_addr
+                state.sp = blocked_sp + 4
+            elif state.main_loop_pc and _pc_valid(state.main_loop_pc):
+                state.pc = state.main_loop_pc
+                state.sp = state.main_loop_sp
+
     def run_burst(self, state: HandlerLaunchState, max_cycles=200000, debug: bool = False):
         """Run the handler from its current PC/SP for a limited number of cycles."""
         import sys
@@ -836,77 +930,10 @@ class HandlerLauncher:
             # WaitPort/Wait or other blocking call failed - handler is waiting for a message.
             if blocked_sp is not None:
                 state.block_state = block_state
-                ret_addr = blocked_ret if blocked_ret is not None else mem.r32(blocked_sp)
-                # Save as main loop PC if not yet set - this is where handler waits for messages
-                if (not state.initialized or state.main_loop_pc == 0) and _pc_valid(ret_addr):
-                    state.main_loop_pc = ret_addr
-                    state.main_loop_sp = blocked_sp + 4
-                    state.initialized = True
-                    # Capture Wait mask for _flush_pending_signals before
-                    # _clear_all_block_state wipes it.
-                    if wait_mask is not None and not state.wait_mask:
-                        state.wait_mask = wait_mask
-                # Check if there's something pending that would wake the handler
-                if wait_mask is not None:
-                    # Wait() blocked - check for ANY pending signals (messages OR IO completion)
-                    pending = self._compute_pending_signals(wait_mask)
-                    has_pending = pending != 0
-                    if debug:
-                        all_pending = self._compute_pending_signals(0xFFFFFFFF)
-                        print(f"[run_burst] Wait block: ret=0x{ret_addr:x} mask=0x{wait_mask:x} pending_masked=0x{pending:x} pending_all=0x{all_pending:x} has_pending={has_pending}")
-                else:
-                    # WaitPort blocked - check for message on the port
-                    has_pending = self.exec_impl.port_mgr.has_msg(state.port_addr)
-                if has_pending:
-                    # Resume from blocking call return address (saved on stack)
-                    if _pc_valid(ret_addr):
-                        state.pc = ret_addr
-                        state.sp = blocked_sp + 4
-                    elif state.main_loop_pc and _pc_valid(state.main_loop_pc):
-                        state.pc = state.main_loop_pc
-                        state.sp = state.main_loop_sp
-                    # CRITICAL: Set D0 before resuming from Wait() or WaitPort()
-                    if wait_mask is not None:
-                        # Wait() resume - set D0 to pending signals
-                        if wait_mask == 0:
-                            pending = self._compute_pending_signals(0xFFFFFFFF)
-                        else:
-                            pending = self._compute_pending_signals(wait_mask)
-                        cpu.w_reg(REG_D0, pending)
-                        self._set_saved_reg(state, REG_D0, pending)
-                        if debug:
-                            print(f"[run_burst] Wait resume: D0=0x{pending:x}")
-                        # Clear returned signals from tc_SigRecvd (like Wait() would)
-                        self._clear_signals_from_task(pending)
-                    elif waitport_sp is not None:
-                        # WaitPort()/WaitPkt() resume - set D0 appropriately
-                        waitport_port = block_state.get("waitport_blocked_port")
-                        if waitport_port is not None:
-                            # CRITICAL: use get_msg (not peek_msg) to dequeue.
-                            msg_addr = self.exec_impl.port_mgr.get_msg(waitport_port)
-                            if msg_addr:
-                                _unlink_msg_from_m68k_list(self.mem, msg_addr, debug=debug)
-                            if block_state.get("waitpkt_blocked", False) and msg_addr:
-                                # WaitPkt() resume - extract packet from message
-                                msg = MessageStruct(self.mem, msg_addr)
-                                pkt_addr = msg.node.name.aptr
-                                d0_val = pkt_addr if pkt_addr else 0
-                            else:
-                                # WaitPort() resume - return message address
-                                d0_val = msg_addr if msg_addr else 0
-                            cpu.w_reg(REG_D0, d0_val)
-                            self._set_saved_reg(state, REG_D0, d0_val)
-                    # Clear both blocking states
-                    _clear_all_block_state()
-                    state.block_state = None
-                else:
-                    # No message pending - save restart point for later
-                    if _pc_valid(ret_addr):
-                        state.pc = ret_addr
-                        state.sp = blocked_sp + 4
-                    elif state.main_loop_pc and _pc_valid(state.main_loop_pc):
-                        state.pc = state.main_loop_pc
-                        state.sp = state.main_loop_sp
+                self._finalize_burst_blocked(
+                    state, block_state, blocked_sp, blocked_ret,
+                    wait_mask, waitport_sp, ram_end, debug=debug,
+                )
             elif state.initialized and state.main_loop_pc != 0:
                 # Fall back to saved main loop PC
                 state.pc = state.main_loop_pc
@@ -917,75 +944,10 @@ class HandlerLauncher:
             # Check if WaitPort/Wait blocked - if so, we can get the return address from the saved SP
             if blocked_sp is not None:
                 state.block_state = block_state
-                ret_addr = blocked_ret if blocked_ret is not None else mem.r32(blocked_sp)
-                # Save as main loop PC if not yet initialized
-                if (not state.initialized or state.main_loop_pc == 0) and _pc_valid(ret_addr):
-                    state.main_loop_pc = ret_addr
-                    state.main_loop_sp = blocked_sp + 4  # Pop return address
-                    state.initialized = True
-                    if wait_mask is not None and not state.wait_mask:
-                        state.wait_mask = wait_mask
-                # Only restart immediately if there's something pending (message or signal).
-                # Otherwise, leave state pointing to Wait/WaitPort return - caller
-                # will queue a message before calling run_burst again.
-                if wait_mask is not None:
-                    # Wait() blocked - check for ANY pending signals (messages OR IO completion)
-                    pending = self._compute_pending_signals(wait_mask)
-                    has_pending = pending != 0
-                else:
-                    # WaitPort blocked - check for message on the port
-                    has_pending = self.exec_impl.port_mgr.has_msg(state.port_addr)
-                if has_pending:
-                    # Restart from return address (where Wait/WaitPort was called)
-                    if _pc_valid(ret_addr):
-                        state.pc = ret_addr
-                        state.sp = blocked_sp + 4  # Pop the return address
-                    elif state.main_loop_pc and _pc_valid(state.main_loop_pc):
-                        state.pc = state.main_loop_pc
-                        state.sp = state.main_loop_sp
-                    # CRITICAL: Set D0 before resuming from Wait() or WaitPort()
-                    if wait_mask is not None:
-                        # Wait() resume - set D0 to pending signals
-                        if wait_mask == 0:
-                            pending = self._compute_pending_signals(0xFFFFFFFF)
-                        else:
-                            pending = self._compute_pending_signals(wait_mask)
-                        cpu.w_reg(REG_D0, pending)
-                        self._set_saved_reg(state, REG_D0, pending)
-                        # Clear returned signals from tc_SigRecvd (like Wait() would)
-                        self._clear_signals_from_task(pending)
-                    elif waitport_sp is not None:
-                        # WaitPort()/WaitPkt() resume - set D0 appropriately
-                        waitport_port = block_state.get("waitport_blocked_port")
-                        if waitport_port is not None:
-                            # CRITICAL: use get_msg (not peek_msg) to dequeue.
-                            msg_addr = self.exec_impl.port_mgr.get_msg(waitport_port)
-                            if msg_addr:
-                                _unlink_msg_from_m68k_list(self.mem, msg_addr, debug=debug)
-                            if block_state.get("waitpkt_blocked", False) and msg_addr:
-                                # WaitPkt() resume - extract packet from message
-                                msg = MessageStruct(self.mem, msg_addr)
-                                pkt_addr = msg.node.name.aptr
-                                d0_val = pkt_addr if pkt_addr else 0
-                            else:
-                                # WaitPort() resume - return message address
-                                d0_val = msg_addr if msg_addr else 0
-                            cpu.w_reg(REG_D0, d0_val)
-                            self._set_saved_reg(state, REG_D0, d0_val)
-                    # Clear the blocked states
-                    _clear_all_block_state()
-                    state.block_state = None
-                    state.exit_count = 0  # Reset exit counter
-                else:
-                    # No message pending - save restart point but don't spin.
-                    # Next run_burst will restart from here when a message is queued.
-                    if _pc_valid(ret_addr):
-                        state.pc = ret_addr
-                        state.sp = blocked_sp + 4
-                    elif state.main_loop_pc and _pc_valid(state.main_loop_pc):
-                        state.pc = state.main_loop_pc
-                        state.sp = state.main_loop_sp
-                    # Keep blocked state so we know handler is waiting
+                self._finalize_burst_blocked(
+                    state, block_state, blocked_sp, blocked_ret,
+                    wait_mask, waitport_sp, ram_end, debug=debug,
+                )
             else:
                 # Normal exit trap (RTS to run_exit_addr) without WaitPort block.
                 # For FFS, this means startup processing is complete. Check if there's

--- a/amifuse/startup_runner.py
+++ b/amifuse/startup_runner.py
@@ -788,7 +788,7 @@ class HandlerLauncher:
             # Clear both blocking states
             _clear_all_block_state()
             state.block_state = None
-            state.exit_count = 0
+            state.exit_count = 0  # Reset for both callers (field is vestigial)
         else:
             # No message pending - save restart point for later
             if _pc_valid(ret_addr):

--- a/amifuse/tray.py
+++ b/amifuse/tray.py
@@ -128,19 +128,31 @@ class TrayApp:
         return cb
 
     def _unmount_single(self, mount):
-        from .platform import kill_pids
+        from .platform import kill_pids, notify_shell_drive_change
 
         kill_pids([mount["pid"]], timeout=2.0)
+        # Notify Explorer that drive was removed (crash recovery path:
+        # if process crashes, destroy() never fires; tray detects the
+        # dead process and sends notification here)
+        mountpoint = mount.get("mountpoint")
+        if mountpoint:
+            notify_shell_drive_change(mountpoint, added=False)
         self._wake_event.set()
 
     def _unmount_all(self):
         with self._lock:
-            pids = [m["pid"] for m in self._mounts]
+            mounts_copy = list(self._mounts)
+            pids = [m["pid"] for m in mounts_copy]
         if not pids:
             return
-        from .platform import kill_pids
+        from .platform import kill_pids, notify_shell_drive_change
 
         kill_pids(pids, timeout=2.0)
+        # Notify Explorer for each removed drive
+        for mount in mounts_copy:
+            mountpoint = mount.get("mountpoint")
+            if mountpoint:
+                notify_shell_drive_change(mountpoint, added=False)
 
     def _unmount_all_cb(self, icon, item):
         self._unmount_all()

--- a/amifuse/windows_shell.py
+++ b/amifuse/windows_shell.py
@@ -20,6 +20,9 @@ PROGID_DESCRIPTIONS = {
 
 ICON_DIR = Path(os.environ.get("APPDATA", "")) / "AmiFUSE" / "icons"
 _AMIFUSE_DIR = Path(os.environ.get("APPDATA", "")) / "AmiFUSE"
+# Security note: launch.vbs is user-writable (%APPDATA%). Shell verb
+# registration trusts this path — integrity depends on the user account
+# not being compromised. Acceptable for a user-space tool.
 _LAUNCH_VBS = _AMIFUSE_DIR / "launch.vbs"
 
 # VBScript launcher: runs a command with hidden window and no wait,

--- a/amifuse/windows_shell.py
+++ b/amifuse/windows_shell.py
@@ -241,22 +241,17 @@ def _register_progid(winreg, progid: str, launcher: str) -> None:
         f'wscript.exe //nologo //b "{vbs}" "{launcher}" open "%1"',
     )
 
-    # Flat verb: mount — wscript runs VBS launcher invisibly (no cmd.exe flash)
-    _set_verb(
-        winreg,
-        base,
-        "mount",
-        "Mount with AmiFUSE",
-        f'wscript.exe //nologo //b "{vbs}" "{launcher}" mount "%1"',
-    )
+    # Clean up stale verb keys from previous registrations
+    for stale_verb in ("mount", "mountrw"):
+        _delete_key_recursive(winreg.HKEY_CURRENT_USER, rf"{base}\shell\{stale_verb}")
 
-    # Flat verb: mountrw
+    # Flat verb: mountro — read-only mount without opening Explorer
     _set_verb(
         winreg,
         base,
-        "mountrw",
-        "Mount Read-Write with AmiFUSE",
-        f'wscript.exe //nologo //b "{vbs}" "{launcher}" mount --write "%1"',
+        "mountro",
+        "Mount Read-Only with AmiFUSE",
+        f'wscript.exe //nologo //b "{vbs}" "{launcher}" mount "%1"',
     )
 
     # DefaultIcon

--- a/amifuse/windows_shell.py
+++ b/amifuse/windows_shell.py
@@ -221,8 +221,24 @@ def _register_progid(winreg, progid: str, launcher: str) -> None:
     finally:
         winreg.CloseKey(key)
 
-    # Flat verb: mount — wscript runs VBS launcher invisibly (no cmd.exe flash)
+    # Set default verb to "open" so double-click triggers mount
     vbs = str(_LAUNCH_VBS)
+    shell_key = winreg.CreateKey(winreg.HKEY_CURRENT_USER, rf"{base}\shell")
+    try:
+        winreg.SetValueEx(shell_key, "", 0, winreg.REG_SZ, "open")
+    finally:
+        winreg.CloseKey(shell_key)
+
+    # Flat verb: open — mount and open Explorer (default action for double-click)
+    _set_verb(
+        winreg,
+        base,
+        "open",
+        "Mount && Open with AmiFUSE",
+        f'wscript.exe //nologo //b "{vbs}" "{launcher}" open "%1"',
+    )
+
+    # Flat verb: mount — wscript runs VBS launcher invisibly (no cmd.exe flash)
     _set_verb(
         winreg,
         base,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,14 @@ classifiers = [
     "Environment :: Console",
     "Intended Audience :: Developers",
     "Operating System :: MacOS",
+    "Operating System :: Microsoft :: Windows",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: System :: Filesystems",
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,6 +41,17 @@ def fuse_mock(monkeypatch):
     fake_fuse.Operations = type("Operations", (), {})
     monkeypatch.setitem(sys.modules, "fuse", fake_fuse)
 
+    # If amifuse.fuse_fs was already imported without this mock (e.g. by an
+    # earlier test in a different order), it permanently bound FUSE=None at
+    # import time. Rebind its module-level symbols so those tests can't leave
+    # fuse_fs in an unusable state. setattr auto-reverts at teardown.
+    mod = sys.modules.get("amifuse.fuse_fs")
+    if mod is not None:
+        monkeypatch.setattr(mod, "FUSE", fake_fuse.FUSE)
+        monkeypatch.setattr(mod, "FuseOSError", fake_fuse.FuseOSError)
+        monkeypatch.setattr(mod, "LoggingMixIn", fake_fuse.LoggingMixIn)
+        monkeypatch.setattr(mod, "Operations", fake_fuse.Operations)
+
     def _stub_module(name, **attrs):
         mod = types.ModuleType(name)
         for key, value in attrs.items():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,6 +73,7 @@ def fuse_mock(monkeypatch):
         FileInfoBlockStruct=dummy_cls,
         FileHandleStruct=dummy_cls,
         DosPacketStruct=dummy_cls,
+        InfoDataStruct=dummy_cls,
     )
     # DosProtection needs to be callable with an int arg and str-able
     # so _format_protection(prot_bits) works in tests.

--- a/tests/integration/test_mount_lifecycle.py
+++ b/tests/integration/test_mount_lifecycle.py
@@ -187,10 +187,14 @@ def test_unmount_twice_is_safe(mount_image, pfs3_image, pfs3_driver):
     # Poll until unmount detected
     deadline = time.monotonic() + 10.0
     while time.monotonic() < deadline:
-        try:
-            os.listdir(mp_str)
-        except OSError:
-            break
+        if sys.platform.startswith("win"):
+            try:
+                os.listdir(mp_str)
+            except OSError:
+                break
+        else:
+            if not os.path.ismount(mp_str):
+                break
         time.sleep(0.5)
 
     # Second unmount -- should fail cleanly, not hang
@@ -200,6 +204,56 @@ def test_unmount_twice_is_safe(mount_image, pfs3_image, pfs3_driver):
     assert "Traceback" not in combined, (
         f"Got raw traceback on double unmount:\n{combined}"
     )
+
+
+def test_unmount_path_not_accessible(mount_image, pfs3_image, pfs3_driver):
+    """After unmount, the mountpoint path must not resolve as a filesystem.
+
+    On Windows this validates that the drive letter is released (SHChangeNotify
+    informs Explorer, but the OS-level absence is testable). On Unix the
+    mountpoint directory reverts to a normal (empty) directory.
+    """
+    proc, mountpoint = mount_image(pfs3_image, driver=pfs3_driver)
+    mp_str = str(mountpoint)
+
+    # Confirm mount is live
+    entries_before = os.listdir(mp_str)
+    assert len(entries_before) > 0, "Mount should have visible files"
+
+    # Unmount
+    result = _run_amifuse("unmount", mp_str)
+
+    # Wait for process exit
+    try:
+        proc.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait(timeout=5)
+
+    # Poll until unmount detected
+    deadline = time.monotonic() + 10.0
+    while time.monotonic() < deadline:
+        if sys.platform.startswith("win"):
+            try:
+                os.listdir(mp_str)
+            except OSError:
+                break
+        else:
+            if not os.path.ismount(mp_str):
+                break
+        time.sleep(0.5)
+
+    # Platform-specific post-unmount assertions
+    if sys.platform.startswith("win"):
+        # Windows: drive letter should no longer exist
+        with pytest.raises(OSError):
+            os.listdir(mp_str)
+    else:
+        # Unix: directory exists but is not a mount, and should be empty
+        # (FUSE detached; the dir was created by tmp_path)
+        assert not os.path.ismount(mp_str), (
+            f"{mp_str} still appears as a mount after unmount"
+        )
 
 
 def test_mount_invalid_image_fails(fuse_available, tmp_path):

--- a/tests/integration/test_statfs.py
+++ b/tests/integration/test_statfs.py
@@ -1,0 +1,96 @@
+"""Integration tests for statfs (disk space reporting).
+
+Verifies that mounted images report correct filesystem geometry via os.statvfs
+(Unix) or GetDiskFreeSpaceExW (Windows).
+"""
+import os
+import sys
+
+import pytest
+
+pytestmark = pytest.mark.fuse
+
+
+def test_statfs_reports_nonzero_blocks(pfs3_mount):
+    """Mounted PFS3 image reports non-zero block count via statvfs."""
+    _proc, mountpoint = pfs3_mount
+    mp = str(mountpoint)
+
+    if sys.platform.startswith("win"):
+        import ctypes
+
+        free_bytes = ctypes.c_ulonglong(0)
+        total_bytes = ctypes.c_ulonglong(0)
+        total_free_bytes = ctypes.c_ulonglong(0)
+        result = ctypes.windll.kernel32.GetDiskFreeSpaceExW(
+            mp + "\\",
+            ctypes.byref(free_bytes),
+            ctypes.byref(total_bytes),
+            ctypes.byref(total_free_bytes),
+        )
+        assert result != 0, "GetDiskFreeSpaceExW failed"
+        assert total_bytes.value > 0, "Total bytes should be non-zero"
+    else:
+        st = os.statvfs(mp)
+        assert st.f_blocks > 0, f"f_blocks should be non-zero, got {st.f_blocks}"
+        assert st.f_bsize > 0, f"f_bsize should be non-zero, got {st.f_bsize}"
+
+
+def test_statfs_free_less_than_or_equal_total(pfs3_mount):
+    """Free space should not exceed total space."""
+    _proc, mountpoint = pfs3_mount
+    mp = str(mountpoint)
+
+    if sys.platform.startswith("win"):
+        import ctypes
+
+        free_bytes = ctypes.c_ulonglong(0)
+        total_bytes = ctypes.c_ulonglong(0)
+        total_free_bytes = ctypes.c_ulonglong(0)
+        result = ctypes.windll.kernel32.GetDiskFreeSpaceExW(
+            mp + "\\",
+            ctypes.byref(free_bytes),
+            ctypes.byref(total_bytes),
+            ctypes.byref(total_free_bytes),
+        )
+        assert result != 0, "GetDiskFreeSpaceExW failed"
+        assert total_free_bytes.value <= total_bytes.value, (
+            f"Free ({total_free_bytes.value}) exceeds total ({total_bytes.value})"
+        )
+    else:
+        st = os.statvfs(mp)
+        assert st.f_bfree <= st.f_blocks, (
+            f"f_bfree ({st.f_bfree}) exceeds f_blocks ({st.f_blocks})"
+        )
+
+
+def test_statfs_block_size_is_power_of_two(pfs3_mount):
+    """Block size should be a power of two (512, 1024, 2048, etc.)."""
+    _proc, mountpoint = pfs3_mount
+    mp = str(mountpoint)
+
+    if sys.platform.startswith("win"):
+        import ctypes
+
+        sectors_per_cluster = ctypes.c_ulong(0)
+        bytes_per_sector = ctypes.c_ulong(0)
+        free_clusters = ctypes.c_ulong(0)
+        total_clusters = ctypes.c_ulong(0)
+        result = ctypes.windll.kernel32.GetDiskFreeSpaceW(
+            mp + "\\",
+            ctypes.byref(sectors_per_cluster),
+            ctypes.byref(bytes_per_sector),
+            ctypes.byref(free_clusters),
+            ctypes.byref(total_clusters),
+        )
+        if result == 0:
+            pytest.skip("GetDiskFreeSpaceW not supported for this mount")
+        bsize = bytes_per_sector.value
+    else:
+        st = os.statvfs(mp)
+        bsize = st.f_bsize
+
+    assert bsize > 0, f"Block size should be positive, got {bsize}"
+    assert (bsize & (bsize - 1)) == 0, (
+        f"Block size {bsize} is not a power of two"
+    )

--- a/tests/integration/test_write_persistence.py
+++ b/tests/integration/test_write_persistence.py
@@ -1,0 +1,135 @@
+"""Integration tests for write persistence.
+
+Verifies that files written to a writable mount persist across unmount/remount
+cycles and that written content is readable immediately.
+"""
+import os
+import shutil
+import subprocess
+import sys
+import time
+
+import pytest
+
+pytestmark = [pytest.mark.fuse, pytest.mark.slow]
+
+
+@pytest.fixture
+def writable_pfs3_mount(pfs3_image, pfs3_driver, fuse_available, mount_image, tmp_path):
+    """Mount a COPY of the PFS3 image in write mode.
+
+    Uses a copy of the test image to avoid corrupting the shared fixture.
+    Yields (process, mountpoint, work_image_path).
+    """
+    # Copy image so writes don't corrupt the shared fixture
+    work_image = tmp_path / "write_test.hdf"
+    shutil.copy2(pfs3_image, work_image)
+
+    proc, mountpoint = mount_image(
+        work_image,
+        driver=pfs3_driver,
+        extra_args=["--write"],
+    )
+
+    yield proc, mountpoint, work_image
+
+
+def test_write_file_readable_immediately(writable_pfs3_mount):
+    """Write a file through FUSE mount and read it back immediately."""
+    _proc, mountpoint, _work_image = writable_pfs3_mount
+    mp = str(mountpoint)
+
+    test_file = os.path.join(mp, "testfile.txt")
+    test_content = b"Hello from AmiFUSE write test!"
+
+    with open(test_file, "wb") as f:
+        f.write(test_content)
+
+    # Verify file exists
+    assert os.path.exists(test_file), "File should exist after write"
+
+    # Read back and verify content
+    with open(test_file, "rb") as f:
+        readback = f.read()
+    assert readback == test_content, (
+        f"Content mismatch: {readback!r} != {test_content!r}"
+    )
+
+
+def test_write_file_appears_in_listing(writable_pfs3_mount):
+    """Written file should appear in os.listdir of the mount root."""
+    _proc, mountpoint, _work_image = writable_pfs3_mount
+    mp = str(mountpoint)
+
+    test_file = os.path.join(mp, "listed_file.txt")
+    with open(test_file, "wb") as f:
+        f.write(b"listing test")
+
+    entries = os.listdir(mp)
+    assert "listed_file.txt" in entries, (
+        f"Expected 'listed_file.txt' in listing, got: {entries}"
+    )
+
+
+def test_write_persists_after_remount(
+    writable_pfs3_mount, mount_image, pfs3_driver,
+):
+    """Write a file, unmount, remount read-only, verify file present.
+
+    This is the full persistence test: data must survive the unmount/remount
+    cycle, proving it was flushed to the image file.
+    """
+    proc, mountpoint, work_image = writable_pfs3_mount
+    mp = str(mountpoint)
+
+    # Write a test file
+    test_file = os.path.join(mp, "persist_test.txt")
+    test_content = b"Data that must survive remount"
+    with open(test_file, "wb") as f:
+        f.write(test_content)
+
+    # Verify written
+    assert os.path.exists(test_file)
+
+    # Unmount the writable mount
+    subprocess.run(
+        [sys.executable, "-m", "amifuse", "unmount", mp],
+        capture_output=True, text=True, timeout=10, check=False,
+    )
+
+    # Wait for process exit
+    try:
+        proc.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait(timeout=5)
+
+    # Wait for unmount to complete
+    deadline = time.monotonic() + 10.0
+    while time.monotonic() < deadline:
+        if sys.platform.startswith("win"):
+            try:
+                os.listdir(mp)
+            except OSError:
+                break
+        else:
+            if not os.path.ismount(mp):
+                break
+        time.sleep(0.5)
+
+    # Remount read-only
+    proc2, mountpoint2 = mount_image(work_image, driver=pfs3_driver)
+    mp2 = str(mountpoint2)
+
+    # Verify the file persisted
+    remounted_file = os.path.join(mp2, "persist_test.txt")
+    assert os.path.exists(remounted_file), (
+        f"File 'persist_test.txt' did not persist after remount.\n"
+        f"Listing: {os.listdir(mp2)}"
+    )
+
+    with open(remounted_file, "rb") as f:
+        readback = f.read()
+    assert readback == test_content, (
+        f"Content did not persist: {readback!r} != {test_content!r}"
+    )

--- a/tests/unit/test_fuse_fs.py
+++ b/tests/unit/test_fuse_fs.py
@@ -3904,3 +3904,43 @@ class TestPinnedStatCache:
         assert "/new" not in fs._pinned_stats
         assert "/old" not in fs._stat_cache
         assert "/new" not in fs._stat_cache
+
+
+class TestCacheLocking:
+    """Verify _cache_lock protects cache dicts from concurrent access."""
+
+    def test_cache_lock_exists_in_init(self):
+        """AmigaFuseFS.__init__ creates a _cache_lock RLock."""
+        import inspect
+        from amifuse.fuse_fs import AmigaFuseFS
+        source = inspect.getsource(AmigaFuseFS.__init__)
+        assert "_cache_lock" in source
+        assert "RLock()" in source
+
+    def test_get_cached_stat_uses_lock(self):
+        """_get_cached_stat acquires _cache_lock."""
+        import inspect
+        from amifuse.fuse_fs import AmigaFuseFS
+        source = inspect.getsource(AmigaFuseFS._get_cached_stat)
+        assert "_cache_lock" in source
+
+    def test_set_cached_stat_uses_lock(self):
+        """_set_cached_stat acquires _cache_lock."""
+        import inspect
+        from amifuse.fuse_fs import AmigaFuseFS
+        source = inspect.getsource(AmigaFuseFS._set_cached_stat)
+        assert "_cache_lock" in source
+
+    def test_is_neg_cached_uses_lock(self):
+        """_is_neg_cached acquires _cache_lock."""
+        import inspect
+        from amifuse.fuse_fs import AmigaFuseFS
+        source = inspect.getsource(AmigaFuseFS._is_neg_cached)
+        assert "_cache_lock" in source
+
+    def test_set_neg_cached_uses_lock(self):
+        """_set_neg_cached acquires _cache_lock."""
+        import inspect
+        from amifuse.fuse_fs import AmigaFuseFS
+        source = inspect.getsource(AmigaFuseFS._set_neg_cached)
+        assert "_cache_lock" in source

--- a/tests/unit/test_fuse_fs.py
+++ b/tests/unit/test_fuse_fs.py
@@ -3944,3 +3944,44 @@ class TestCacheLocking:
         from amifuse.fuse_fs import AmigaFuseFS
         source = inspect.getsource(AmigaFuseFS._set_neg_cached)
         assert "_cache_lock" in source
+
+
+# ---------------------------------------------------------------------------
+# TestStatfs -- disk space reporting
+# ---------------------------------------------------------------------------
+
+
+class TestStatfs:
+    """Verify statfs implementation."""
+
+    def test_statfs_method_exists(self):
+        """AmigaFuseFS has a statfs method."""
+        from amifuse.fuse_fs import AmigaFuseFS
+        assert hasattr(AmigaFuseFS, 'statfs')
+
+    def test_get_disk_info_method_exists(self):
+        """HandlerBridge has a get_disk_info method."""
+        from amifuse.fuse_fs import HandlerBridge
+        assert hasattr(HandlerBridge, 'get_disk_info')
+
+    def test_statfs_returns_required_keys(self):
+        """statfs returns dict with all required statvfs keys."""
+        import inspect
+        from amifuse.fuse_fs import AmigaFuseFS
+        source = inspect.getsource(AmigaFuseFS.statfs)
+        for key in ['f_bsize', 'f_frsize', 'f_blocks', 'f_bfree', 'f_bavail', 'f_namemax']:
+            assert key in source
+
+    def test_disk_info_cache_ttl_readonly(self):
+        """Read-only mount uses infinite disk info cache TTL."""
+        import inspect
+        from amifuse.fuse_fs import AmigaFuseFS
+        source = inspect.getsource(AmigaFuseFS.__init__)
+        assert "_disk_info_ttl" in source
+
+    def test_disk_info_cache_ttl_write(self):
+        """Write mount uses 30s disk info cache TTL."""
+        import inspect
+        from amifuse.fuse_fs import AmigaFuseFS
+        source = inspect.getsource(AmigaFuseFS.__init__)
+        assert "30.0" in source or "30" in source

--- a/tests/unit/test_fuse_fs.py
+++ b/tests/unit/test_fuse_fs.py
@@ -3985,3 +3985,22 @@ class TestStatfs:
         from amifuse.fuse_fs import AmigaFuseFS
         source = inspect.getsource(AmigaFuseFS.__init__)
         assert "30.0" in source or "30" in source
+
+
+# ---------------------------------------------------------------------------
+# TestFuseInit -- shell notification integration
+# ---------------------------------------------------------------------------
+
+
+class TestFuseInit:
+    """Verify init() method exists for shell notification."""
+
+    def test_init_method_exists(self):
+        from amifuse.fuse_fs import AmigaFuseFS
+        assert hasattr(AmigaFuseFS, "init")
+
+    def test_destroy_has_notification(self):
+        import inspect
+        from amifuse.fuse_fs import AmigaFuseFS
+        source = inspect.getsource(AmigaFuseFS.destroy)
+        assert "notify_shell_drive_change" in source

--- a/tests/unit/test_launcher.py
+++ b/tests/unit/test_launcher.py
@@ -187,3 +187,97 @@ class TestLauncherUsesFileLogging:
         assert log_file.exists()
         content = log_file.read_text()
         assert "test message" in content
+
+
+class TestOpenCommand:
+    """Verify the open (mount + Explorer) command."""
+
+    def test_open_subparser_exists(self, mock_popen, mock_windll, mock_exit, monkeypatch):
+        """Launcher accepts 'open' subcommand without error."""
+        # Simulate: only Z:\ is available
+        poll_count = [0]
+        orig_exists = os.path.exists
+
+        def fake_exists(p):
+            p = str(p)
+            if p == "Z:\\":
+                poll_count[0] += 1
+                return poll_count[0] > 1  # drive search = False, poll = True
+            if len(p) == 3 and p[1:] == ":\\":
+                return True
+            return orig_exists(p)
+
+        monkeypatch.setattr("amifuse.launcher.os.path.exists", fake_exists)
+        monkeypatch.setattr("amifuse.launcher.os.startfile", lambda p: None)
+        import time
+        monkeypatch.setattr("time.sleep", lambda s: None)
+        mock_windll.kernel32.OpenMutexW.return_value = 1
+
+        from amifuse.launcher import main
+        main(["open", "test.hdf"])
+
+        # Mount subprocess was launched
+        assert mock_popen.call_count >= 1
+        cmd = mock_popen.call_args_list[0][0][0]
+        assert "--mountpoint" in cmd
+
+    def test_do_open_function_exists(self):
+        """_do_open function is defined."""
+        from amifuse import launcher
+        assert hasattr(launcher, '_do_open')
+        assert callable(launcher._do_open)
+
+    def test_show_error_function_exists(self):
+        """_show_error function is defined."""
+        from amifuse import launcher
+        assert hasattr(launcher, '_show_error')
+        assert callable(launcher._show_error)
+
+    def test_open_shows_error_on_no_drive(self, mock_popen, mock_windll, mock_exit, monkeypatch):
+        """Shows error when no drive letter is available."""
+        # All drives "exist"
+        monkeypatch.setattr("amifuse.launcher.os.path.exists", lambda p: True)
+        monkeypatch.setattr("amifuse.launcher.os.path.isfile", lambda p: False)
+        mock_windll.kernel32.OpenMutexW.return_value = 1
+
+        from amifuse.launcher import main
+        main(["open", "test.hdf"])
+
+        # MessageBoxW should have been called with error
+        mock_windll.user32.MessageBoxW.assert_called_once()
+        call_args = mock_windll.user32.MessageBoxW.call_args[0]
+        assert "No available drive letter" in call_args[1]
+
+    def test_open_includes_daemon_and_mountpoint(self, mock_popen, mock_windll, mock_exit, monkeypatch):
+        """Open command passes --mountpoint and --daemon to mount subprocess."""
+        # Simulate: only Z:\ is available (all others "exist")
+        target_drive = "Z:"
+        poll_count = [0]
+        orig_exists = os.path.exists
+
+        def fake_exists(p):
+            p = str(p)
+            if p == f"{target_drive}\\":
+                poll_count[0] += 1
+                # First call is drive search (return False = available)
+                # Second call is poll (return True = mounted)
+                return poll_count[0] > 1
+            # All other drive letters "exist" (not available)
+            if len(p) == 3 and p[1:] == ":\\":
+                return True
+            return orig_exists(p)
+
+        monkeypatch.setattr("amifuse.launcher.os.path.exists", fake_exists)
+        monkeypatch.setattr("amifuse.launcher.os.startfile", lambda p: None)
+        import time
+        monkeypatch.setattr("time.sleep", lambda s: None)
+        mock_windll.kernel32.OpenMutexW.return_value = 1
+
+        from amifuse.launcher import main
+        main(["open", "test.hdf"])
+
+        cmd = mock_popen.call_args_list[0][0][0]
+        assert "--daemon" in cmd
+        assert "--mountpoint" in cmd
+        mp_idx = cmd.index("--mountpoint")
+        assert cmd[mp_idx + 1] == target_drive

--- a/tests/unit/test_launcher.py
+++ b/tests/unit/test_launcher.py
@@ -246,7 +246,9 @@ class TestOpenCommand:
         # MessageBoxW should have been called with error
         mock_windll.user32.MessageBoxW.assert_called_once()
         call_args = mock_windll.user32.MessageBoxW.call_args[0]
-        assert "No available drive letter" in call_args[1]
+        # call_args[1] is ctypes.c_wchar_p; extract .value for string comparison
+        msg = call_args[1].value if hasattr(call_args[1], 'value') else call_args[1]
+        assert "No available drive letter" in msg
 
     def test_open_includes_daemon_and_mountpoint(self, mock_popen, mock_windll, mock_exit, monkeypatch):
         """Open command passes --mountpoint and --daemon to mount subprocess."""

--- a/tests/unit/test_launcher.py
+++ b/tests/unit/test_launcher.py
@@ -281,5 +281,6 @@ class TestOpenCommand:
         cmd = mock_popen.call_args_list[0][0][0]
         assert "--daemon" in cmd
         assert "--mountpoint" in cmd
+        assert "--write" in cmd
         mp_idx = cmd.index("--mountpoint")
         assert cmd[mp_idx + 1] == target_drive

--- a/tests/unit/test_launcher.py
+++ b/tests/unit/test_launcher.py
@@ -39,9 +39,45 @@ def mock_exit(monkeypatch):
     return mock
 
 
+@pytest.fixture
+def no_sleep(monkeypatch):
+    """Make the mount poll loops run without real delays."""
+    monkeypatch.setattr("time.sleep", lambda s: None)
+
+
+@pytest.fixture
+def drive_env(monkeypatch, no_sleep):
+    """Configure a deterministic drive environment for the launcher.
+
+    Returns a ``configure(allocated, present)`` callable:
+
+    - ``allocated``: iterable of bare uppercase letters the shared helper
+      ``platform._windows_allocated_drive_letters`` should report as taken.
+    - ``present``: iterable of drive paths (e.g. ``{"D:\\\\"}``) that
+      ``os.path.exists`` should report True for -- i.e. mounts that "appeared".
+
+    Selection is driven purely by ``allocated`` (the GetLogicalDrives bitmask
+    stand-in); the mount-appeared poll is driven purely by ``present``. Keeping
+    the two independent is what lets the Task 2 tests prove selection no longer
+    uses ``os.path.exists``.
+    """
+    def _configure(allocated=("A", "B", "C"), present=()):
+        monkeypatch.setattr(
+            "amifuse.launcher.platform._windows_allocated_drive_letters",
+            lambda: set(allocated),
+        )
+        present_set = set(present)
+        monkeypatch.setattr(
+            "amifuse.launcher.os.path.exists",
+            lambda p: str(p) in present_set,
+        )
+    return _configure
+
+
 class TestMountCommand:
-    def test_mount_command_includes_daemon(self, mock_popen, mock_windll, mock_exit):
+    def test_mount_command_includes_daemon(self, mock_popen, mock_windll, mock_exit, drive_env):
         """--daemon is included in mount command."""
+        drive_env(allocated=("A", "B", "C"), present={"D:\\"})
         # Mutex exists (tray already running)
         mock_windll.kernel32.OpenMutexW.return_value = 1
 
@@ -52,8 +88,9 @@ class TestMountCommand:
         cmd = args[0][0]
         assert "--daemon" in cmd
 
-    def test_mount_command_includes_write_flag(self, mock_popen, mock_windll, mock_exit):
+    def test_mount_command_includes_write_flag(self, mock_popen, mock_windll, mock_exit, drive_env):
         """--write is included when specified."""
+        drive_env(allocated=("A", "B", "C"), present={"D:\\"})
         mock_windll.kernel32.OpenMutexW.return_value = 1
 
         from amifuse.launcher import main
@@ -62,8 +99,9 @@ class TestMountCommand:
         cmd = mock_popen.call_args_list[0][0][0]
         assert "--write" in cmd
 
-    def test_mount_creation_flags_include_breakaway(self, mock_popen, mock_windll, mock_exit):
+    def test_mount_creation_flags_include_breakaway(self, mock_popen, mock_windll, mock_exit, drive_env):
         """Mount uses DETACHED flags with CREATE_BREAKAWAY_FROM_JOB."""
+        drive_env(allocated=("A", "B", "C"), present={"D:\\"})
         mock_windll.kernel32.OpenMutexW.return_value = 1
 
         from amifuse.launcher import (
@@ -79,8 +117,9 @@ class TestMountCommand:
         kwargs = mock_popen.call_args_list[0][1]
         assert kwargs["creationflags"] == expected_flags
 
-    def test_mount_falls_back_without_breakaway(self, mock_popen, mock_windll, mock_exit):
+    def test_mount_falls_back_without_breakaway(self, mock_popen, mock_windll, mock_exit, drive_env):
         """If CREATE_BREAKAWAY_FROM_JOB fails, retry without it."""
+        drive_env(allocated=("A", "B", "C"), present={"D:\\"})
         mock_windll.kernel32.OpenMutexW.return_value = 1
 
         # First Popen raises (breakaway denied), second succeeds
@@ -118,8 +157,9 @@ class TestInspectCommand:
 
 
 class TestEnsureTrayRunning:
-    def test_ensure_tray_running_skips_when_running(self, mock_popen, mock_windll, mock_exit, monkeypatch):
+    def test_ensure_tray_running_skips_when_running(self, mock_popen, mock_windll, mock_exit, drive_env):
         """When mutex exists, no tray Popen is spawned."""
+        drive_env(allocated=("A", "B", "C"), present={"D:\\"})
         mock_windll.kernel32.OpenMutexW.return_value = 42  # non-zero = exists
 
         from amifuse.launcher import main
@@ -128,8 +168,9 @@ class TestEnsureTrayRunning:
         # First call is mount Popen; should be no second call for tray
         assert mock_popen.call_count == 1
 
-    def test_ensure_tray_running_spawns_when_not_running(self, mock_popen, mock_windll, mock_exit, monkeypatch):
+    def test_ensure_tray_running_spawns_when_not_running(self, mock_popen, mock_windll, mock_exit, monkeypatch, drive_env):
         """When mutex doesn't exist, tray is spawned."""
+        drive_env(allocated=("A", "B", "C"), present={"D:\\"})
         mock_windll.kernel32.OpenMutexW.return_value = 0  # 0 = not found
         # Make tray exe not exist so it falls back to python -m
         monkeypatch.setattr("amifuse.launcher.os.path.isfile", lambda p: False)
@@ -142,8 +183,9 @@ class TestEnsureTrayRunning:
 
 
 class TestMainExits:
-    def test_main_calls_os_exit(self, mock_popen, mock_windll, mock_exit):
+    def test_main_calls_os_exit(self, mock_popen, mock_windll, mock_exit, drive_env):
         """main() calls os._exit(0) for immediate exit."""
+        drive_env(allocated=("A", "B", "C"), present={"D:\\"})
         mock_windll.kernel32.OpenMutexW.return_value = 1
 
         from amifuse.launcher import main
@@ -158,8 +200,9 @@ class TestMainExits:
 
 
 class TestMountUsesPythonw:
-    def test_mount_uses_pythonw(self, mock_popen, mock_windll, mock_exit, monkeypatch):
+    def test_mount_uses_pythonw(self, mock_popen, mock_windll, mock_exit, monkeypatch, drive_env):
         """Mount subprocess uses pythonw.exe."""
+        drive_env(allocated=("A", "B", "C"), present={"D:\\"})
         mock_windll.kernel32.OpenMutexW.return_value = 1
         monkeypatch.setattr("sys.executable", r"C:\Python\python.exe")
         monkeypatch.setattr(
@@ -192,25 +235,10 @@ class TestLauncherUsesFileLogging:
 class TestOpenCommand:
     """Verify the open (mount + Explorer) command."""
 
-    def test_open_subparser_exists(self, mock_popen, mock_windll, mock_exit, monkeypatch):
+    def test_open_subparser_exists(self, mock_popen, mock_windll, mock_exit, monkeypatch, drive_env):
         """Launcher accepts 'open' subcommand without error."""
-        # Simulate: only Z:\ is available
-        poll_count = [0]
-        orig_exists = os.path.exists
-
-        def fake_exists(p):
-            p = str(p)
-            if p == "Z:\\":
-                poll_count[0] += 1
-                return poll_count[0] > 1  # drive search = False, poll = True
-            if len(p) == 3 and p[1:] == ":\\":
-                return True
-            return orig_exists(p)
-
-        monkeypatch.setattr("amifuse.launcher.os.path.exists", fake_exists)
+        drive_env(allocated=("A", "B", "C"), present={"D:\\"})
         monkeypatch.setattr("amifuse.launcher.os.startfile", lambda p: None)
-        import time
-        monkeypatch.setattr("time.sleep", lambda s: None)
         mock_windll.kernel32.OpenMutexW.return_value = 1
 
         from amifuse.launcher import main
@@ -233,16 +261,18 @@ class TestOpenCommand:
         assert hasattr(launcher, '_show_error')
         assert callable(launcher._show_error)
 
-    def test_open_shows_error_on_no_drive(self, mock_popen, mock_windll, mock_exit, monkeypatch):
+    def test_open_shows_error_on_no_drive(self, mock_popen, mock_windll, mock_exit, monkeypatch, drive_env):
         """Shows error when no drive letter is available."""
-        # All drives "exist"
-        monkeypatch.setattr("amifuse.launcher.os.path.exists", lambda p: True)
+        # Every letter allocated -> helper reports no free letter.
+        drive_env(allocated=set("ABCDEFGHIJKLMNOPQRSTUVWXYZ"), present=())
         monkeypatch.setattr("amifuse.launcher.os.path.isfile", lambda p: False)
         mock_windll.kernel32.OpenMutexW.return_value = 1
 
         from amifuse.launcher import main
         main(["open", "test.hdf"])
 
+        # No mount subprocess should be spawned when no letter is free.
+        assert mock_popen.call_count == 0
         # MessageBoxW should have been called with error
         mock_windll.user32.MessageBoxW.assert_called_once()
         call_args = mock_windll.user32.MessageBoxW.call_args[0]
@@ -250,29 +280,11 @@ class TestOpenCommand:
         msg = call_args[1].value if hasattr(call_args[1], 'value') else call_args[1]
         assert "No available drive letter" in msg
 
-    def test_open_includes_daemon_and_mountpoint(self, mock_popen, mock_windll, mock_exit, monkeypatch):
+    def test_open_includes_daemon_and_mountpoint(self, mock_popen, mock_windll, mock_exit, monkeypatch, drive_env):
         """Open command passes --mountpoint and --daemon to mount subprocess."""
-        # Simulate: only Z:\ is available (all others "exist")
-        target_drive = "Z:"
-        poll_count = [0]
-        orig_exists = os.path.exists
-
-        def fake_exists(p):
-            p = str(p)
-            if p == f"{target_drive}\\":
-                poll_count[0] += 1
-                # First call is drive search (return False = available)
-                # Second call is poll (return True = mounted)
-                return poll_count[0] > 1
-            # All other drive letters "exist" (not available)
-            if len(p) == 3 and p[1:] == ":\\":
-                return True
-            return orig_exists(p)
-
-        monkeypatch.setattr("amifuse.launcher.os.path.exists", fake_exists)
+        # C: taken, so first free letter is D:.
+        drive_env(allocated=("A", "B", "C"), present={"D:\\"})
         monkeypatch.setattr("amifuse.launcher.os.startfile", lambda p: None)
-        import time
-        monkeypatch.setattr("time.sleep", lambda s: None)
         mock_windll.kernel32.OpenMutexW.return_value = 1
 
         from amifuse.launcher import main
@@ -283,4 +295,141 @@ class TestOpenCommand:
         assert "--mountpoint" in cmd
         assert "--write" in cmd
         mp_idx = cmd.index("--mountpoint")
-        assert cmd[mp_idx + 1] == target_drive
+        assert cmd[mp_idx + 1] == "D:"
+
+
+class TestOpenDriveSelection:
+    """Task 2: _do_open selects letters via the shared allocated-letters helper."""
+
+    def test_open_skips_allocated_letters(self, mock_popen, mock_windll, mock_exit, monkeypatch, drive_env):
+        """Selection skips allocated letters and lands on the first free one.
+
+        A,B,C,D allocated -> first free letter is E:. Crucially, os.path.exists
+        reports True ONLY for E:\\ (the poll target) -- so if selection wrongly
+        used os.path.exists it would pick D: (which reads as absent). Landing on
+        E: proves selection is driven by the GetLogicalDrives helper, not the
+        media probe.
+        """
+        drive_env(allocated=("A", "B", "C", "D"), present={"E:\\"})
+        monkeypatch.setattr("amifuse.launcher.os.startfile", lambda p: None)
+        mock_windll.kernel32.OpenMutexW.return_value = 1
+
+        from amifuse.launcher import main
+        main(["open", "test.hdf"])
+
+        cmd = mock_popen.call_args_list[0][0][0]
+        mp_idx = cmd.index("--mountpoint")
+        assert cmd[mp_idx + 1] == "E:"
+
+    def test_open_consults_allocated_helper(self, mock_popen, mock_windll, mock_exit, monkeypatch):
+        """_do_open selects via platform._windows_allocated_drive_letters()."""
+        helper = MagicMock(return_value={"A", "B", "C"})
+        monkeypatch.setattr(
+            "amifuse.launcher.platform._windows_allocated_drive_letters", helper,
+        )
+        monkeypatch.setattr("amifuse.launcher.os.path.exists", lambda p: str(p) == "D:\\")
+        monkeypatch.setattr("amifuse.launcher.os.startfile", lambda p: None)
+        monkeypatch.setattr("time.sleep", lambda s: None)
+        mock_windll.kernel32.OpenMutexW.return_value = 1
+
+        from amifuse.launcher import main
+        main(["open", "test.hdf"])
+
+        helper.assert_called()
+
+    def test_open_preserves_write_flag(self, mock_popen, mock_windll, mock_exit, monkeypatch, drive_env):
+        """open always mounts writable -- --write must remain in the command."""
+        drive_env(allocated=("A", "B", "C"), present={"D:\\"})
+        monkeypatch.setattr("amifuse.launcher.os.startfile", lambda p: None)
+        mock_windll.kernel32.OpenMutexW.return_value = 1
+
+        from amifuse.launcher import main
+        main(["open", "test.hdf"])
+
+        cmd = mock_popen.call_args_list[0][0][0]
+        assert "--write" in cmd
+
+
+class TestMountSurfacesErrors:
+    """Task 3: the mount (mountro verb) surfaces failures via a dialog."""
+
+    def test_mount_success_no_dialog(self, mock_popen, mock_windll, mock_exit, drive_env):
+        """When the mount appears, no error dialog is shown."""
+        drive_env(allocated=("A", "B", "C"), present={"D:\\"})
+        mock_windll.kernel32.OpenMutexW.return_value = 1
+
+        from amifuse.launcher import main
+        main(["mount", "test.hdf"])
+
+        mock_windll.user32.MessageBoxW.assert_not_called()
+
+    def test_mount_timeout_shows_error(self, mock_popen, mock_windll, mock_exit, monkeypatch, drive_env):
+        """When the mount never appears, a single error dialog is shown and the
+        tray is started (a slow cold mount may still be initializing)."""
+        # present=() -> os.path.exists always False -> poll times out.
+        drive_env(allocated=("A", "B", "C"), present=())
+        mock_windll.kernel32.OpenMutexW.return_value = 1
+        tray = MagicMock()
+        monkeypatch.setattr("amifuse.launcher._ensure_tray_running", tray)
+
+        from amifuse.launcher import main
+        main(["mount", "test.hdf"])
+
+        # Tray is started even on timeout (slow-but-successful cold mount).
+        tray.assert_called_once()
+        # Dialog shown exactly once, with the softened (non-definitive) wording.
+        mock_windll.user32.MessageBoxW.assert_called_once()
+        call_args = mock_windll.user32.MessageBoxW.call_args[0]
+        msg = call_args[1].value if hasattr(call_args[1], "value") else call_args[1]
+        assert "did not appear" in msg.lower()
+
+    def test_mount_spawn_failure_shows_error(self, mock_popen, mock_windll, mock_exit, drive_env):
+        """A spawn failure surfaces an error dialog instead of exiting silently."""
+        drive_env(allocated=("A", "B", "C"), present={"D:\\"})
+        # Both breakaway and fallback Popen raise -> _spawn_detached propagates.
+        mock_popen.side_effect = OSError("spawn failed")
+        mock_windll.kernel32.OpenMutexW.return_value = 1
+
+        from amifuse.launcher import main
+        main(["mount", "test.hdf"])
+
+        mock_windll.user32.MessageBoxW.assert_called_once()
+
+    def test_mount_no_free_letter_shows_error(self, mock_popen, mock_windll, mock_exit, drive_env):
+        """No free drive letter -> error dialog, no subprocess spawned."""
+        drive_env(allocated=set("ABCDEFGHIJKLMNOPQRSTUVWXYZ"), present=())
+        mock_windll.kernel32.OpenMutexW.return_value = 1
+
+        from amifuse.launcher import main
+        main(["mount", "test.hdf"])
+
+        assert mock_popen.call_count == 0
+        mock_windll.user32.MessageBoxW.assert_called_once()
+
+    def test_mount_passes_mountpoint_and_write(self, mock_popen, mock_windll, mock_exit, drive_env):
+        """A write mount passes explicit --mountpoint and --write."""
+        drive_env(allocated=("A", "B", "C"), present={"D:\\"})
+        mock_windll.kernel32.OpenMutexW.return_value = 1
+
+        from amifuse.launcher import main
+        main(["mount", "--write", "test.hdf"])
+
+        cmd = mock_popen.call_args_list[0][0][0]
+        assert "--mountpoint" in cmd
+        mp_idx = cmd.index("--mountpoint")
+        assert cmd[mp_idx + 1] == "D:"
+        assert "--write" in cmd
+
+    def test_mount_readonly_omits_write(self, mock_popen, mock_windll, mock_exit, drive_env):
+        """A read-only mount (mountro verb) passes --mountpoint but not --write."""
+        drive_env(allocated=("A", "B", "C"), present={"D:\\"})
+        mock_windll.kernel32.OpenMutexW.return_value = 1
+
+        from amifuse.launcher import main
+        main(["mount", "test.hdf"])
+
+        cmd = mock_popen.call_args_list[0][0][0]
+        assert "--mountpoint" in cmd
+        mp_idx = cmd.index("--mountpoint")
+        assert cmd[mp_idx + 1] == "D:"
+        assert "--write" not in cmd

--- a/tests/unit/test_launcher.py
+++ b/tests/unit/test_launcher.py
@@ -14,6 +14,16 @@ import pytest
 pytestmark = pytest.mark.skipif(sys.platform != "win32", reason="Windows-only")
 
 
+def _msg_text(mock_windll) -> str:
+    """Extract the message string from the last MessageBoxW call.
+
+    The message arg is a ``ctypes.c_wchar_p``; return its ``.value`` (or the raw
+    arg if it is already a plain string).
+    """
+    arg = mock_windll.user32.MessageBoxW.call_args[0][1]
+    return arg.value if hasattr(arg, "value") else arg
+
+
 @pytest.fixture
 def mock_popen(monkeypatch):
     """Mock subprocess.Popen and return the mock."""
@@ -350,6 +360,97 @@ class TestOpenDriveSelection:
         assert "--write" in cmd
 
 
+class TestSelectDriveLetters:
+    """Task 3: _select_drive_letters(n) -> (chosen, total_free) selector."""
+
+    @pytest.fixture
+    def allocated(self, monkeypatch):
+        """Return a setter that mocks the GetLogicalDrives allocation helper.
+
+        Selection is driven purely by the bitmask stand-in; no real drives are
+        touched. The helper returns bare uppercase letters (e.g. ``{"A","B"}``),
+        matching platform._windows_allocated_drive_letters.
+        """
+        def _set(letters):
+            monkeypatch.setattr(
+                "amifuse.launcher.platform._windows_allocated_drive_letters",
+                lambda: set(letters),
+            )
+        return _set
+
+    def test_returns_n_distinct_free_letters_in_order(self, allocated):
+        """(a) n distinct free letters are returned in D-start alphabet order."""
+        allocated(("A", "B", "C"))  # only reserved letters taken
+        from amifuse.launcher import _select_drive_letters
+
+        chosen, total_free = _select_drive_letters(3)
+        assert chosen == ["D:", "E:", "F:"]
+        assert len(set(chosen)) == 3  # distinct
+
+    def test_total_free_reflects_true_availability(self, allocated):
+        """(b) total_free counts every free letter in the D-start alphabet."""
+        # A,B,C reserved + D,E taken -> free = F..Z = 21 letters.
+        allocated(("A", "B", "C", "D", "E"))
+        from amifuse.launcher import _select_drive_letters
+
+        chosen, total_free = _select_drive_letters(2)
+        assert chosen == ["F:", "G:"]
+        assert total_free == 21
+
+    def test_partial_when_total_free_below_n(self, allocated):
+        """(c) when total_free < n, only total_free letters are returned."""
+        # Everything except X,Y,Z allocated -> 3 free, request 5.
+        allocated(set("ABCDEFGHIJKLMNOPQRSTUVW"))
+        from amifuse.launcher import _select_drive_letters
+
+        chosen, total_free = _select_drive_letters(5)
+        assert chosen == ["X:", "Y:", "Z:"]
+        assert total_free == 3
+        assert len(chosen) == total_free  # partial, not padded
+
+    def test_no_free_letters_returns_empty(self, allocated):
+        """(c') full exhaustion -> empty chosen, total_free 0 (no IndexError)."""
+        allocated(set("ABCDEFGHIJKLMNOPQRSTUVWXYZ"))
+        from amifuse.launcher import _select_drive_letters
+
+        chosen, total_free = _select_drive_letters(3)
+        assert chosen == []
+        assert total_free == 0
+
+    def test_single_wrapper_matches_first_free_letter(self, allocated):
+        """(d) _select_drive_letter() still returns the same first free letter."""
+        allocated(("A", "B", "C", "D"))  # first free is E:
+        from amifuse.launcher import _select_drive_letter, _select_drive_letters
+
+        assert _select_drive_letter() == "E:"
+        # Identity: the N=1 wrapper is exactly the first chosen letter, i.e.
+        # _select_drive_letters(1) -> (["E:"], total); chosen[0] == "E:".
+        chosen, _total = _select_drive_letters(1)
+        assert _select_drive_letter() == chosen[0]
+
+    def test_single_wrapper_returns_none_when_no_free_letter(self, allocated):
+        """(d') the N=1 wrapper preserves the None contract on exhaustion."""
+        allocated(set("ABCDEFGHIJKLMNOPQRSTUVWXYZ"))
+        from amifuse.launcher import _select_drive_letter
+
+        assert _select_drive_letter() is None
+
+    def test_abc_never_returned_or_counted_when_free(self, allocated):
+        """(e) D-start alphabet: A/B/C are never chosen and never counted.
+
+        Report A,B,C as free-in-bitmask-terms (nothing allocated at all). An A-Z
+        implementation would return A:/B:/C: and count them; the D-start alphabet
+        must skip them for both the chosen list and total_free.
+        """
+        allocated(())  # bitmask reports every letter, incl. A/B/C, as free
+        from amifuse.launcher import _select_drive_letters
+
+        chosen, total_free = _select_drive_letters(3)
+        assert chosen == ["D:", "E:", "F:"]  # not A:/B:/C:
+        assert "A:" not in chosen and "B:" not in chosen and "C:" not in chosen
+        assert total_free == 23  # D..Z, not 26 -- A/B/C excluded from the count
+
+
 class TestMountSurfacesErrors:
     """Task 3: the mount (mountro verb) surfaces failures via a dialog."""
 
@@ -433,3 +534,447 @@ class TestMountSurfacesErrors:
         mp_idx = cmd.index("--mountpoint")
         assert cmd[mp_idx + 1] == "D:"
         assert "--write" not in cmd
+
+
+@pytest.fixture
+def fanout(monkeypatch, no_sleep):
+    """Drive mount_image_all with controlled enumeration + drive environment.
+
+    Returns ``(configure, opened)``. ``configure`` patches:
+
+    - ``_enumerate_mount_units`` -> ``_MountUnit`` list from ``units_spec`` (each
+      entry a partition name, or ``None`` for the collapsed no-``--partition``
+      unit) plus ``fallback_reason``. Enumeration is mocked so the fan-out logic
+      is tested in isolation from rdb_inspect/amitools.
+    - the GetLogicalDrives allocation helper (letter selection) from ``allocated``.
+    - ``os.path.exists`` (the arrival poll) from ``present``.
+    - ``os.startfile`` -- recorded into the returned ``opened`` list.
+    """
+    opened: list[str] = []
+
+    def _configure(units_spec, allocated, present, fallback_reason=None):
+        from amifuse.launcher import _MountUnit
+        units = [_MountUnit(name=n, label=(n or "disk image")) for n in units_spec]
+        monkeypatch.setattr(
+            "amifuse.launcher._enumerate_mount_units",
+            lambda image: (units, fallback_reason),
+        )
+        monkeypatch.setattr(
+            "amifuse.launcher.platform._windows_allocated_drive_letters",
+            lambda: set(allocated),
+        )
+        present_set = set(present)
+        monkeypatch.setattr(
+            "amifuse.launcher.os.path.exists", lambda p: str(p) in present_set
+        )
+        monkeypatch.setattr(
+            "amifuse.launcher.os.startfile", lambda p: opened.append(str(p))
+        )
+
+    return _configure, opened
+
+
+class TestMountImageAllFanOut:
+    """Task 4: the mount_image_all fan-out core behind _do_open / _do_mount."""
+
+    def test_open_spawns_one_mount_per_partition_by_name(
+        self, mock_popen, mock_windll, mock_exit, fanout
+    ):
+        """open -> one --write spawn per partition, keyed by --partition <name>."""
+        configure, _opened = fanout
+        configure(["WB_1.3", "WB_2.x", "Work"], ("A", "B", "C"),
+                  {"D:\\", "E:\\", "F:\\"})
+        mock_windll.kernel32.OpenMutexW.return_value = 1  # tray already running
+
+        from amifuse.launcher import main
+        main(["open", "img.hdf"])
+
+        cmds = [c[0][0] for c in mock_popen.call_args_list]
+        assert len(cmds) == 3  # three mount spawns, no tray spawn (mutex present)
+        expected = [("WB_1.3", "D:"), ("WB_2.x", "E:"), ("Work", "F:")]
+        for cmd, (name, letter) in zip(cmds, expected):
+            assert cmd[cmd.index("--partition") + 1] == name
+            assert cmd[cmd.index("--mountpoint") + 1] == letter
+            assert "--write" in cmd
+            assert cmd[cmd.index("--daemon") + 1] == "img.hdf"
+
+    def test_mountro_spawns_all_partitions_without_write(
+        self, mock_popen, mock_windll, mock_exit, fanout
+    ):
+        """mountro -> one spawn per partition, each with --partition, no --write."""
+        configure, _opened = fanout
+        configure(["WB_1.3", "WB_2.x", "Work"], ("A", "B", "C"),
+                  {"D:\\", "E:\\", "F:\\"})
+        mock_windll.kernel32.OpenMutexW.return_value = 1
+
+        from amifuse.launcher import main
+        main(["mount", "img.hdf"])
+
+        cmds = [c[0][0] for c in mock_popen.call_args_list]
+        assert len(cmds) == 3
+        for cmd in cmds:
+            assert "--partition" in cmd
+            assert "--write" not in cmd  # mountro never passes --write
+
+    def test_open_opens_one_window_per_confirmed_drive(
+        self, mock_popen, mock_windll, mock_exit, fanout
+    ):
+        """open opens exactly one Explorer window per confirmed drive."""
+        configure, opened = fanout
+        configure(["WB_1.3", "WB_2.x", "Work"], ("A", "B", "C"),
+                  {"D:\\", "E:\\", "F:\\"})
+        mock_windll.kernel32.OpenMutexW.return_value = 1
+
+        from amifuse.launcher import main
+        main(["open", "img.hdf"])
+
+        assert sorted(opened) == ["D:\\", "E:\\", "F:\\"]
+
+    def test_mountro_opens_no_windows(
+        self, mock_popen, mock_windll, mock_exit, fanout
+    ):
+        """mountro opens no Explorer windows (init() refresh handles arrival)."""
+        configure, opened = fanout
+        configure(["WB_1.3", "WB_2.x", "Work"], ("A", "B", "C"),
+                  {"D:\\", "E:\\", "F:\\"})
+        mock_windll.kernel32.OpenMutexW.return_value = 1
+
+        from amifuse.launcher import main
+        main(["mount", "img.hdf"])
+
+        assert opened == []
+
+    def test_tray_started_once(
+        self, mock_popen, mock_windll, mock_exit, monkeypatch, fanout
+    ):
+        """The tray is started exactly once after the aggregate poll, not per spawn."""
+        configure, _opened = fanout
+        configure(["WB_1.3", "WB_2.x", "Work"], ("A", "B", "C"),
+                  {"D:\\", "E:\\", "F:\\"})
+        tray = MagicMock()
+        monkeypatch.setattr("amifuse.launcher._ensure_tray_running", tray)
+
+        from amifuse.launcher import main
+        main(["open", "img.hdf"])
+
+        tray.assert_called_once()
+
+    def test_partial_on_letter_exhaustion_names_skipped(
+        self, mock_popen, mock_windll, mock_exit, fanout
+    ):
+        """Fewer letters than partitions -> mount what fits, skip the rest, and
+        show ONE summary dialog naming the skipped partition."""
+        configure, opened = fanout
+        # Only D: and E: free (everything else allocated) -> total_free == 2.
+        allocated = set("ABC") | set("FGHIJKLMNOPQRSTUVWXYZ")
+        configure(["WB_1.3", "WB_2.x", "Work"], allocated, {"D:\\", "E:\\"})
+        mock_windll.kernel32.OpenMutexW.return_value = 1
+
+        from amifuse.launcher import main
+        main(["open", "img.hdf"])
+
+        # Two spawns only (Work skipped -- no free letter).
+        assert len(mock_popen.call_args_list) == 2
+        # A window is opened for each CONFIRMED drive (D:, E:) and none for the
+        # skipped partition -- the open path only follows through on real drives.
+        assert sorted(opened) == ["D:\\", "E:\\"]
+        # Exactly one summary dialog, naming the skipped partition + reason.
+        mock_windll.user32.MessageBoxW.assert_called_once()
+        msg = _msg_text(mock_windll)
+        assert "Work" in msg
+        assert "no free drive letter" in msg
+        assert "WB_1.3 (D:)" in msg and "WB_2.x (E:)" in msg  # succeeded named
+
+    def test_fallback_reason_surfaced_in_summary(
+        self, mock_popen, mock_windll, mock_exit, fanout
+    ):
+        """A duplicate-name fallback_reason is surfaced in the summary dialog even
+        though the (single) mount itself succeeds."""
+        configure, _opened = fanout
+        reason = ("multiple RDBs with colliding partition names "
+                  "('DH0'); mounted first only")
+        configure([None], ("A", "B", "C"), {"D:\\"}, fallback_reason=reason)
+        mock_windll.kernel32.OpenMutexW.return_value = 1
+
+        from amifuse.launcher import main
+        main(["open", "img.hdf"])
+
+        mock_windll.user32.MessageBoxW.assert_called_once()
+        assert "colliding partition names" in _msg_text(mock_windll)
+
+    def test_timeout_reports_pending_softly(
+        self, mock_popen, mock_windll, mock_exit, fanout
+    ):
+        """A drive that never appears is reported with soft, non-definitive wording."""
+        configure, _opened = fanout
+        configure(["WB_1.3"], ("A", "B", "C"), present=())  # never appears
+        mock_windll.kernel32.OpenMutexW.return_value = 1
+
+        from amifuse.launcher import main
+        main(["open", "img.hdf"])
+
+        mock_windll.user32.MessageBoxW.assert_called_once()
+        assert "did not appear" in _msg_text(mock_windll).lower()
+
+    def test_deadline_scales_with_spawn_count(
+        self, mock_popen, mock_windll, mock_exit, monkeypatch, fanout
+    ):
+        """The poll uses the aggregate deadline sized by the spawn count (N=3),
+        not a flat per-mount 15s."""
+        configure, _opened = fanout
+        configure(["WB_1.3", "WB_2.x", "Work"], ("A", "B", "C"),
+                  {"D:\\", "E:\\", "F:\\"})
+        mock_windll.kernel32.OpenMutexW.return_value = 1
+        spy = MagicMock(return_value=25.0)
+        monkeypatch.setattr("amifuse.launcher._aggregate_timeout", spy)
+
+        from amifuse.launcher import main
+        main(["open", "img.hdf"])
+
+        spy.assert_called_once_with(3)
+
+    def test_spawn_failure_is_definite_and_isolated(
+        self, mock_popen, mock_windll, mock_exit, fanout
+    ):
+        """One partition whose _spawn_detached raises lands in the spawn-failed
+        bucket with DEFINITE wording (not the soft "may still be starting"), and
+        the other partitions still mount and open windows -- independent
+        processes, so one never-started mount does not sink the others."""
+        configure, opened = fanout
+        configure(["WB_1.3", "WB_2.x", "Work"], ("A", "B", "C"),
+                  {"D:\\", "E:\\", "F:\\"})
+        mock_windll.kernel32.OpenMutexW.return_value = 1
+
+        # WB_2.x (E:) never launches: raise a NON-OSError so _spawn_detached
+        # propagates immediately (its retry only catches OSError). The other two
+        # spawns succeed.
+        def _side(cmd, *a, **kw):
+            if "--partition" in cmd and cmd[cmd.index("--partition") + 1] == "WB_2.x":
+                raise RuntimeError("CreateProcess failed")
+            return MagicMock()
+        mock_popen.side_effect = _side
+
+        from amifuse.launcher import main
+        main(["open", "img.hdf"])
+
+        # Isolation: the two healthy partitions still mounted and each opened a
+        # window; the never-started one opened none.
+        assert sorted(opened) == ["D:\\", "F:\\"]
+
+        # One dialog, definite wording for the spawn failure, and NO soft
+        # "may still be starting" phrasing (nothing timed out here).
+        mock_windll.user32.MessageBoxW.assert_called_once()
+        msg = _msg_text(mock_windll)
+        assert "Could not start mount for WB_2.x (E:)" in msg
+        assert "CreateProcess failed" in msg          # the underlying reason
+        assert "may still be starting" not in msg      # not softened
+        assert "WB_1.3 (D:)" in msg and "Work (F:)" in msg  # healthy ones named
+
+    def test_skipped_and_timeout_share_one_dialog(
+        self, mock_popen, mock_windll, mock_exit, fanout
+    ):
+        """Letter exhaustion (skipped) and an arrival timeout (failed) co-occur
+        in a SINGLE summary dialog naming both buckets -- one _show_error call."""
+        configure, _opened = fanout
+        # Only D: and E: free -> Work is skipped; D:/E: spawn but never appear.
+        allocated = set("ABC") | set("FGHIJKLMNOPQRSTUVWXYZ")
+        configure(["WB_1.3", "WB_2.x", "Work"], allocated, present=())
+        mock_windll.kernel32.OpenMutexW.return_value = 1
+
+        from amifuse.launcher import main
+        main(["open", "img.hdf"])
+
+        # Exactly one dialog carrying BOTH buckets.
+        mock_windll.user32.MessageBoxW.assert_called_once()
+        msg = _msg_text(mock_windll)
+        # Skipped bucket (letter exhaustion).
+        assert "Work" in msg and "no free drive letter" in msg
+        # Failed bucket (arrival timeout, soft wording), naming both drives.
+        assert "did not appear" in msg
+        assert "WB_1.3 (D:)" in msg and "WB_2.x (E:)" in msg
+
+
+class TestN1Identity:
+    """Task 4 coherence guarantee: a single unit reproduces the legacy path."""
+
+    def test_open_single_unit_is_byte_for_byte_legacy_cmd(
+        self, mock_popen, mock_windll, mock_exit, fanout
+    ):
+        """A lone unit spawns the exact legacy open command: no --partition,
+        --write before --mountpoint, one window, and NO dialog on success."""
+        configure, opened = fanout
+        configure([None], ("A", "B", "C"), {"D:\\"})  # single collapsed unit
+        mock_windll.kernel32.OpenMutexW.return_value = 1
+
+        from amifuse.launcher import main
+        main(["open", "img.hdf"])
+
+        assert len(mock_popen.call_args_list) == 1
+        cmd = mock_popen.call_args_list[0][0][0]
+        assert "--partition" not in cmd
+        # Byte-for-byte legacy open tail.
+        assert cmd[-6:] == [
+            "mount", "--write", "--mountpoint", "D:", "--daemon", "img.hdf",
+        ]
+        assert opened == ["D:\\"]              # one window
+        mock_windll.user32.MessageBoxW.assert_not_called()  # no dialog on success
+
+    def test_mountro_single_unit_is_byte_for_byte_legacy_cmd(
+        self, mock_popen, mock_windll, mock_exit, fanout
+    ):
+        """A lone unit on mountro spawns the legacy read-only command and opens
+        no window."""
+        configure, opened = fanout
+        configure([None], ("A", "B", "C"), {"D:\\"})
+        mock_windll.kernel32.OpenMutexW.return_value = 1
+
+        from amifuse.launcher import main
+        main(["mount", "img.hdf"])
+
+        assert len(mock_popen.call_args_list) == 1
+        cmd = mock_popen.call_args_list[0][0][0]
+        assert "--partition" not in cmd
+        assert "--write" not in cmd
+        assert cmd[-5:] == [
+            "mount", "--mountpoint", "D:", "--daemon", "img.hdf",
+        ]
+        assert opened == []
+
+
+class TestAggregateTimeout:
+    """Task 4: the min(15 + 5*(n-1), 45) aggregate deadline formula."""
+
+    def test_n1_stays_at_legacy_15s(self):
+        """N=1 keeps the unchanged single-partition 15s budget."""
+        from amifuse.launcher import _aggregate_timeout, MOUNT_POLL_TIMEOUT
+        assert _aggregate_timeout(1) == 15.0 == MOUNT_POLL_TIMEOUT
+
+    def test_scales_5s_per_extra_partition(self):
+        """Each extra concurrent partition adds 5s of cold-init headroom."""
+        from amifuse.launcher import _aggregate_timeout
+        assert _aggregate_timeout(2) == 20.0
+        assert _aggregate_timeout(3) == 25.0
+
+    def test_capped_at_45s(self):
+        """The budget caps at 45s no matter how many partitions."""
+        from amifuse.launcher import _aggregate_timeout
+        assert _aggregate_timeout(10) == 45.0
+        assert _aggregate_timeout(100) == 45.0
+
+    def test_zero_spawns_is_harmless(self):
+        """n<=1 (incl. 0 spawned) yields the base budget, no negative/odd value."""
+        from amifuse.launcher import _aggregate_timeout
+        assert _aggregate_timeout(0) == 15.0
+
+
+class TestEnumerateMountUnits:
+    """Task 4: enumeration order, single-unit collapse, and graceful fallback."""
+
+    @pytest.fixture
+    def rdb(self, monkeypatch):
+        """Patch the three rdb_inspect enumeration entry points the core uses.
+
+        set(adf=..., iso=..., parts=...) where ``parts`` is either a fake
+        PartitionList, an Exception instance to raise, or a MagicMock. Fakes use
+        SimpleNamespace so no real amitools objects are constructed.
+        """
+        from types import SimpleNamespace
+
+        def _plist(names, fallback_reason=None):
+            return SimpleNamespace(
+                partitions=[SimpleNamespace(name=n) for n in names],
+                fallback_reason=fallback_reason,
+            )
+
+        def _set(adf=None, iso=None, parts=None):
+            monkeypatch.setattr("amifuse.rdb_inspect.detect_adf", lambda img: adf)
+            monkeypatch.setattr("amifuse.rdb_inspect.detect_iso", lambda img: iso)
+            if isinstance(parts, Exception):
+                def _raise(img, *a, **k):
+                    raise parts
+                monkeypatch.setattr("amifuse.rdb_inspect.list_partitions", _raise)
+            elif parts is not None:
+                monkeypatch.setattr(
+                    "amifuse.rdb_inspect.list_partitions", lambda img, *a, **k: parts
+                )
+            return SimpleNamespace(plist=_plist)
+
+        return _set
+
+    def test_adf_short_circuits_before_list_partitions(self, rdb, monkeypatch):
+        """detect_adf non-None -> single unit, list_partitions never called."""
+        list_parts = MagicMock()
+        rdb(adf=object(), iso=None)
+        monkeypatch.setattr("amifuse.rdb_inspect.list_partitions", list_parts)
+
+        from amifuse.launcher import _enumerate_mount_units
+        units, fallback = _enumerate_mount_units("floppy.adf")
+
+        assert len(units) == 1 and units[0].name is None
+        assert fallback is None
+        list_parts.assert_not_called()
+
+    def test_iso_short_circuits_before_list_partitions(self, rdb, monkeypatch):
+        """detect_iso non-None -> single unit, list_partitions never called."""
+        list_parts = MagicMock()
+        rdb(adf=None, iso=object())
+        monkeypatch.setattr("amifuse.rdb_inspect.list_partitions", list_parts)
+
+        from amifuse.launcher import _enumerate_mount_units
+        units, fallback = _enumerate_mount_units("cd.iso")
+
+        assert len(units) == 1 and units[0].name is None
+        assert fallback is None
+        list_parts.assert_not_called()
+
+    def test_single_partition_rdb_collapses_to_no_partition(self, rdb):
+        """A single-partition RDB collapses to a no---partition unit (byte-for-byte
+        legacy) while keeping the partition name as the dialog label."""
+        helper = rdb(adf=None, iso=None)
+        rdb(adf=None, iso=None, parts=helper.plist(["WB_1.3"]))
+
+        from amifuse.launcher import _enumerate_mount_units
+        units, fallback = _enumerate_mount_units("single.hdf")
+
+        assert len(units) == 1
+        assert units[0].name is None        # collapsed -> omit --partition
+        assert units[0].label == "WB_1.3"   # label preserved for any dialog
+        assert fallback is None
+
+    def test_multi_partition_rdb_keys_by_name(self, rdb):
+        """A multi-partition RDB emits one named unit per partition, in order."""
+        helper = rdb(adf=None, iso=None)
+        rdb(adf=None, iso=None,
+            parts=helper.plist(["WB_1.3", "WB_2.x", "Work"]))
+
+        from amifuse.launcher import _enumerate_mount_units
+        units, fallback = _enumerate_mount_units("multi.hdf")
+
+        assert [u.name for u in units] == ["WB_1.3", "WB_2.x", "Work"]
+        assert fallback is None
+
+    def test_duplicate_name_fallback_returns_reason_and_single_unit(self, rdb):
+        """The duplicate-name fallback (partitions == [first], fallback_reason set)
+        collapses to one no---partition unit and propagates the reason."""
+        helper = rdb(adf=None, iso=None)
+        reason = "multiple RDBs with colliding partition names ('DH0'); mounted first only"
+        rdb(adf=None, iso=None,
+            parts=helper.plist(["WB_1.3"], fallback_reason=reason))
+
+        from amifuse.launcher import _enumerate_mount_units
+        units, fallback = _enumerate_mount_units("colliding.hdf")
+
+        assert len(units) == 1 and units[0].name is None
+        assert fallback == reason
+
+    def test_enumeration_error_falls_back_to_single_unit(self, rdb):
+        """An IOError from list_partitions (non-RDB / unreadable) degrades to a
+        single no---partition unit -- the launcher never crashes on enumeration."""
+        rdb(adf=None, iso=None, parts=IOError("not an RDB image"))
+
+        from amifuse.launcher import _enumerate_mount_units
+        units, fallback = _enumerate_mount_units("bogus.hdf")
+
+        assert len(units) == 1 and units[0].name is None
+        assert units[0].label == "disk image"
+        assert fallback is None

--- a/tests/unit/test_platform.py
+++ b/tests/unit/test_platform.py
@@ -1168,3 +1168,117 @@ class TestNotifyShellDriveChange:
         # Should return without error
         plat.notify_shell_drive_change("D:", added=True)
         plat.notify_shell_drive_change("D:", added=False)
+
+
+# ---------------------------------------------------------------------------
+# TestParseMountTokensQuoting -- quote-stripping in _parse_mount_tokens
+# ---------------------------------------------------------------------------
+
+
+class TestParseMountTokensQuoting:
+    """Verify _parse_mount_tokens strips a matched surrounding quote pair.
+
+    On Windows the command line is tokenized with shlex.split(posix=False),
+    which retains the literal quotes that list2cmdline adds around spaced paths.
+    The parser must return image/mountpoint without those surrounding quotes,
+    while leaving unbalanced input untouched (no crash).
+    """
+
+    def test_quoted_spaced_image_and_mountpoint_stripped(self):
+        # Tokens as produced by shlex.split(cmdline, posix=False) on Windows:
+        # the spaced image path and mountpoint keep their surrounding quotes.
+        from amifuse.platform import _parse_mount_tokens
+
+        tokens = [
+            "pythonw", "-m", "amifuse", "mount",
+            "--mountpoint", "I:",
+            "--write", "--daemon",
+            '"U:\\thomas\\Test Fixtures\\hd0-ericA3000.hdf"',
+        ]
+        image, mountpoint = _parse_mount_tokens(tokens)
+        assert image == "U:\\thomas\\Test Fixtures\\hd0-ericA3000.hdf"
+        assert mountpoint == "I:"
+        # No surrounding quotes leaked through.
+        assert not image.startswith('"') and not image.endswith('"')
+
+    def test_quoted_spaced_mountpoint_stripped(self):
+        from amifuse.platform import _parse_mount_tokens
+
+        tokens = [
+            "amifuse", "mount",
+            "--mountpoint", '"/Volumes/My Disk"',
+            "/path/plain.hdf",
+        ]
+        image, mountpoint = _parse_mount_tokens(tokens)
+        assert mountpoint == "/Volumes/My Disk"
+        assert image == "/path/plain.hdf"
+
+    def test_unbalanced_leading_quote_left_untouched(self):
+        # Only a leading quote (no matching trailing one): must not be stripped
+        # and must not raise.
+        from amifuse.platform import _parse_mount_tokens
+
+        tokens = ["amifuse", "mount", '"U:\\thomas\\weird.hdf']
+        image, mountpoint = _parse_mount_tokens(tokens)
+        assert image == '"U:\\thomas\\weird.hdf'
+        assert mountpoint is None
+
+    def test_unbalanced_trailing_quote_left_untouched(self):
+        from amifuse.platform import _parse_mount_tokens
+
+        tokens = ["amifuse", "mount", 'U:\\thomas\\weird.hdf"']
+        image, mountpoint = _parse_mount_tokens(tokens)
+        assert image == 'U:\\thomas\\weird.hdf"'
+
+    def test_unquoted_image_unchanged(self):
+        # Unix posix=True path already strips quotes: tokens have none, so the
+        # strip is a harmless no-op.
+        from amifuse.platform import _parse_mount_tokens
+
+        tokens = [
+            "python", "-m", "amifuse", "mount",
+            "--mountpoint", "/mnt/amiga",
+            "/home/user/disk.hdf",
+        ]
+        image, mountpoint = _parse_mount_tokens(tokens)
+        assert image == "/home/user/disk.hdf"
+        assert mountpoint == "/mnt/amiga"
+
+    def test_quoted_spaced_unc_image_stripped(self):
+        # UNC path with a space: a single surrounding quote pair is stripped
+        # while the internal backslashes (including the leading \\) survive.
+        from amifuse.platform import _parse_mount_tokens
+
+        tokens = [
+            "amifuse", "mount",
+            '"\\\\192.168.3.3\\share\\my disk.hdf"',
+        ]
+        image, mountpoint = _parse_mount_tokens(tokens)
+        assert image == "\\\\192.168.3.3\\share\\my disk.hdf"
+        assert mountpoint is None
+        # No surrounding quotes leaked; the leading UNC \\ is intact.
+        assert not image.startswith('"') and not image.endswith('"')
+        assert image.startswith("\\\\")
+
+    def test_lone_quote_token_unchanged(self):
+        # A token of exactly one double-quote (len 1) exercises the
+        # len(value) >= 2 guard: it must be returned unchanged, not stripped.
+        from amifuse.platform import _parse_mount_tokens
+
+        tokens = ["amifuse", "mount", '"']
+        image, mountpoint = _parse_mount_tokens(tokens)
+        assert image == '"'
+        assert mountpoint is None
+
+    def test_quoted_spaced_image_and_mountpoint_both_stripped(self):
+        # Both image and mountpoint quoted-and-spaced in a single call.
+        from amifuse.platform import _parse_mount_tokens
+
+        tokens = [
+            "amifuse", "mount",
+            "--mountpoint", '"/Volumes/My Disk"',
+            '"/path/My Disk.hdf"',
+        ]
+        image, mountpoint = _parse_mount_tokens(tokens)
+        assert image == "/path/My Disk.hdf"
+        assert mountpoint == "/Volumes/My Disk"

--- a/tests/unit/test_platform.py
+++ b/tests/unit/test_platform.py
@@ -20,6 +20,43 @@ import pytest
 
 
 # ---------------------------------------------------------------------------
+# Helpers for mocking the Windows GetLogicalDrives bitmask deterministically.
+#
+# The drive-letter probe now uses ctypes.windll.kernel32.GetLogicalDrives()
+# instead of os.path.exists(). These helpers install a fake windll so the
+# Windows drive-letter tests never depend on the real machine's drive state.
+# ---------------------------------------------------------------------------
+
+
+def _mask_for(letters):
+    """Build a GetLogicalDrives-style bitmask for the given letters.
+
+    Bit 0 = A:, bit 1 = B:, ... bit 25 = Z:.
+    """
+    mask = 0
+    for ch in letters:
+        mask |= 1 << (ord(ch.upper()) - ord("A"))
+    return mask
+
+
+def _install_fake_get_logical_drives(monkeypatch, mask, calls=None):
+    """Patch ctypes.windll.kernel32.GetLogicalDrives to return a fixed mask.
+
+    Works cross-platform: on non-Windows, ctypes has no ``windll`` attribute,
+    so we add it with raising=False. When ``calls`` is provided, each call
+    appends to it, letting a test assert the API was (or was not) invoked.
+    """
+    def get_logical_drives():
+        if calls is not None:
+            calls.append(True)
+        return mask
+
+    kernel32 = types.SimpleNamespace(GetLogicalDrives=get_logical_drives)
+    fake_windll = types.SimpleNamespace(kernel32=kernel32)
+    monkeypatch.setattr("ctypes.windll", fake_windll, raising=False)
+
+
+# ---------------------------------------------------------------------------
 # A. get_default_mountpoint() -- 3 tests
 # ---------------------------------------------------------------------------
 
@@ -44,18 +81,12 @@ class TestGetDefaultMountpoint:
         assert result is None
 
     def test_default_mountpoint_windows(self, monkeypatch):
-        """On Windows, returns first available drive letter as Path.
+        """On Windows, returns first unallocated drive letter as Path.
 
-        Mocks os.path.exists at the module level to simulate D: being in use
-        and E: being available.
+        Mocks GetLogicalDrives so C: and D: are allocated and E: is free.
         """
         monkeypatch.setattr("sys.platform", "win32")
-
-        def fake_exists(path):
-            # D: is taken, E: is free
-            return path == "D:"
-
-        monkeypatch.setattr("amifuse.platform.os.path.exists", fake_exists)
+        _install_fake_get_logical_drives(monkeypatch, _mask_for("CD"))
         from amifuse.platform import get_default_mountpoint
 
         result = get_default_mountpoint("TestVol")
@@ -550,29 +581,23 @@ class TestValidateMountpoint:
     """
 
     def test_validate_drive_letter_available(self, monkeypatch):
-        r"""On Windows, D: with D:\ not existing returns None (available)."""
+        """On Windows, D: unallocated returns None (available)."""
         monkeypatch.setattr("sys.platform", "win32")
-        monkeypatch.setattr(
-            "amifuse.platform.os.path.exists",
-            lambda path: False,
-        )
+        _install_fake_get_logical_drives(monkeypatch, _mask_for("C"))
         from amifuse.platform import validate_mountpoint
 
         result = validate_mountpoint(Path("D:"))
         assert result is None
 
     def test_validate_drive_letter_in_use(self, monkeypatch):
-        r"""On Windows, D: with D:\ existing returns error string."""
+        """On Windows, an allocated D: returns an 'allocated' error string."""
         monkeypatch.setattr("sys.platform", "win32")
-        monkeypatch.setattr(
-            "amifuse.platform.os.path.exists",
-            lambda path: path == "D:\\",
-        )
+        _install_fake_get_logical_drives(monkeypatch, _mask_for("CD"))
         from amifuse.platform import validate_mountpoint
 
         result = validate_mountpoint(Path("D:"))
         assert result is not None
-        assert "already in use" in result
+        assert "already allocated" in result
 
     def test_validate_unix_mountpoint_available(self, monkeypatch):
         """On Linux, path that doesn't exist returns None (available)."""
@@ -685,12 +710,10 @@ class TestWindowsMountpointEdgeCases:
     """
 
     def test_default_mountpoint_windows_all_taken(self, monkeypatch):
-        """On Windows, all D-Z drive letters taken returns None."""
+        """On Windows, all A-Z drive letters allocated returns None."""
         monkeypatch.setattr("sys.platform", "win32")
-        # All drive letters exist (are in use)
-        monkeypatch.setattr(
-            "amifuse.platform.os.path.exists",
-            lambda path: True,
+        _install_fake_get_logical_drives(
+            monkeypatch, _mask_for("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
         )
         from amifuse.platform import get_default_mountpoint
 
@@ -698,29 +721,129 @@ class TestWindowsMountpointEdgeCases:
         assert result is None
 
     def test_default_mountpoint_windows_first_available(self, monkeypatch):
-        """On Windows, D-F taken and G free returns Path('G:')."""
+        """On Windows, C-F allocated and G free returns Path('G:')."""
         monkeypatch.setattr("sys.platform", "win32")
-        taken = {"D:", "E:", "F:"}
-        monkeypatch.setattr(
-            "amifuse.platform.os.path.exists",
-            lambda path: path in taken,
-        )
+        _install_fake_get_logical_drives(monkeypatch, _mask_for("CDEF"))
         from amifuse.platform import get_default_mountpoint
 
         result = get_default_mountpoint("TestVol")
         assert result == Path("G:")
 
     def test_default_mountpoint_windows_d_available(self, monkeypatch):
-        """On Windows, all drives free returns Path('D:') (first checked)."""
+        """On Windows, only C allocated returns Path('D:') (first checked)."""
         monkeypatch.setattr("sys.platform", "win32")
-        monkeypatch.setattr(
-            "amifuse.platform.os.path.exists",
-            lambda path: False,
-        )
+        _install_fake_get_logical_drives(monkeypatch, _mask_for("C"))
         from amifuse.platform import get_default_mountpoint
 
         result = get_default_mountpoint("TestVol")
         assert result == Path("D:")
+
+
+# ---------------------------------------------------------------------------
+# I2. _windows_allocated_drive_letters() and the GetLogicalDrives rewire
+# ---------------------------------------------------------------------------
+
+
+class TestWindowsAllocatedDriveLetters:
+    """Tests for the GetLogicalDrives-based drive-letter probe (Task 1).
+
+    Covers the helper's decode contract, the empirical oracle from the
+    investigation, the conservative zero/failure fallback, and the
+    cross-platform guard that keeps windll untouched off Windows.
+    """
+
+    def test_decode_returns_bare_uppercase_letters(self, monkeypatch):
+        """Helper returns bare uppercase single letters (e.g. {'C', 'D'})."""
+        monkeypatch.setattr("sys.platform", "win32")
+        _install_fake_get_logical_drives(monkeypatch, _mask_for("CD"))
+        from amifuse.platform import _windows_allocated_drive_letters
+
+        assert _windows_allocated_drive_letters() == {"C", "D"}
+
+    def test_empirical_oracle_selects_I(self, monkeypatch):
+        """Assigned C,D,E,F,G,H,S-Z -> get_default_mountpoint returns I:.
+
+        This is the empirical oracle captured on the investigation machine:
+        D-H are empty removable card-reader slots (allocated but mediumless)
+        and S-Z are network drives. The old os.path.exists probe false-selected
+        the empty D:; the bitmask probe skips all allocated letters and lands on
+        the first genuinely-free letter, I:.
+        """
+        monkeypatch.setattr("sys.platform", "win32")
+        _install_fake_get_logical_drives(
+            monkeypatch, _mask_for("CDEFGHSTUVWXYZ")
+        )
+        from amifuse.platform import get_default_mountpoint
+
+        assert get_default_mountpoint("TestVol") == Path("I:")
+
+    def test_zero_return_does_not_resurrect_D_bug(self, monkeypatch):
+        """GetLogicalDrives() -> 0 (API failure) must not re-select D:.
+
+        A naive decode of 0 yields an empty set, making every letter look free
+        and regressing to the empty D:. The conservative fallback treats every
+        letter as allocated, so auto-selection declines rather than picking D:.
+        """
+        monkeypatch.setattr("sys.platform", "win32")
+        _install_fake_get_logical_drives(monkeypatch, 0)
+        from amifuse.platform import get_default_mountpoint
+
+        result = get_default_mountpoint("TestVol")
+        assert result != Path("D:")
+        assert result is None
+
+    def test_zero_return_all_letters_allocated(self, monkeypatch):
+        """On a 0 return the helper reports every letter as allocated."""
+        monkeypatch.setattr("sys.platform", "win32")
+        _install_fake_get_logical_drives(monkeypatch, 0)
+        from amifuse.platform import _windows_allocated_drive_letters
+
+        assert _windows_allocated_drive_letters() == set(
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        )
+
+    def test_exception_falls_back_to_all_allocated(self, monkeypatch):
+        """If the windll call raises, fall back to treating all as allocated."""
+        monkeypatch.setattr("sys.platform", "win32")
+
+        class _ExplodingWinDLL:
+            def __getattr__(self, name):
+                raise OSError("simulated GetLogicalDrives failure")
+
+        monkeypatch.setattr("ctypes.windll", _ExplodingWinDLL(), raising=False)
+        from amifuse.platform import _windows_allocated_drive_letters
+
+        assert _windows_allocated_drive_letters() == set(
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        )
+
+    def test_guard_no_windll_on_non_windows(self, monkeypatch):
+        """On non-Windows the helper returns set() without touching windll.
+
+        The GetLogicalDrives sentinel raises if any attribute is accessed. A
+        broken guard would enter the try-body, hit the sentinel (caught by the
+        except -> all-allocated set), and the empty-set assertion would fail.
+        """
+        monkeypatch.setattr("sys.platform", "linux")
+
+        class _ExplodingWinDLL:
+            def __getattr__(self, name):
+                raise AssertionError(f"windll.{name} accessed on non-Windows")
+
+        monkeypatch.setattr("ctypes.windll", _ExplodingWinDLL(), raising=False)
+        from amifuse.platform import _windows_allocated_drive_letters
+
+        assert _windows_allocated_drive_letters() == set()
+
+    def test_validate_lowercase_letter_normalized(self, monkeypatch):
+        """An explicit lowercase 'd:' is still caught when D: is allocated."""
+        monkeypatch.setattr("sys.platform", "win32")
+        _install_fake_get_logical_drives(monkeypatch, _mask_for("CD"))
+        from amifuse.platform import validate_mountpoint
+
+        result = validate_mountpoint(Path("d:"))
+        assert result is not None
+        assert "already allocated" in result
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_platform.py
+++ b/tests/unit/test_platform.py
@@ -1024,3 +1024,24 @@ class TestWmicCreationFlags:
 
         _find_amifuse_mounts_windows()
         assert captured_kwargs.get("creationflags") == _CREATE_NO_WINDOW
+
+
+# ---------------------------------------------------------------------------
+# TestNotifyShellDriveChange
+# ---------------------------------------------------------------------------
+
+
+class TestNotifyShellDriveChange:
+    """Verify notify_shell_drive_change function."""
+
+    def test_function_exists(self):
+        from amifuse.platform import notify_shell_drive_change
+        assert callable(notify_shell_drive_change)
+
+    def test_noop_on_non_windows(self, monkeypatch):
+        """Does not crash on non-Windows platforms."""
+        import amifuse.platform as plat
+        monkeypatch.setattr(sys, "platform", "linux")
+        # Should return without error
+        plat.notify_shell_drive_change("D:", added=True)
+        plat.notify_shell_drive_change("D:", added=False)

--- a/tests/unit/test_rdb_inspect.py
+++ b/tests/unit/test_rdb_inspect.py
@@ -5,6 +5,7 @@ top-level ``amitools`` imports that fail without it.  The tested functions
 themselves are pure Python and do not call into amitools.
 """
 import struct
+import types
 
 import pytest
 
@@ -408,3 +409,312 @@ def test_offset_block_device_write_boundary(amitools_mock):
 
     with pytest.raises(OSError, match="Write beyond partition"):
         obd.write_block(10, b"\x00" * 512, 1)
+
+
+# ---------------------------------------------------------------------------
+# E. list_partitions() -- RDB partition enumeration (5 tests)
+#
+# list_partitions() calls into open_rdisk / rdisk.parts / DosType, so these
+# tests mock those at the module level (per the suite's "patch where names are
+# looked up" convention) rather than driving real amitools block I/O. The
+# amitools_mock fixture stubs DosType without num_to_tag_str, so each test
+# patches in a faithful stand-in.
+# ---------------------------------------------------------------------------
+
+# FFS / DOS1 -- the dostype of every partition in the hd0-ericA3000.hdf fixture.
+_FFS_DOS1 = 0x444F5301
+
+
+def _fake_num_to_tag_str(dos_type):
+    """Faithful stand-in for amitools DosType.num_to_tag_str.
+
+    Mirrors the real algorithm: three ASCII bytes then the low byte rendered as
+    a digit when < 32 (e.g. 0x444F5301 -> "DOS1").
+    """
+    tag = bytes(
+        ((dos_type >> 24) & 0xFF, (dos_type >> 16) & 0xFF, (dos_type >> 8) & 0xFF)
+    ).decode("latin-1")
+    last = dos_type & 0xFF
+    return tag + (chr(last + 48) if last < 32 else chr(last))
+
+
+class _FakeDriveName:
+    """Stands in for the amitools BSTR drv_name; str() yields the drive name."""
+
+    def __init__(self, name):
+        self._name = name
+
+    def __str__(self):
+        return self._name
+
+
+class _FakePartition:
+    """Minimal amitools Partition.
+
+    Exposes the three fields list_partitions reads: ``num`` (per-RDB index),
+    ``get_drive_name()`` (BSTR), and ``part_blk.dos_env.dos_type``.
+    """
+
+    def __init__(self, num, name, dos_type):
+        self.num = num
+        self._name = name
+        self.part_blk = types.SimpleNamespace(
+            dos_env=types.SimpleNamespace(dos_type=dos_type)
+        )
+
+    def get_drive_name(self):
+        return _FakeDriveName(self._name)
+
+
+class _FakeRDisk:
+    """Records close() so tests can assert the rdisk handle is released."""
+
+    def __init__(self, parts):
+        self.parts = parts
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+
+class _FakeBlkDev:
+    """Records close() so tests can assert the block device is released."""
+
+    def __init__(self):
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+
+def _patch_dostype(monkeypatch, rdb_inspect):
+    monkeypatch.setattr(
+        rdb_inspect.DosType, "num_to_tag_str", _fake_num_to_tag_str, raising=False
+    )
+
+
+def test_list_partitions_plain_rdb(amitools_mock, monkeypatch, tmp_path):
+    """Plain RDB: enumerate all 3 fixture partitions, keyed by name, close both.
+
+    Reproduces the hd0-ericA3000.hdf layout (WB_1.3, WB_2.x, Work -- all
+    FFS/DOS1). No MBR -> the plain-RDB path opens once with no
+    mbr_partition_index and closes both the rdisk and block device.
+    """
+    import amifuse.rdb_inspect as rdb_inspect
+
+    _patch_dostype(monkeypatch, rdb_inspect)
+    monkeypatch.setattr(rdb_inspect, "detect_mbr", lambda image: None)
+
+    parts = [
+        _FakePartition(0, "WB_1.3", _FFS_DOS1),
+        _FakePartition(1, "WB_2.x", _FFS_DOS1),
+        _FakePartition(2, "Work", _FFS_DOS1),
+    ]
+    rdisk = _FakeRDisk(parts)
+    blkdev = _FakeBlkDev()
+    calls = []
+
+    def fake_open_rdisk(image, block_size=None, mbr_partition_index=None):
+        calls.append((block_size, mbr_partition_index))
+        return blkdev, rdisk, None
+
+    monkeypatch.setattr(rdb_inspect, "open_rdisk", fake_open_rdisk)
+
+    result = rdb_inspect.list_partitions(tmp_path / "hd0-ericA3000.hdf")
+
+    assert result.fallback_reason is None
+    assert [p.name for p in result.partitions] == ["WB_1.3", "WB_2.x", "Work"]
+    assert [p.index for p in result.partitions] == [0, 1, 2]
+    assert all(p.dostype == _FFS_DOS1 for p in result.partitions)
+    assert all(p.dostype_str == "DOS1" for p in result.partitions)
+    # Plain-RDB path: opened exactly once, with no MBR partition index.
+    assert calls == [(None, None)]
+    # Both handles released (RDisk.close() alone would leak the image handle).
+    assert rdisk.closed is True
+    assert blkdev.closed is True
+
+
+def test_list_partitions_single_partition_rdb(amitools_mock, monkeypatch, tmp_path):
+    """Single-partition RDB (N=1): one PartInfo, no fallback, both handles closed."""
+    import amifuse.rdb_inspect as rdb_inspect
+
+    _patch_dostype(monkeypatch, rdb_inspect)
+    monkeypatch.setattr(rdb_inspect, "detect_mbr", lambda image: None)
+
+    rdisk = _FakeRDisk([_FakePartition(0, "DH0", _FFS_DOS1)])
+    blkdev = _FakeBlkDev()
+    monkeypatch.setattr(
+        rdb_inspect,
+        "open_rdisk",
+        lambda image, block_size=None, mbr_partition_index=None: (blkdev, rdisk, None),
+    )
+
+    result = rdb_inspect.list_partitions(tmp_path / "one.hdf")
+
+    assert result.fallback_reason is None
+    assert len(result.partitions) == 1
+    assert result.partitions[0].name == "DH0"
+    assert result.partitions[0].dostype_str == "DOS1"
+    assert rdisk.closed is True
+    assert blkdev.closed is True
+
+
+def test_list_partitions_single_amiga_mbr_uses_plain_path(
+    amitools_mock, monkeypatch, tmp_path
+):
+    """A single 0x76 MBR partition takes the plain-RDB path (no mbr index).
+
+    With len(amiga_parts) <= 1 there is nothing to fan out across, so
+    open_rdisk is called once with mbr_partition_index=None (it auto-selects the
+    only 0x76 RDB).
+    """
+    import amifuse.rdb_inspect as rdb_inspect
+    from amifuse.rdb_inspect import MBRInfo, MBRPartition, MBR_TYPE_AMIGA_RDB
+
+    _patch_dostype(monkeypatch, rdb_inspect)
+    mbr = MBRInfo(
+        partitions=[
+            MBRPartition(
+                index=0,
+                bootable=False,
+                partition_type=MBR_TYPE_AMIGA_RDB,
+                start_lba=1,
+                num_sectors=1000,
+            )
+        ],
+        has_amiga_partitions=True,
+    )
+    monkeypatch.setattr(rdb_inspect, "detect_mbr", lambda image: mbr)
+
+    rdisk = _FakeRDisk([_FakePartition(0, "DH0", _FFS_DOS1)])
+    blkdev = _FakeBlkDev()
+    calls = []
+
+    def fake_open_rdisk(image, block_size=None, mbr_partition_index=None):
+        calls.append((block_size, mbr_partition_index))
+        return blkdev, rdisk, None
+
+    monkeypatch.setattr(rdb_inspect, "open_rdisk", fake_open_rdisk)
+
+    result = rdb_inspect.list_partitions(tmp_path / "emu68.img")
+
+    assert result.fallback_reason is None
+    assert [p.name for p in result.partitions] == ["DH0"]
+    assert calls == [(None, None)]  # plain path, no per-RDB index
+    assert rdisk.closed is True
+    assert blkdev.closed is True
+
+
+def test_list_partitions_multi_rdb_distinct_names(
+    amitools_mock, monkeypatch, tmp_path
+):
+    """Multi-RDB with distinct names: enumerate across ALL RDBs, no fallback.
+
+    Two 0x76 RDBs (DH0/DH1 in the first, DH2 in the second) enumerate to three
+    PartInfos keyed by name. Note ``.num`` collides across RDBs (0,1 then 0) --
+    that is expected and harmless because the fan-out keys on name, not index.
+    Every per-RDB handle is closed inside the loop.
+    """
+    import amifuse.rdb_inspect as rdb_inspect
+    from amifuse.rdb_inspect import MBRInfo, MBRPartition, MBR_TYPE_AMIGA_RDB
+
+    _patch_dostype(monkeypatch, rdb_inspect)
+    mbr = MBRInfo(
+        partitions=[
+            MBRPartition(
+                index=0,
+                bootable=False,
+                partition_type=MBR_TYPE_AMIGA_RDB,
+                start_lba=1,
+                num_sectors=1000,
+            ),
+            MBRPartition(
+                index=1,
+                bootable=False,
+                partition_type=MBR_TYPE_AMIGA_RDB,
+                start_lba=2000,
+                num_sectors=1000,
+            ),
+        ],
+        has_amiga_partitions=True,
+    )
+    monkeypatch.setattr(rdb_inspect, "detect_mbr", lambda image: mbr)
+
+    rdb0 = _FakeRDisk(
+        [_FakePartition(0, "DH0", _FFS_DOS1), _FakePartition(1, "DH1", _FFS_DOS1)]
+    )
+    rdb1 = _FakeRDisk([_FakePartition(0, "DH2", _FFS_DOS1)])
+    blk0, blk1 = _FakeBlkDev(), _FakeBlkDev()
+    rets = {0: (blk0, rdb0, None), 1: (blk1, rdb1, None)}
+
+    def fake_open_rdisk(image, block_size=None, mbr_partition_index=None):
+        return rets[mbr_partition_index]
+
+    monkeypatch.setattr(rdb_inspect, "open_rdisk", fake_open_rdisk)
+
+    result = rdb_inspect.list_partitions(tmp_path / "multi.hdf")
+
+    assert result.fallback_reason is None
+    assert [p.name for p in result.partitions] == ["DH0", "DH1", "DH2"]
+    assert [p.index for p in result.partitions] == [0, 1, 0]  # .num collides; name keys
+    assert rdb0.closed and blk0.closed
+    assert rdb1.closed and blk1.closed
+
+
+def test_list_partitions_duplicate_name_fallback(amitools_mock, monkeypatch, tmp_path):
+    """Name colliding across RDBs -> first-partition-only fallback + reason.
+
+    Two 0x76 RDBs both hold a ``DH0``. Because ``--partition <name>`` cannot be
+    routed unambiguously, list_partitions falls back to index 0 of the FIRST RDB
+    and surfaces a reason string for the caller's summary dialog. Every opened
+    handle (including the RDB that triggered the fallback) is closed.
+    """
+    import amifuse.rdb_inspect as rdb_inspect
+    from amifuse.rdb_inspect import MBRInfo, MBRPartition, MBR_TYPE_AMIGA_RDB
+
+    _patch_dostype(monkeypatch, rdb_inspect)
+    mbr = MBRInfo(
+        partitions=[
+            MBRPartition(
+                index=0,
+                bootable=False,
+                partition_type=MBR_TYPE_AMIGA_RDB,
+                start_lba=1,
+                num_sectors=1000,
+            ),
+            MBRPartition(
+                index=1,
+                bootable=False,
+                partition_type=MBR_TYPE_AMIGA_RDB,
+                start_lba=2000,
+                num_sectors=1000,
+            ),
+        ],
+        has_amiga_partitions=True,
+    )
+    monkeypatch.setattr(rdb_inspect, "detect_mbr", lambda image: mbr)
+
+    rdb0 = _FakeRDisk(
+        [_FakePartition(0, "DH0", _FFS_DOS1), _FakePartition(1, "DH1", _FFS_DOS1)]
+    )
+    rdb1 = _FakeRDisk([_FakePartition(0, "DH0", _FFS_DOS1)])  # collides with rdb0
+    blk0, blk1 = _FakeBlkDev(), _FakeBlkDev()
+    rets = {0: (blk0, rdb0, None), 1: (blk1, rdb1, None)}
+
+    def fake_open_rdisk(image, block_size=None, mbr_partition_index=None):
+        return rets[mbr_partition_index]
+
+    monkeypatch.setattr(rdb_inspect, "open_rdisk", fake_open_rdisk)
+
+    result = rdb_inspect.list_partitions(tmp_path / "collide.hdf")
+
+    assert result.fallback_reason is not None
+    assert "colliding partition names" in result.fallback_reason
+    assert "mounted first only" in result.fallback_reason
+    # Fell back to index 0 of the FIRST RDB, exactly one unit.
+    assert len(result.partitions) == 1
+    assert result.partitions[0].name == "DH0"
+    assert result.partitions[0].index == 0
+    # No leaked handles, including the collision-triggering RDB.
+    assert rdb0.closed and blk0.closed
+    assert rdb1.closed and blk1.closed

--- a/tests/unit/test_scsi_device.py
+++ b/tests/unit/test_scsi_device.py
@@ -5,6 +5,10 @@ import struct
 import pytest
 from unittest.mock import MagicMock, patch
 
+from amitools.vamos.machine.mock.mem import MockMemory
+from amitools.vamos.libstructs.exec_ import IORequestStruct
+from amifuse.scsi_device import SCSICmdStruct
+
 
 @pytest.fixture
 def mock_backend():
@@ -100,3 +104,124 @@ class TestReadCapacityOverflow:
         source = inspect.getsource(ScsiDevice.BeginIO)
         assert "0xFFFFFFFF" in source
         assert "last_lba > 0xFFFFFFFF" in source
+
+
+class TestScsiWriteShortBuffer:
+    """Tests for WRITE(10) short-buffer validation."""
+
+    # Memory layout constants
+    IOR_ADDR = 0x1000
+    SCSI_CMD_ADDR = 0x2000
+    CDB_ADDR = 0x3000
+    DATA_ADDR = 0x4000
+    SENSE_ADDR = 0x5000
+
+    def _setup_write10(self, mem, scsi_dev, *, xfer_blocks, data_len,
+                       lba=0, sense_len=18):
+        """Set up memory for a WRITE(10) HD_SCSICMD call and invoke BeginIO.
+
+        Returns (ior, scsi_struct) for assertions.
+        """
+        # Build IORequestStruct at IOR_ADDR
+        ior = IORequestStruct(mem, self.IOR_ADDR)
+        ior.command.val = 28  # HD_SCSICMD
+        ior.data.val = self.SCSI_CMD_ADDR  # buf_ptr -> SCSICmdStruct
+
+        # Build SCSICmdStruct at SCSI_CMD_ADDR
+        scsi_struct = SCSICmdStruct(mem, self.SCSI_CMD_ADDR)
+        scsi_struct.scsi_Data.val = self.DATA_ADDR
+        scsi_struct.scsi_Length.val = data_len
+        scsi_struct.scsi_Command.val = self.CDB_ADDR
+        scsi_struct.scsi_CmdLength.val = 10
+        scsi_struct.scsi_Flags.val = 0
+        scsi_struct.scsi_Status.val = 0
+        scsi_struct.scsi_SenseData.val = self.SENSE_ADDR if sense_len > 0 else 0
+        scsi_struct.scsi_SenseLength.val = sense_len
+        scsi_struct.scsi_SenseActual.val = 0
+        scsi_struct.scsi_Actual.val = 0
+
+        # Build WRITE(10) CDB at CDB_ADDR
+        mem.w8(self.CDB_ADDR, 0x2A)  # opcode
+        mem.w32(self.CDB_ADDR + 2, lba)  # LBA
+        mem.w16(self.CDB_ADDR + 7, xfer_blocks)  # transfer length
+
+        # Fill data buffer with a recognizable pattern
+        for i in range(min(data_len, 1024)):
+            mem.w8(self.DATA_ADDR + i, (i & 0xFF))
+
+        # Create minimal ctx
+        ctx = MagicMock()
+        ctx.mem = mem
+
+        scsi_dev.BeginIO(ctx, self.IOR_ADDR)
+
+        # Re-read structs after call (values updated in memory)
+        ior = IORequestStruct(mem, self.IOR_ADDR)
+        scsi_struct = SCSICmdStruct(mem, self.SCSI_CMD_ADDR)
+        return ior, scsi_struct
+
+    def test_write10_short_buffer_check_condition(self, mock_backend):
+        """WRITE(10) with buffer shorter than xfer_blocks should return CHECK CONDITION."""
+        from amifuse.scsi_device import ScsiDevice
+        dev = ScsiDevice(mock_backend, debug=False)
+        mem = MockMemory(size_kib=64)
+
+        # Request 2 blocks (1024 bytes) but only provide 512 bytes
+        _, scsi_struct = self._setup_write10(
+            mem, dev, xfer_blocks=2, data_len=512
+        )
+
+        assert scsi_struct.scsi_Status.val == 2  # CHECK CONDITION
+        mock_backend.write_blocks.assert_not_called()
+
+    def test_write10_short_buffer_sense_data(self, mock_backend):
+        """WRITE(10) short buffer should write ILLEGAL_REQUEST sense data."""
+        from amifuse.scsi_device import ScsiDevice
+        dev = ScsiDevice(mock_backend, debug=False)
+        mem = MockMemory(size_kib=64)
+
+        _, scsi_struct = self._setup_write10(
+            mem, dev, xfer_blocks=2, data_len=512, sense_len=18
+        )
+
+        assert scsi_struct.scsi_Status.val == 2
+        assert scsi_struct.scsi_SenseActual.val == 18
+
+        # Verify sense data bytes
+        sense = mem.r_block(self.SENSE_ADDR, 18)
+        assert sense[0] == 0x70  # current errors, fixed format
+        assert sense[2] == 0x05  # ILLEGAL_REQUEST
+        assert sense[7] == 0x0A  # additional sense length
+        assert sense[12] == 0x24  # ASC: INVALID FIELD IN CDB
+        assert sense[13] == 0x00  # ASCQ
+
+    def test_write10_adequate_buffer_succeeds(self, mock_backend):
+        """WRITE(10) with adequate buffer should succeed and call write_blocks."""
+        from amifuse.scsi_device import ScsiDevice
+        dev = ScsiDevice(mock_backend, debug=False)
+        mem = MockMemory(size_kib=64)
+
+        # Request 2 blocks (1024 bytes) with 1024 bytes available
+        _, scsi_struct = self._setup_write10(
+            mem, dev, xfer_blocks=2, data_len=1024
+        )
+
+        assert scsi_struct.scsi_Status.val == 0  # GOOD
+        mock_backend.write_blocks.assert_called_once()
+        args = mock_backend.write_blocks.call_args
+        assert args[0][0] == 0  # lba
+        assert len(args[0][1]) == 1024  # full data
+        assert args[0][2] == 2  # xfer_blocks
+
+    def test_write10_zero_blocks_succeeds(self, mock_backend):
+        """WRITE(10) with xfer_blocks=0 should succeed without writing."""
+        from amifuse.scsi_device import ScsiDevice
+        dev = ScsiDevice(mock_backend, debug=False)
+        mem = MockMemory(size_kib=64)
+
+        _, scsi_struct = self._setup_write10(
+            mem, dev, xfer_blocks=0, data_len=0
+        )
+
+        assert scsi_struct.scsi_Status.val == 0  # GOOD
+        mock_backend.write_blocks.assert_not_called()

--- a/tests/unit/test_startup_runner.py
+++ b/tests/unit/test_startup_runner.py
@@ -212,3 +212,21 @@ class TestStdpktRingBuffer:
         assert launcher._stdpkt_ring[0] is old_mem
         assert launcher._stdpkt_sizes[0] == 32
         launcher.alloc.free_memory.assert_not_called()
+
+
+class TestFinalizeBurstBlocked:
+    """Verify _finalize_burst_blocked helper exists and is used."""
+
+    def test_method_exists(self):
+        """HandlerLauncher has _finalize_burst_blocked method."""
+        from amifuse.startup_runner import HandlerLauncher
+        assert hasattr(HandlerLauncher, '_finalize_burst_blocked')
+
+    def test_run_burst_uses_helper(self):
+        """run_burst delegates blocked-state handling to _finalize_burst_blocked."""
+        import inspect
+        from amifuse.startup_runner import HandlerLauncher
+        source = inspect.getsource(HandlerLauncher.run_burst)
+        assert "_finalize_burst_blocked" in source
+        # Should appear at least twice (error branch + done branch)
+        assert source.count("_finalize_burst_blocked") >= 2

--- a/tests/unit/test_status.py
+++ b/tests/unit/test_status.py
@@ -330,6 +330,8 @@ class TestFindAmifuseMountsDispatch:
 # ---------------------------------------------------------------------------
 
 
+# requests fuse_mock so importing amifuse.fuse_fs here cannot pin FUSE=None for later tests
+@pytest.mark.usefixtures("fuse_mock")
 class TestCmdStatus:
     """Test the cmd_status handler in fuse_fs."""
 
@@ -483,6 +485,8 @@ class TestFindMountOwnerPidsRefactored:
 # ---------------------------------------------------------------------------
 
 
+# requests fuse_mock so importing amifuse.fuse_fs here cannot pin FUSE=None for later tests
+@pytest.mark.usefixtures("fuse_mock")
 class TestTruncateLeft:
     """Tests for _truncate_left helper."""
 
@@ -525,6 +529,8 @@ class TestTruncateLeft:
 # ---------------------------------------------------------------------------
 
 
+# requests fuse_mock so importing amifuse.fuse_fs here cannot pin FUSE=None for later tests
+@pytest.mark.usefixtures("fuse_mock")
 class TestEnrichNullMountpoints:
     """Tests for _enrich_null_mountpoints and platform-specific helpers."""
 

--- a/tests/unit/test_windows_shell.py
+++ b/tests/unit/test_windows_shell.py
@@ -398,3 +398,52 @@ class TestRegisterCreatesLaunchVbs:
         assert launch_vbs.exists()
         content = launch_vbs.read_text(encoding="utf-8")
         assert "WScript" in content or "CreateObject" in content
+
+
+class TestOpenVerb:
+    """Verify open verb registration for double-click mount."""
+
+    def test_register_sets_default_verb(self, fake_registry, tmp_path, monkeypatch):
+        """register() sets shell\\(Default) to 'open'."""
+        reg, _ = fake_registry
+        monkeypatch.setattr("amifuse.windows_shell.ICON_DIR", tmp_path / "icons")
+
+        from amifuse.windows_shell import register
+        register()
+
+        # shell key's default value should be "open"
+        val = reg.get_value(
+            reg.HKEY_CURRENT_USER,
+            r"Software\Classes\AmiFUSE.DiskImage\shell",
+            "",
+        )
+        assert val == "open"
+
+    def test_register_creates_open_verb(self, fake_registry, tmp_path, monkeypatch):
+        """register() creates open verb under ProgID."""
+        reg, _ = fake_registry
+        monkeypatch.setattr("amifuse.windows_shell.ICON_DIR", tmp_path / "icons")
+
+        from amifuse.windows_shell import register
+        register()
+
+        base = r"Software\Classes\AmiFUSE.DiskImage"
+        assert reg.key_exists(reg.HKEY_CURRENT_USER, rf"{base}\shell\open")
+        assert reg.key_exists(reg.HKEY_CURRENT_USER, rf"{base}\shell\open\command")
+
+    def test_open_verb_command_uses_open_subcommand(self, fake_registry, tmp_path, monkeypatch):
+        """open verb command line invokes launcher with 'open' subcommand."""
+        reg, _ = fake_registry
+        monkeypatch.setattr("amifuse.windows_shell.ICON_DIR", tmp_path / "icons")
+
+        from amifuse.windows_shell import register
+        register()
+
+        base = r"Software\Classes\AmiFUSE.DiskImage"
+        cmd_val = reg.get_value(
+            reg.HKEY_CURRENT_USER,
+            rf"{base}\shell\open\command",
+            "",
+        )
+        assert cmd_val is not None
+        assert " open " in cmd_val

--- a/tests/unit/test_windows_shell.py
+++ b/tests/unit/test_windows_shell.py
@@ -189,7 +189,7 @@ class TestRegister:
         assert reg.key_exists(reg.HKEY_CURRENT_USER, r"Software\Classes\AmiFUSE.FloppyImage")
 
     def test_register_creates_flat_verb_keys(self, fake_registry, tmp_path, monkeypatch):
-        """mount and mountrw verbs created under ProgID."""
+        """mountro verb created under ProgID."""
         reg, _ = fake_registry
         monkeypatch.setattr("amifuse.windows_shell.ICON_DIR", tmp_path / "icons")
 
@@ -197,10 +197,8 @@ class TestRegister:
         register()
 
         base = r"Software\Classes\AmiFUSE.DiskImage"
-        assert reg.key_exists(reg.HKEY_CURRENT_USER, rf"{base}\shell\mount")
-        assert reg.key_exists(reg.HKEY_CURRENT_USER, rf"{base}\shell\mount\command")
-        assert reg.key_exists(reg.HKEY_CURRENT_USER, rf"{base}\shell\mountrw")
-        assert reg.key_exists(reg.HKEY_CURRENT_USER, rf"{base}\shell\mountrw\command")
+        assert reg.key_exists(reg.HKEY_CURRENT_USER, rf"{base}\shell\mountro")
+        assert reg.key_exists(reg.HKEY_CURRENT_USER, rf"{base}\shell\mountro\command")
 
     def test_register_creates_open_with_progids(self, fake_registry, tmp_path, monkeypatch):
         """OpenWithProgids entry created for each extension."""

--- a/tools/install-windows.ps1
+++ b/tools/install-windows.ps1
@@ -5,9 +5,24 @@
 .DESCRIPTION
     Installs Python, WinFSP, creates a venv, installs AmiFUSE and dependencies,
     then runs amifuse doctor --fix.  Idempotent -- safe to run multiple times.
+.PARAMETER Uninstall
+    Remove AmiFUSE venv, registry keys, and shell extensions.
 #>
 
+param(
+    [switch]$Uninstall
+)
+
 $ErrorActionPreference = "Stop"
+
+# Ensure script can run even with restricted execution policy
+if ((Get-ExecutionPolicy -Scope Process) -eq 'Restricted') {
+    Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force
+}
+
+# ---------------------------------------------------------------------------
+# Helper functions
+# ---------------------------------------------------------------------------
 
 function Write-Banner {
     Write-Host ""
@@ -27,6 +42,113 @@ function Write-Ok($msg) {
 
 function Write-Err($msg) {
     Write-Host "[!] $msg" -ForegroundColor Red
+}
+
+function Test-IsAdmin {
+    $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+    $principal = [Security.Principal.WindowsPrincipal]$identity
+    return $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
+# ---------------------------------------------------------------------------
+# Admin privilege check
+# ---------------------------------------------------------------------------
+if (-not (Test-IsAdmin)) {
+    Write-Err "This script requires administrator privileges."
+    Write-Host ""
+    Write-Host "Right-click PowerShell and select 'Run as Administrator'," -ForegroundColor White
+    Write-Host "or run: Start-Process powershell -Verb RunAs -ArgumentList '-File', '$PSCommandPath'" -ForegroundColor White
+    exit 1
+}
+
+# ---------------------------------------------------------------------------
+# Uninstall mode
+# ---------------------------------------------------------------------------
+if ($Uninstall) {
+    Write-Banner
+    Write-Host "  Uninstalling AmiFUSE..." -ForegroundColor Yellow
+    Write-Host ""
+
+    $removed = @()
+
+    # 1. Remove venv (run unregister first while amifuse is still available)
+    $venvPath = Join-Path $env:LOCALAPPDATA "amifuse\venv"
+    if (Test-Path $venvPath) {
+        $venvPython = Join-Path $venvPath "Scripts\python.exe"
+        if (Test-Path $venvPython) {
+            Write-Step "Unregistering shell extensions..."
+            try {
+                & $venvPython -m amifuse unregister 2>&1 | Out-Null
+                $removed += "Shell extensions (unregistered)"
+            } catch { }
+        }
+        Write-Step "Removing virtual environment..."
+        Remove-Item -Recurse -Force $venvPath
+        $removed += "Venv: $venvPath"
+    }
+
+    # 2. Remove registry keys (ProgID and file associations)
+    $regKeys = @(
+        "HKCU:\Software\Classes\AmiFUSE.DiskImage",
+        "HKCU:\Software\Classes\AmiFUSE.DiskImage.HDF",
+        "HKCU:\Software\Classes\AmiFUSE.DiskImage.ADF",
+        "HKCU:\Software\Classes\.hdf\OpenWithProgids",
+        "HKCU:\Software\Classes\.adf\OpenWithProgids"
+    )
+    foreach ($key in $regKeys) {
+        if (Test-Path $key) {
+            # For OpenWithProgids, only remove our entries, not the whole key
+            if ($key -match 'OpenWithProgids$') {
+                try {
+                    Remove-ItemProperty -Path $key -Name "AmiFUSE.DiskImage.HDF" -ErrorAction SilentlyContinue
+                    Remove-ItemProperty -Path $key -Name "AmiFUSE.DiskImage.ADF" -ErrorAction SilentlyContinue
+                    Remove-ItemProperty -Path $key -Name "AmiFUSE.DiskImage" -ErrorAction SilentlyContinue
+                    $removed += "Registry: $key (AmiFUSE entries)"
+                } catch { }
+            } else {
+                Remove-Item -Recurse -Force $key -ErrorAction SilentlyContinue
+                $removed += "Registry: $key"
+            }
+        }
+    }
+
+    # 3. Remove scheduled tasks
+    try {
+        $tasks = Get-ScheduledTask -TaskPath "\AmiFUSE\" -ErrorAction SilentlyContinue
+        if ($tasks) {
+            foreach ($task in $tasks) {
+                Unregister-ScheduledTask -TaskName $task.TaskName -TaskPath $task.TaskPath -Confirm:$false
+                $removed += "Scheduled task: $($task.TaskName)"
+            }
+        }
+    } catch { }
+
+    # 4. Remove amifuse app data directory (if empty after venv removal)
+    $appDir = Join-Path $env:LOCALAPPDATA "amifuse"
+    if ((Test-Path $appDir) -and ((Get-ChildItem $appDir -Force | Measure-Object).Count -eq 0)) {
+        Remove-Item -Force $appDir
+        $removed += "App directory: $appDir"
+    }
+
+    # 5. Summary
+    Write-Host ""
+    Write-Host "========================================" -ForegroundColor Cyan
+    Write-Host "  Uninstall Complete" -ForegroundColor Cyan
+    Write-Host "========================================" -ForegroundColor Cyan
+    Write-Host ""
+    if ($removed.Count -gt 0) {
+        Write-Host "  Removed:" -ForegroundColor White
+        foreach ($item in $removed) {
+            Write-Host "    - $item" -ForegroundColor White
+        }
+    } else {
+        Write-Host "  Nothing to remove (AmiFUSE was not installed)." -ForegroundColor White
+    }
+    Write-Host ""
+    Write-Host "  Note: WinFSP was NOT removed (shared dependency)." -ForegroundColor Yellow
+    Write-Host "  To remove WinFSP: winget uninstall WinFsp.WinFsp" -ForegroundColor White
+    Write-Host ""
+    exit 0
 }
 
 # ---------------------------------------------------------------------------
@@ -141,12 +263,14 @@ if ($env:VIRTUAL_ENV) {
     $activateScript = Join-Path $venvPath "Scripts\Activate.ps1"
 
     if (Test-Path $venvPath) {
-        if (Test-Path $activateScript) {
-            Write-Ok "Existing venv found at $venvPath"
-        } else {
-            Write-Step "Venv at $venvPath is broken (missing Activate.ps1). Removing..."
+        $venvPython = Join-Path $venvPath "Scripts\python.exe"
+        $venvPip = Join-Path $venvPath "Scripts\pip.exe"
+        if (-not (Test-Path $activateScript) -or -not (Test-Path $venvPython)) {
+            Write-Step "Venv at $venvPath is broken (missing core files). Removing..."
             Remove-Item -Recurse -Force $venvPath
             Write-Ok "Removed broken venv."
+        } else {
+            Write-Ok "Existing venv found at $venvPath"
         }
     }
 

--- a/tools/install-windows.ps1
+++ b/tools/install-windows.ps1
@@ -3,8 +3,16 @@
 .SYNOPSIS
     One-command Windows bootstrap for AmiFUSE.
 .DESCRIPTION
-    Installs Python, WinFSP, creates a venv, installs AmiFUSE and dependencies,
-    then runs amifuse doctor --fix.  Idempotent -- safe to run multiple times.
+    Runs UNELEVATED as the current (standard) user. Obtains a compatible Python
+    (3.9-3.13, provisioning per-user if needed), ensures WinFSP is present
+    (elevating ONLY that one machine-wide step), creates a per-user venv,
+    installs AmiFUSE and its dependencies, then runs amifuse doctor --fix and
+    registers the Explorer shell integration in the user's own HKCU hive.
+    Idempotent -- safe to run multiple times.
+
+    Elevation model = SPLIT. Everything user-scoped (Python, venv, pip, HKCU
+    registration) stays unelevated so it lands in the double-clicking user's
+    profile and hive. Only the WinFSP kernel-driver install elevates.
 .PARAMETER Uninstall
     Remove AmiFUSE venv, registry keys, and shell extensions.
 #>
@@ -15,10 +23,23 @@ param(
 
 $ErrorActionPreference = "Stop"
 
-# Ensure script can run even with restricted execution policy
+# G0 -- Ensure this process can run scripts even under a Restricted policy.
 if ((Get-ExecutionPolicy -Scope Process) -eq 'Restricted') {
     Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force
 }
+
+# ---------------------------------------------------------------------------
+# Constants (target Python + provisioning pins)
+# ---------------------------------------------------------------------------
+$TargetPyVersion = "3.13.14"
+$PyInstallerUrl  = "https://www.python.org/ftp/python/3.13.14/python-3.13.14-amd64.exe"
+$PyInstallerSha  = "c54d9b9bbb8a36e6489363ddd01139707fd781d72f1f9e90c7ec65d0061368e0"
+$PerUserPy313    = Join-Path $env:LOCALAPPDATA "Programs\Python\Python313\python.exe"
+
+# WinFSP: pinned MSI (account-agnostic install via msiexec; see G2). Verified.
+$WinFspVersion   = "2.1"
+$WinFspMsiUrl    = "https://github.com/winfsp/winfsp/releases/download/v2.1/winfsp-2.1.25156.msi"
+$WinFspMsiSha    = "073a70e00f77423e34bed98b86e600def93393ba5822204fac57a29324db9f7a"
 
 # ---------------------------------------------------------------------------
 # Helper functions
@@ -50,15 +71,173 @@ function Test-IsAdmin {
     return $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
 }
 
-# ---------------------------------------------------------------------------
-# Admin privilege check
-# ---------------------------------------------------------------------------
-if (-not (Test-IsAdmin)) {
-    Write-Err "This script requires administrator privileges."
-    Write-Host ""
-    Write-Host "Right-click PowerShell and select 'Run as Administrator'," -ForegroundColor White
-    Write-Host "or run: Start-Process powershell -Verb RunAs -ArgumentList '-File', '$PSCommandPath'" -ForegroundColor White
-    exit 1
+function Test-HasWinget {
+    return ($null -ne (Get-Command winget -ErrorAction SilentlyContinue))
+}
+
+# Run <exe> --version and return version info, or $null if it isn't a usable
+# Python. Never throws.
+function Get-PythonVersionInfo {
+    param([string]$ExePath)
+    if (-not $ExePath -or -not (Test-Path $ExePath)) { return $null }
+    try {
+        $out = & $ExePath --version 2>&1
+    } catch {
+        return $null
+    }
+    $text = ($out | Out-String)
+    if ($text -match 'Python\s+(\d+)\.(\d+)\.(\d+)') {
+        return [pscustomobject]@{
+            Path    = $ExePath
+            Major   = [int]$Matches[1]
+            Minor   = [int]$Matches[2]
+            Version = "$($Matches[1]).$($Matches[2]).$($Matches[3])"
+        }
+    }
+    return $null
+}
+
+# The ceiling: accept ONLY 3.9 <= minor <= 13 (machine68k-amifuse ships
+# cp39..cp313 win_amd64 wheels; 3.14 has no wheel and would fail late).
+function Test-InRange {
+    param($Info)
+    if ($null -eq $Info) { return $false }
+    return ($Info.Major -eq 3 -and $Info.Minor -ge 9 -and $Info.Minor -le 13)
+}
+
+# Enumerate candidate interpreters WITHOUT relying on a stale in-session PATH.
+# Primary source is the py launcher (`py -0p`), which reads the live registry;
+# bare python/python3 on PATH are added as a fallback for machines lacking the
+# launcher. Microsoft Store alias stubs (WindowsApps) are skipped -- executing
+# one when no real Python is installed pops the Store.
+function Get-InstalledPythons {
+    $paths = New-Object System.Collections.Generic.List[string]
+    try {
+        $lines = & py -0p 2>&1
+        if ($LASTEXITCODE -eq 0) {
+            foreach ($line in ($lines -split "`r?`n")) {
+                if ($line -match '([A-Za-z]:\\[^\r\n]*?python\.exe)') {
+                    $p = $Matches[1].Trim()
+                    if ($p -notmatch '\\WindowsApps\\') { $paths.Add($p) }
+                }
+            }
+        }
+    } catch { }
+    foreach ($name in @('python.exe', 'python3.exe')) {
+        try {
+            $found = & where.exe $name 2>$null
+            foreach ($f in ($found -split "`r?`n")) {
+                $f = $f.Trim()
+                if ($f -and ($f -notmatch '\\WindowsApps\\') -and (Test-Path $f)) {
+                    $paths.Add($f)
+                }
+            }
+        } catch { }
+    }
+    return ($paths | Select-Object -Unique)
+}
+
+# From a set of interpreter paths, pick the highest one in 3.9-3.13.
+function Select-BestPython {
+    param([string[]]$Paths)
+    $best = $null
+    foreach ($p in $Paths) {
+        $info = Get-PythonVersionInfo $p
+        if (Test-InRange $info) {
+            if ($null -eq $best -or $info.Minor -gt $best.Minor) { $best = $info }
+        }
+    }
+    return $best
+}
+
+# After provisioning, locate the interpreter deterministically (B6): known
+# per-user path first, then `py -3.13` (the running launcher sees a freshly
+# registered 3.13 without a restart), then re-enumerate. Never re-probe bare
+# `python` (PATH is stale in-session).
+function Resolve-ProvisionedPython {
+    $info = Get-PythonVersionInfo $PerUserPy313
+    if (Test-InRange $info) { return $info }
+    try {
+        $out = & py -3.13 -c "import sys; print(sys.executable)" 2>&1
+        if ($LASTEXITCODE -eq 0) {
+            $line = (($out -split "`r?`n") | Where-Object { $_.Trim() } | Select-Object -Last 1)
+            if ($line) {
+                $info = Get-PythonVersionInfo ($line.Trim())
+                if (Test-InRange $info) { return $info }
+            }
+        }
+    } catch { }
+    return (Select-BestPython (Get-InstalledPythons))
+}
+
+# Provision Python 3.13 per-user, UNELEVATED: winget first, then a verified
+# python.org silent install. Returns version info or $null.
+function Invoke-PythonProvision {
+    if (Test-HasWinget) {
+        Write-Step "Installing Python 3.13 via winget (per-user, no admin)..."
+        winget install Python.Python.3.13 --scope user --silent --accept-source-agreements --accept-package-agreements 2>&1 | ForEach-Object { Write-Host $_ }
+        $info = Resolve-ProvisionedPython
+        if (Test-InRange $info) { return $info }
+        Write-Err "winget did not yield a usable Python 3.13; falling back to direct download."
+    }
+
+    $dl = Join-Path $env:TEMP "python-$TargetPyVersion-amd64.exe"
+    Write-Step "Downloading Python $TargetPyVersion (~27 MB) from python.org..."
+    $prev = $ProgressPreference
+    $ProgressPreference = 'SilentlyContinue'
+    $downloaded = $false
+    try {
+        Invoke-WebRequest -Uri $PyInstallerUrl -OutFile $dl -UseBasicParsing
+        $downloaded = $true
+    } catch {
+        Write-Err "Download failed: $($_.Exception.Message)"
+    } finally {
+        $ProgressPreference = $prev
+    }
+    if (-not $downloaded) { return $null }
+    Write-Ok "Download complete."
+
+    Write-Step "Verifying SHA256..."
+    $hash = (Get-FileHash -Algorithm SHA256 -Path $dl).Hash
+    if ($hash -ne $PyInstallerSha.ToUpper()) {
+        Write-Err "SHA256 mismatch -- refusing to run the installer."
+        Write-Err "  expected: $($PyInstallerSha.ToUpper())"
+        Write-Err "  actual:   $hash"
+        Remove-Item -Force $dl -ErrorAction SilentlyContinue
+        return $null
+    }
+    Write-Ok "SHA256 verified."
+
+    Write-Step "Installing Python $TargetPyVersion (per-user, no admin)..."
+    $proc = Start-Process -FilePath $dl -Wait -PassThru -ArgumentList @(
+        '/quiet', 'InstallAllUsers=0', 'PrependPath=1', 'Include_launcher=1', 'Include_pip=1'
+    )
+    Remove-Item -Force $dl -ErrorAction SilentlyContinue
+    if ($proc.ExitCode -ne 0) {
+        Write-Err "Python installer exited with code $($proc.ExitCode); will verify anyway..."
+    }
+    return (Resolve-ProvisionedPython)
+}
+
+# Detect an existing WinFSP install (registry InstallDir, then filesystem).
+function Find-WinFsp {
+    $regPaths = @(
+        "HKLM:\SOFTWARE\WinFsp",
+        "HKLM:\SOFTWARE\WOW6432Node\WinFsp"
+    )
+    foreach ($regPath in $regPaths) {
+        try {
+            $dir = (Get-ItemProperty $regPath -Name InstallDir -ErrorAction Stop).InstallDir
+            if ($dir -and (Test-Path $dir)) { return $dir }
+        } catch { }
+    }
+    foreach ($candidate in @(
+        "${env:ProgramFiles}\WinFsp",
+        "${env:ProgramFiles(x86)}\WinFsp"
+    )) {
+        if (Test-Path (Join-Path $candidate "bin\winfsp-x64.dll")) { return $candidate }
+    }
+    return $null
 }
 
 # ---------------------------------------------------------------------------
@@ -112,25 +291,14 @@ if ($Uninstall) {
         }
     }
 
-    # 3. Remove scheduled tasks
-    try {
-        $tasks = Get-ScheduledTask -TaskPath "\AmiFUSE\" -ErrorAction SilentlyContinue
-        if ($tasks) {
-            foreach ($task in $tasks) {
-                Unregister-ScheduledTask -TaskName $task.TaskName -TaskPath $task.TaskPath -Confirm:$false
-                $removed += "Scheduled task: $($task.TaskName)"
-            }
-        }
-    } catch { }
-
-    # 4. Remove amifuse app data directory (if empty after venv removal)
+    # 3. Remove amifuse app data directory (if empty after venv removal)
     $appDir = Join-Path $env:LOCALAPPDATA "amifuse"
     if ((Test-Path $appDir) -and ((Get-ChildItem $appDir -Force | Measure-Object).Count -eq 0)) {
         Remove-Item -Force $appDir
         $removed += "App directory: $appDir"
     }
 
-    # 5. Summary
+    # 4. Summary
     Write-Host ""
     Write-Host "========================================" -ForegroundColor Cyan
     Write-Host "  Uninstall Complete" -ForegroundColor Cyan
@@ -146,104 +314,116 @@ if ($Uninstall) {
     }
     Write-Host ""
     Write-Host "  Note: WinFSP was NOT removed (shared dependency)." -ForegroundColor Yellow
-    Write-Host "  To remove WinFSP: winget uninstall WinFsp.WinFsp" -ForegroundColor White
+    Write-Host "  To remove WinFSP: use Windows 'Apps & features' (search WinFSP)." -ForegroundColor White
     Write-Host ""
     exit 0
 }
 
 # ---------------------------------------------------------------------------
-# 1. Banner
+# Banner  (installer runs UNELEVATED -- no admin gate; see split-elevation note)
 # ---------------------------------------------------------------------------
 Write-Banner
 
 # ---------------------------------------------------------------------------
-# 2. Detect Python 3.9+
+# G1 -- Compatible Python (3.9-3.13): reuse, else provision per-user unelevated
 # ---------------------------------------------------------------------------
-Write-Step "Detecting Python..."
+Write-Step "Detecting a compatible Python (3.9-3.13)..."
 
-$python = $null
-foreach ($candidate in @("py -3", "python3", "python")) {
-    try {
-        $tokens = $candidate -split " "
-        $ver = & $tokens[0] $tokens[1..($tokens.Length-1)] --version 2>&1
-        if ($ver -match "Python\s+(\d+)\.(\d+)") {
-            $major = [int]$Matches[1]
-            $minor = [int]$Matches[2]
-            if ($major -ge 3 -and $minor -ge 9) {
-                $python = $tokens
-                Write-Ok "Found $ver ($candidate)"
-                break
-            }
-        }
-    } catch { }
+$pythonInfo = Select-BestPython (Get-InstalledPythons)
+if (Test-InRange $pythonInfo) {
+    Write-Ok "Found compatible Python $($pythonInfo.Version) at $($pythonInfo.Path)"
+} else {
+    Write-Step "No compatible Python (3.9-3.13) present; provisioning Python $TargetPyVersion..."
+    $pythonInfo = Invoke-PythonProvision
+    if (-not (Test-InRange $pythonInfo)) {
+        Write-Err "Could not obtain a compatible Python (3.9-3.13)."
+        Write-Host "  Install Python 3.13 from python.org and re-run." -ForegroundColor White
+        exit 1
+    }
+    Write-Ok "Provisioned Python $($pythonInfo.Version) at $($pythonInfo.Path)"
 }
-
-if (-not $python) {
-    Write-Err "Python 3.9+ not found."
-    Write-Host ""
-    Write-Host "Install Python with:" -ForegroundColor White
-    Write-Host "  winget install Python.Python.3.12" -ForegroundColor White
-    Write-Host ""
-    Write-Host "Then re-run this script." -ForegroundColor White
-    exit 1
-}
+$pythonExe = $pythonInfo.Path
 
 # ---------------------------------------------------------------------------
-# 3. Detect WinFSP
+# G2 -- WinFSP (machine-wide kernel driver): the ONLY elevated step
 # ---------------------------------------------------------------------------
 Write-Step "Detecting WinFSP..."
-
-$winfspDir = $null
-$winfspRegPaths = @(
-    "HKLM:\SOFTWARE\WinFsp",
-    "HKLM:\SOFTWARE\WOW6432Node\WinFsp"
-)
-
-function Find-WinFsp {
-    foreach ($regPath in $winfspRegPaths) {
-        try {
-            $dir = (Get-ItemProperty $regPath -Name InstallDir -ErrorAction Stop).InstallDir
-            if ($dir -and (Test-Path $dir)) { return $dir }
-        } catch { }
-    }
-    # Filesystem fallback
-    foreach ($candidate in @(
-        "${env:ProgramFiles}\WinFsp",
-        "${env:ProgramFiles(x86)}\WinFsp"
-    )) {
-        if (Test-Path (Join-Path $candidate "bin\winfsp-x64.dll")) { return $candidate }
-    }
-    return $null
-}
-
 $winfspDir = Find-WinFsp
 
 if ($winfspDir) {
     Write-Ok "WinFSP found at $winfspDir"
 } else {
-    Write-Err "WinFSP not found."
-    Write-Host ""
-    Write-Host "WinFSP requires elevated (admin) installation." -ForegroundColor White
-    $reply = Read-Host "Install WinFSP via winget now? (y/n)"
-    if ($reply -eq "y") {
-        Write-Step "Installing WinFSP (may prompt for elevation)..."
-        winget install WinFsp.WinFsp --accept-source-agreements --accept-package-agreements
-        # Verify
-        $winfspDir = Find-WinFsp
-        if ($winfspDir) {
-            Write-Ok "WinFSP installed at $winfspDir"
+    Write-Step "WinFSP not found. It is a machine-wide driver and needs a one-time elevation."
+
+    # Download the MSI UNELEVATED, as the standard user, into that user's TEMP.
+    # This is the account-agnostic path: the only elevated action is msiexec.exe
+    # (a System32 binary present for EVERY account, with no winget/MSIX alias or
+    # per-profile dependency). Under over-the-shoulder UAC the elevated admin
+    # token can still READ the standard user's TEMP file. We verify SHA256 before
+    # handing the MSI to the elevated installer.
+    $msi = Join-Path $env:TEMP "winfsp-$WinFspVersion.msi"
+    Write-Step "Downloading WinFSP $WinFspVersion (~2 MB)..."
+    $prev = $ProgressPreference
+    $ProgressPreference = 'SilentlyContinue'
+    $downloaded = $false
+    try {
+        Invoke-WebRequest -Uri $WinFspMsiUrl -OutFile $msi -UseBasicParsing
+        $downloaded = $true
+    } catch {
+        Write-Err "WinFSP download failed: $($_.Exception.Message)"
+    } finally {
+        $ProgressPreference = $prev
+    }
+    if (-not $downloaded) {
+        Write-Err "Could not download the WinFSP installer."
+        Write-Err "Install WinFSP manually from https://winfsp.dev/ and re-run."
+        exit 1
+    }
+    Write-Ok "Download complete."
+
+    Write-Step "Verifying SHA256..."
+    $hash = (Get-FileHash -Algorithm SHA256 -Path $msi).Hash
+    if ($hash -ne $WinFspMsiSha.ToUpper()) {
+        Write-Err "SHA256 mismatch -- refusing to install WinFSP."
+        Write-Err "  expected: $($WinFspMsiSha.ToUpper())"
+        Write-Err "  actual:   $hash"
+        Remove-Item -Force $msi -ErrorAction SilentlyContinue
+        exit 1
+    }
+    Write-Ok "SHA256 verified."
+
+    Write-Step "Installing WinFSP (requires administrator)..."
+    $msiArgs = "/i `"$msi`" /qn /norestart"
+    try {
+        if (Test-IsAdmin) {
+            # Already elevated (rare for this flow) -- run msiexec directly, no 2nd UAC.
+            $p = Start-Process -FilePath "msiexec.exe" -Wait -PassThru -ArgumentList $msiArgs
         } else {
-            Write-Err "WinFSP install could not be verified. You may need to restart this script."
-            exit 1
+            # Normal case: elevate JUST msiexec (a UAC prompt will appear).
+            $p = Start-Process -FilePath "msiexec.exe" -Verb RunAs -Wait -PassThru -ArgumentList $msiArgs
         }
+        if ($p.ExitCode -ne 0) {
+            Write-Err "WinFSP installer (msiexec) reported exit code $($p.ExitCode); will verify..."
+        }
+    } catch {
+        Write-Err "Elevation for the WinFSP install was cancelled or failed."
+        Write-Err "WinFSP is required. Re-run and approve the prompt, or install from https://winfsp.dev/."
+        Remove-Item -Force $msi -ErrorAction SilentlyContinue
+        exit 1
+    }
+    Remove-Item -Force $msi -ErrorAction SilentlyContinue
+
+    $winfspDir = Find-WinFsp
+    if ($winfspDir) {
+        Write-Ok "WinFSP installed at $winfspDir"
     } else {
-        Write-Err "WinFSP is required. Install it manually from https://winfsp.dev/ and re-run."
+        Write-Err "WinFSP install could not be verified -- restart and re-run, or install from https://winfsp.dev/."
         exit 1
     }
 }
 
 # ---------------------------------------------------------------------------
-# 4. Detect / create venv
+# G3 -- venv (per-user; lands in the standard user's %LOCALAPPDATA%)
 # ---------------------------------------------------------------------------
 Write-Step "Setting up virtual environment..."
 
@@ -264,7 +444,6 @@ if ($env:VIRTUAL_ENV) {
 
     if (Test-Path $venvPath) {
         $venvPython = Join-Path $venvPath "Scripts\python.exe"
-        $venvPip = Join-Path $venvPath "Scripts\pip.exe"
         if (-not (Test-Path $activateScript) -or -not (Test-Path $venvPython)) {
             Write-Step "Venv at $venvPath is broken (missing core files). Removing..."
             Remove-Item -Recurse -Force $venvPath
@@ -276,9 +455,10 @@ if ($env:VIRTUAL_ENV) {
 
     if (-not (Test-Path $venvPath)) {
         Write-Step "Creating venv at $venvPath..."
-        & $python[0] $python[1..($python.Length-1)] -m venv $venvPath
+        & $pythonExe -m venv $venvPath
         if (-not (Test-Path $activateScript)) {
             Write-Err "Venv creation failed -- $activateScript not found after creation."
+            Write-Host "  Delete $venvPath and re-run." -ForegroundColor White
             exit 1
         }
         Write-Ok "Venv created."
@@ -296,8 +476,38 @@ if (-not $env:VIRTUAL_ENV) {
 }
 Write-Ok "Venv activated at $venvPath"
 
+# Persist the venv Scripts dir to the standard user's PATH ourselves (HKCU),
+# independent of doctor. After dot-sourcing Activate.ps1 above, `amifuse` is on
+# THIS process's PATH, so doctor's shutil.which("amifuse") returns non-None and
+# it SKIPS its persistent HKCU\Environment\Path write -- leaving a fresh terminal
+# with no `amifuse`. Writing it here (unelevated) lands in the standard user's
+# own hive, consistent with the split. Idempotent.
+$venvScripts = Join-Path $venvPath "Scripts"
+$userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+if (($userPath -split ';') -notcontains $venvScripts) {
+    $userPath = if ($userPath) { "$userPath;$venvScripts" } else { $venvScripts }
+    [Environment]::SetEnvironmentVariable("Path", $userPath, "User")
+    Write-Ok "Added $venvScripts to your user PATH (open a new terminal to use 'amifuse')."
+} else {
+    Write-Ok "$venvScripts already on your user PATH."
+}
+
 # ---------------------------------------------------------------------------
-# 5. Install AmiFUSE
+# G4 -- pip bootstrap / upgrade in the venv
+# ---------------------------------------------------------------------------
+Write-Step "Bootstrapping pip in the venv..."
+python -m ensurepip --upgrade 2>&1 | ForEach-Object { Write-Host $_ }
+python -m pip install --upgrade pip 2>&1 | ForEach-Object { Write-Host $_ }
+
+$pipVer = python -m pip --version 2>&1
+if ($LASTEXITCODE -ne 0) {
+    Write-Err "pip bootstrap failed in venv."
+    exit 1
+}
+Write-Ok "pip ready: $pipVer"
+
+# ---------------------------------------------------------------------------
+# G5 -- Install AmiFUSE + dependencies
 # ---------------------------------------------------------------------------
 Write-Step "Installing AmiFUSE..."
 
@@ -313,19 +523,90 @@ if ($pyprojectPath -and (Test-Path $pyprojectPath)) {
 
 if ($devMode) {
     Write-Step "Dev checkout detected -- installing in editable mode with [windows] extras..."
-    python -m pip install -e "$repoRoot[windows]"
-    Write-Ok "Editable install complete (dependencies including machine68k-amifuse pulled from pyproject.toml)."
+    # G1 guarantees the venv python is 3.9-3.13, so the machine68k-amifuse wheel
+    # pulled transitively (via amitools-amifuse[vamos]) resolves without an sdist
+    # build. The import check below is the fast/clear guard.
+    #
+    # setuptools_scm (upstream pyproject build config) derives the version from git
+    # and lists tracked files via os.path.relpath(file, cwd). That crashes when the
+    # repo is on a mapped network drive (git returns UNC paths, cwd is a drive letter
+    # -- "path is on mount '\\host\share', start on mount 'U:'") and also when the
+    # repo came from a GitHub ZIP (no .git -> "unable to determine version"). Pinning
+    # SETUPTOOLS_SCM_PRETEND_VERSION_FOR_AMIFUSE bypasses both the file-finder and
+    # version derivation. The package-scoped form (suffix canonicalized to "amifuse")
+    # targets ONLY our package -- the unscoped var would force this version onto any
+    # other setuptools_scm-based package built from sdist in the same isolated build
+    # env (e.g. transitive amitools-amifuse). Prefer the latest git tag (plain git
+    # works on the network drive; only setuptools_scm's relpath fails), else a
+    # harmless static fallback -- the version is cosmetic for an editable dev install.
+    # Only call git if it exists: a ZIP-download user on a fresh box may not have it,
+    # and with $ErrorActionPreference = "Stop" a bare git call would raise a
+    # terminating CommandNotFoundException (2>$null does NOT suppress that).
+    $scmVersion = $null
+    if (Get-Command git -ErrorAction SilentlyContinue) {
+        $scmVersion = (git -C $repoRoot describe --tags --abbrev=0 2>$null)
+    }
+    # Decide on the STRING being empty, NOT $LASTEXITCODE -- when git is skipped
+    # $LASTEXITCODE holds a stale value from an earlier external command.
+    if ([string]::IsNullOrWhiteSpace($scmVersion)) {
+        $scmVersion = "0.0.0"
+    } else {
+        $scmVersion = $scmVersion.Trim() -replace '^v', ''
+    }
+    $prevScmVersion = $env:SETUPTOOLS_SCM_PRETEND_VERSION_FOR_AMIFUSE
+    try {
+        $env:SETUPTOOLS_SCM_PRETEND_VERSION_FOR_AMIFUSE = $scmVersion
+        python -m pip install -e "$repoRoot[windows]" 2>&1 | ForEach-Object { Write-Host $_ }
+        # Capture the pip exit code BEFORE finally runs -- any command in finally
+        # (e.g. Remove-Item) could clobber $LASTEXITCODE before the check below.
+        $pipExit = $LASTEXITCODE
+    } finally {
+        if ($null -eq $prevScmVersion) {
+            Remove-Item Env:SETUPTOOLS_SCM_PRETEND_VERSION_FOR_AMIFUSE -ErrorAction SilentlyContinue
+        } else {
+            $env:SETUPTOOLS_SCM_PRETEND_VERSION_FOR_AMIFUSE = $prevScmVersion
+        }
+    }
+    if ($pipExit -ne 0) {
+        Write-Err "Editable install failed."
+        exit 1
+    }
+    Write-Ok "Editable install complete."
 } else {
-    Write-Step "Installing from PyPI..."
-    python -m pip install amifuse
-    python -m pip install pystray Pillow
-    # machine68k-amifuse only needed separately for PyPI installs
-    Write-Step "Installing machine68k-amifuse (Windows-compatible fork)..."
-    python -m pip install machine68k-amifuse
+    # Install machine68k-amifuse FIRST, --only-binary=:all:, so an out-of-range
+    # Python fails FAST and CLEAR here (B8). If we installed `amifuse` first it
+    # would pull machine68k-amifuse transitively (via amitools-amifuse[vamos])
+    # WITHOUT --only-binary, hitting a cryptic sdist C-build failure before this
+    # guard is ever reached. G1 should keep us in 3.9-3.13, so this normally just
+    # installs a wheel.
+    Write-Step "Installing machine68k-amifuse (wheel only)..."
+    python -m pip install --only-binary=:all: machine68k-amifuse 2>&1 | ForEach-Object { Write-Host $_ }
+    if ($LASTEXITCODE -ne 0) {
+        $pv = (python --version 2>&1)
+        Write-Err "No compatible machine68k-amifuse wheel for this Python -- need Python 3.9-3.13 (have $pv)."
+        exit 1
+    }
+    Write-Step "Installing AmiFUSE from PyPI..."
+    python -m pip install amifuse pystray Pillow 2>&1 | ForEach-Object { Write-Host $_ }
+    if ($LASTEXITCODE -ne 0) {
+        Write-Err "Failed to install amifuse/pystray/Pillow from PyPI."
+        exit 1
+    }
 }
 
+# Final G5 verification: machine68k must import (wheel installed correctly).
+Write-Step "Verifying machine68k import..."
+python -c "import machine68k" 2>&1 | ForEach-Object { Write-Host $_ }
+if ($LASTEXITCODE -ne 0) {
+    $pv = (python --version 2>&1)
+    Write-Err "No compatible machine68k-amifuse wheel for this Python -- need Python 3.9-3.13 (have $pv)."
+    exit 1
+}
+$machine68kOk = $true
+Write-Ok "machine68k import OK."
+
 # ---------------------------------------------------------------------------
-# 6. Run doctor --fix
+# G6 -- doctor --fix  /  G7 -- HKCU shell registration (both UNELEVATED)
 # ---------------------------------------------------------------------------
 Write-Step "Running amifuse doctor --fix..."
 $ErrorActionPreference = "Continue"
@@ -337,23 +618,65 @@ if ($LASTEXITCODE -ne 0) {
 }
 $ErrorActionPreference = "Stop"
 
+# G7 -- verify Explorer integration landed in THIS user's hive (non-fatal).
+$shellRegistered = Test-Path "HKCU:\Software\Classes\AmiFUSE.DiskImage"
+if ($shellRegistered) {
+    Write-Ok "Explorer integration registered for current user (HKCU)."
+} else {
+    Write-Err "Explorer integration not registered for current user (HKCU:\Software\Classes\AmiFUSE.DiskImage missing)."
+    Write-Host "You can register it later with: amifuse register" -ForegroundColor White
+}
+
 # ---------------------------------------------------------------------------
-# 7. Summary
+# Summary
 # ---------------------------------------------------------------------------
+if (Test-IsAdmin) { $modeText = "elevated (WinFSP-only elevation not needed)" } else { $modeText = "unelevated (user scope)" }
+
+# $ready is the ground truth for the summary text: every core capability must
+# actually be in place. WinFSP and machine68k are guaranteed by earlier exits,
+# but shell registration (G6/G7) is non-fatal and may be missing -- in which case
+# the summary must say "with warnings", not an unqualified "Complete".
+$ready = ([bool]$winfspDir) -and ($machine68kOk -eq $true) -and $shellRegistered
+
 Write-Host ""
 Write-Host "========================================" -ForegroundColor Cyan
-Write-Host "  Installation Complete" -ForegroundColor Cyan
+if ($ready) {
+    Write-Host "  Installation Complete" -ForegroundColor Cyan
+} else {
+    Write-Host "  Installation completed with warnings" -ForegroundColor Yellow
+}
 Write-Host "========================================" -ForegroundColor Cyan
 Write-Host ""
-Write-Host "  Python:   $(python --version)" -ForegroundColor White
+Write-Host "  Python:   $(python --version) (base: $pythonExe)" -ForegroundColor White
 Write-Host "  Venv:     $venvPath" -ForegroundColor White
 Write-Host "  WinFSP:   $winfspDir" -ForegroundColor White
+Write-Host "  Mode:     $modeText" -ForegroundColor White
 if ($devMode) {
-    Write-Host "  Mode:     editable (dev)" -ForegroundColor White
+    Write-Host "  Install:  editable (dev)" -ForegroundColor White
 } else {
-    Write-Host "  Mode:     PyPI release" -ForegroundColor White
+    Write-Host "  Install:  PyPI release" -ForegroundColor White
 }
 Write-Host ""
+if (-not $ready) {
+    Write-Host "Warnings (install is degraded):" -ForegroundColor Yellow
+    if (-not $winfspDir)      { Write-Host "  - WinFSP not verified -- mounts will fail until WinFSP is installed." -ForegroundColor Yellow }
+    if ($machine68kOk -ne $true) { Write-Host "  - machine68k did not import -- the m68k core is unavailable." -ForegroundColor Yellow }
+    if (-not $shellRegistered) { Write-Host "  - Explorer integration not registered -- run 'amifuse register' to add it." -ForegroundColor Yellow }
+    Write-Host ""
+}
+
+# Final read-only health check (no --fix). Informational only: the $ready banner
+# above is the authoritative status. Non-fatal -- a non-zero exit (e.g. amifuse
+# not importable) must not abort the install, so bracket with Continue/Stop.
+Write-Host ""
+Write-Host "Final health check (amifuse doctor):" -ForegroundColor Cyan
+$ErrorActionPreference = "Continue"
+python -m amifuse doctor 2>&1 | ForEach-Object { Write-Host $_ }
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "  (doctor reported items above; see details.)" -ForegroundColor White
+}
+$ErrorActionPreference = "Stop"
+
 Write-Host "Next steps:" -ForegroundColor Yellow
 Write-Host "  amifuse mount <image> <drive-letter>   Mount an Amiga disk image" -ForegroundColor White
 Write-Host "  amifuse doctor                         Check system health" -ForegroundColor White

--- a/tools/install.bat
+++ b/tools/install.bat
@@ -1,0 +1,10 @@
+@echo off
+net session >nul 2>&1
+if %errorlevel% equ 0 goto :run
+
+powershell -Command "Start-Process cmd -Verb RunAs -ArgumentList '/c \"\"%~f0\"\" %*'"
+exit /b
+
+:run
+powershell -ExecutionPolicy Bypass -File "%~dp0install-windows.ps1" %*
+pause

--- a/tools/install.bat
+++ b/tools/install.bat
@@ -1,10 +1,30 @@
 @echo off
-net session >nul 2>&1
-if %errorlevel% equ 0 goto :run
+rem AmiFUSE installer launcher.
+rem
+rem Role: launch install-windows.ps1 UNELEVATED, as the current (standard) user,
+rem and hold the window open so any error / exit code stays readable after a
+rem double-click (double-clicking the .ps1 directly opens an editor, so this
+rem .bat remains the entry point).
+rem
+rem The installer deliberately runs UNELEVATED. Everything user-scoped -- the
+rem per-user Python, the venv under %LOCALAPPDATA%, pip, and the HKCU shell
+rem registration -- must land in the double-clicking user's own profile and
+rem hive. If the whole installer were elevated via over-the-shoulder admin
+rem credentials, all of that would land in the ADMIN's profile and the standard
+rem user would get nothing. The ONE action that needs admin (the machine-wide
+rem WinFSP kernel driver) elevates itself from inside install-windows.ps1.
+rem
+rem Pass-through args (e.g. -Uninstall) are forwarded verbatim.
 
-powershell -Command "Start-Process cmd -Verb RunAs -ArgumentList '/c \"\"%~f0\"\" %*'"
-exit /b
-
-:run
-powershell -ExecutionPolicy Bypass -File "%~dp0install-windows.ps1" %*
+cd /d "%~dp0"
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0install-windows.ps1" %*
+set "_rc=%errorlevel%"
+echo.
+if not "%_rc%"=="0" (
+    echo Installer exited with error code %_rc%.
+) else (
+    echo Installer finished successfully.
+)
+echo.
+rem Hold the window open so the outcome above is readable after a double-click.
 pause


### PR DESCRIPTION
## Summary

Makes AmiFUSE behave as a first-class Windows drive in File Explorer:

- **Disk space reporting** — `statfs` implementation so Explorer Properties and `df` show correct volume size and free space, backed by `ACTION_DISK_INFO` from the Amiga handler
- **Explorer refresh on mount/unmount** — `SHChangeNotify` notifications so the sidebar updates immediately without manual refresh
- **Double-click mount** — Double-clicking an `.hdf`/`.adf` in Explorer mounts the image (read-write by default) and opens an Explorer window to the drive root
- **Installer hardening** — Admin privilege check, broken venv recovery, `--uninstall` switch for clean removal, and a `install.bat` wrapper with UAC auto-elevation

Also fixes three low-severity bugs: SCSI WRITE(10) short-buffer validation, cache locking for multi-threaded read-only mounts, and duplicated resume logic in the startup runner.

## What changed

| Area | Files | What |
|------|-------|------|
| Disk space | `fuse_fs.py`, `startup_runner.py` | `statfs()` via `ACTION_DISK_INFO`; infinite TTL for read-only, 30s for writable |
| Shell notifications | `platform.py`, `fuse_fs.py`, `tray.py` | `SHChangeNotify` on mount/unmount with crash-recovery redundancy |
| Double-click mount | `windows_shell.py`, `launcher.py` | Drive letter allocation, mount polling, Explorer auto-open, simplified to 2 context menu verbs |
| Installer | `install-windows.ps1`, `install.bat` | Admin check, venv recovery, `--uninstall`, UAC wrapper |
| SCSI fix | `scsi_device.py` | Short-buffer validation with proper sense data |
| Cache locking | `fuse_fs.py` | `RLock` protecting stat/dir/neg caches in multi-threaded mode |
| Startup refactor | `startup_runner.py` | Deduplicated resume logic into `_finalize_burst_blocked` |
| Tests | `test_statfs.py`, `test_write_persistence.py`, + 6 more | 65+ new tests; integration tests for statfs, write persistence, unmount lifecycle |
| Metadata | `pyproject.toml`, `README.md` | Windows classifiers, updated install/usage docs |

## Test plan

- [x] `pytest` — 555 passed, 1 skipped (all green locally on Windows)
- [x] Mount image, right-click drive > Properties — correct disk size shown
- [x] Mount/unmount — Explorer sidebar updates within ~2s
- [x] Double-click `.adf` — mounts r/w + Explorer opens to drive root
- [x] `install.bat` double-click — UAC prompt, full install, `doctor` reports ready
- [x] `install.bat -Uninstall` — clean removal, idempotent on re-run
- [x] CI (Windows + macOS + Linux)