### PR TITLE
Guard Windows-only launcher and tray entry points

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,3 +85,10 @@ machine68k fixes
 - One logical change per PR
 - All CI checks should pass (or failures should be pre-existing)
 - Keep the scope focused -- small, reviewable diffs are easier to merge
+
+## Platform-Specific Entry Points
+
+Platform-specific entry points (e.g. Windows-only `gui-scripts`) must guard
+at the top of their entry function with
+`if not sys.platform.startswith("win"): raise SystemExit(...)` so they fail
+cleanly when invoked on another platform.

--- a/amifuse/launcher.py
+++ b/amifuse/launcher.py
@@ -57,6 +57,9 @@ def _spawn_detached(cmd: list[str], **kwargs) -> None:
 
 
 def main(argv=None) -> None:
+    if not sys.platform.startswith("win"):
+        raise SystemExit("The AmiFUSE launcher is only supported on Windows.")
+
     parser = argparse.ArgumentParser(description="AmiFUSE launcher")
     sub = parser.add_subparsers(dest="command", required=True)
 

--- a/amifuse/tray.py
+++ b/amifuse/tray.py
@@ -212,7 +212,10 @@ def _check_single_instance() -> bool:
     return ctypes.get_last_error() != _ERROR_ALREADY_EXISTS
 
 
-def main():
+def main(argv=None) -> None:
+    if not sys.platform.startswith("win"):
+        raise SystemExit("The AmiFUSE tray is only supported on Windows.")
+
     log_dir = Path(os.environ.get("APPDATA", "")) / "AmiFUSE"
     log_dir.mkdir(parents=True, exist_ok=True)
     logging.basicConfig(

--- a/tests/unit/test_launcher.py
+++ b/tests/unit/test_launcher.py
@@ -1,6 +1,8 @@
 """Unit tests for amifuse.launcher module.
 
-Mocks subprocess.Popen and ctypes.windll so tests run on all platforms.
+Mocks subprocess.Popen and ctypes.windll. This module is Windows-only
+(``pytestmark`` skips it off Windows); the cross-platform guard test lives
+in ``test_launcher_guard.py``.
 """
 
 from __future__ import annotations

--- a/tests/unit/test_launcher_guard.py
+++ b/tests/unit/test_launcher_guard.py
@@ -1,0 +1,23 @@
+"""Cross-platform guard test for amifuse.launcher.
+
+Separate from ``test_launcher.py`` (which is Windows-only via ``pytestmark``)
+so this runs on every CI platform. Monkeypatches ``sys.platform`` to a
+non-Windows value and asserts ``main()`` fails cleanly instead of hanging or
+raising an uncaught ``AttributeError`` from Windows-only ctypes calls.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+import amifuse.launcher
+
+
+def test_main_exits_off_windows(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "linux")
+    # ["open", "x.hdf"] would otherwise reach argparse dispatch and the
+    # Windows-only mount/ctypes path; the guard must fire first.
+    with pytest.raises(SystemExit, match="only supported on Windows"):
+        amifuse.launcher.main(["open", "x.hdf"])

--- a/tests/unit/test_tray_guard.py
+++ b/tests/unit/test_tray_guard.py
@@ -1,0 +1,20 @@
+"""Cross-platform guard test for amifuse.tray.
+
+Mirrors ``test_launcher_guard.py``: monkeypatches ``sys.platform`` to a
+non-Windows value and asserts ``main()`` fails cleanly instead of raising an
+uncaught ``AttributeError`` from the Windows-only ctypes mutex call.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+import amifuse.tray
+
+
+def test_main_exits_off_windows(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "linux")
+    with pytest.raises(SystemExit, match="only supported on Windows"):
+        amifuse.tray.main()


### PR DESCRIPTION
## Problem

`amifuse-launcher` and `amifuse-tray` are declared unconditionally under
`[project.gui-scripts]`, so `pip install` creates both executables on every
platform. Their `main()` functions run Windows-only code (`ctypes.windll` /
`ctypes.WinDLL`, `os.startfile`, drive-letter logic) with no platform guard, so
invoking them off-Windows fails without a clear message:

- **launcher** — an `open`/`mount` invocation spawns mount subprocesses and polls
  for the drive (up to ~15s, aggregate and partition-count dependent), then hits
  `ctypes.windll.kernel32.OpenMutexW` in `_ensure_tray_running` and dies with an
  uncaught `AttributeError: module 'ctypes' has no attribute 'windll'`.
- **tray** — `_check_single_instance` calls `ctypes.WinDLL('kernel32', ...)` and
  raises an uncaught `AttributeError` immediately.

This is inconsistent with the rest of the codebase, which guards platform-specific
surfaces at the top of the function (e.g. `windows_shell.register`).

## Fix

Guard each gui-script `main()` with the existing repo idiom so it fails cleanly:

```python
if not sys.platform.startswith("win"):
    raise SystemExit("The AmiFUSE launcher is only supported on Windows.")
```

Guarding the entry `main()` (rather than the leaf helpers) covers every
subcommand/verb with a single check.

## Also in this PR

- Cross-platform guard tests (`test_launcher_guard.py`, `test_tray_guard.py`) that
  run on all CI legs and assert `SystemExit` off-Windows.
- Corrected a stale docstring in `test_launcher.py`.
- Documented the platform-guard convention in `CONTRIBUTING.md`.
- Aligned `tray.main()` to the `main(argv=None)` entry-point convention used by the
  other entry points.

I audited every declared entry point: these two `gui-scripts` were the only
unguarded Windows-only surfaces. The `amifuse`, `rdb-inspect`, and `driver-info`
console scripts are cross-platform, and `windows_shell` was already guarded
(including `is_registered`, which returns `False` off-Windows before touching the
registry).

## Testing

Unit suite: **551 passed / 1 skipped** (full-dependency venv). The two new guard
tests run on all platforms (not skip-gated) and pass.
