### PR TITLE
verify: check the volume actually mounted, not just that the handler responds

### DIFF
--- a/amifuse/fuse_fs.py
+++ b/amifuse/fuse_fs.py
@@ -3376,6 +3376,21 @@ def _json_result(command: str, **kwargs) -> dict:
     return result
 
 
+def _mount_error_details(dinfo: Optional[Dict]) -> Dict:
+    """Machine-readable details for a NOT_MOUNTED error envelope.
+
+    dinfo is None when the handler refused ACTION_DISK_INFO outright, in
+    which case there is no id_DiskType it actually reported and the details
+    stay empty rather than naming a value the handler never sent.
+    """
+    details = {}
+    if dinfo is not None:
+        details["disk_type"] = dinfo["disk_type"]
+        if "volume_node" in dinfo:
+            details["volume_node"] = dinfo["volume_node"]
+    return details
+
+
 def _cleanup_bridge(bridge, temp_driver=None):
     """Shut down a HandlerBridge and release all resources.
 
@@ -3592,6 +3607,23 @@ def cmd_ls(args):
 
     bridge, temp_driver = _create_bridge_from_args(args, "ls")
     try:
+        # A handler that rejected the disk still answers directory reads with
+        # an empty result. The stat fallback below would catch that, but it is
+        # skipped at the root (path != "/"), and -R bypasses it entirely --
+        # so without this guard the default `amifuse ls image.hdf` reports an
+        # unmountable image as an empty volume and exits 0.
+        mounted, dinfo, mount_reason = bridge.is_mounted()
+        if mounted is False:
+            if use_json:
+                print(json.dumps(_json_error(
+                    "ls", "NOT_MOUNTED",
+                    f"No usable volume mounted: {mount_reason}",
+                    details=_mount_error_details(dinfo),
+                )))
+                sys.exit(1)
+            raise SystemExit(
+                f"Error: no usable volume mounted: {mount_reason}")
+
         if recursive:
             entries = _ls_recursive(bridge, path)
         else:
@@ -3625,6 +3657,7 @@ def cmd_ls(args):
                 target=str(args.image),
                 path=path,
                 entries=entries,
+                filesystem_responsive=mounted,
             )
             print(json.dumps(result, indent=2))
         else:
@@ -3633,6 +3666,12 @@ def cmd_ls(args):
                     print(f"  {ent['name']:30s}  <dir>     {ent['protection']}")
                 else:
                     print(f"  {ent['name']:30s}  {ent['size']:>10d}  {ent['protection']}")
+            # An empty listing that we could not confirm is a real listing
+            # looks identical to an empty volume. Say so, on stderr, so the
+            # listing itself stays clean for anything parsing stdout.
+            if not entries and mounted is None:
+                print(f"Warning: mount state unknown -- {mount_reason}",
+                      file=sys.stderr)
     except SystemExit:
         raise
     except Exception as e:
@@ -3667,15 +3706,7 @@ def cmd_verify(args):
         # before either verification path can manufacture a successful result.
         mounted, dinfo, mount_reason = bridge.is_mounted()
         if mounted is False:
-            # dinfo is None when the handler refused ACTION_DISK_INFO outright.
-            # Report only what it actually told us: there is no id_DiskType to
-            # name in that case.
-            details = {}
-            if dinfo is not None:
-                details["disk_type"] = dinfo["disk_type"]
-                if "volume_node" in dinfo:
-                    details["volume_node"] = dinfo["volume_node"]
-
+            details = _mount_error_details(dinfo)
             if use_json:
                 print(json.dumps(_json_error(
                     "verify", "NOT_MOUNTED",

--- a/amifuse/fuse_fs.py
+++ b/amifuse/fuse_fs.py
@@ -1268,7 +1268,8 @@ class HandlerBridge:
     def get_disk_info(self) -> Optional[Dict]:
         """Query filesystem geometry via ACTION_DISK_INFO.
 
-        Returns dict with keys: num_blocks, num_blocks_used, bytes_per_block.
+        Returns a dict containing num_blocks, num_blocks_used,
+        bytes_per_block, disk_type, and volume_node.
         Returns None if the handler doesn't respond.
         """
         with self._lock:
@@ -1285,19 +1286,55 @@ class HandlerBridge:
                 return None
 
             # Read InfoDataStruct fields (all LONGs at known offsets):
-            # id_NumBlocks: offset 12
-            # id_NumBlocksUsed: offset 16
-            # id_BytesPerBlock: offset 20
+            # id_NumBlocks: 12, id_NumBlocksUsed: 16,
+            # id_BytesPerBlock: 20, id_DiskType: 24, id_VolumeNode: 28
             num_blocks = self.mem.r32(info_mem.addr + 12)
             num_blocks_used = self.mem.r32(info_mem.addr + 16)
             bytes_per_block = self.mem.r32(info_mem.addr + 20)
+            disk_type = self.mem.r32(info_mem.addr + 24)
+            volume_node = self.mem.r32(info_mem.addr + 28)
 
             self.vh.alloc.free_memory(info_mem)
             return {
                 "num_blocks": num_blocks,
                 "num_blocks_used": num_blocks_used,
                 "bytes_per_block": bytes_per_block,
+                "disk_type": disk_type,
+                "volume_node": volume_node,
             }
+
+    # AmigaDOS id_DiskType sentinels meaning "no usable volume mounted"
+    _UNMOUNTED_DISK_REASONS = {
+        0xFFFFFFFF: "no disk present",  # ID_NO_DISK_PRESENT (-1)
+        0x42414400: "unreadable disk",  # ID_UNREADABLE_DISK 'BAD\0'
+        0x4E444F53: "not a DOS disk",  # ID_NOT_REALLY_DOS 'NDOS'
+        0x42555359: "disk busy or inhibited",  # ID_BUSY 'BUSY'
+        0x4B49434B: "Kickstart disk has no DOS volume",  # ID_KICKSTART_DISK
+    }
+    # CrossDOS uses ID_MSDOS_DISK for successfully mounted volumes.
+
+    def is_mounted(
+            self) -> Tuple[Optional[bool], Optional[Dict], Optional[str]]:
+        """Return the mount state, ACTION_DISK_INFO result, and reason.
+
+        The state is None when the handler does not provide enough information
+        to decide. Any nonzero type except a known unusable sentinel counts as
+        mounted, allowing custom filesystem identifiers. id_VolumeNode can
+        confirm a mount when the type is zero.
+        """
+        info = self.get_disk_info()
+        if not info:
+            return None, None, "handler did not report disk info"
+
+        disk_type = info.get("disk_type", 0)
+        reason = self._UNMOUNTED_DISK_REASONS.get(disk_type)
+        if reason is not None:
+            return False, info, reason
+        if disk_type != 0:
+            return True, info, None
+        if info.get("volume_node", 0) != 0:
+            return True, info, None
+        return None, info, "handler reported no disk type or volume node"
 
     def volume_name(self) -> str:
         """Best-effort name: RDB drive name, else first dir entry, else fallback."""
@@ -3572,6 +3609,31 @@ def cmd_verify(args):
 
     bridge, temp_driver = _create_bridge_from_args(args, "verify")
     try:
+        # Reject a disk that the handler conclusively identified as unusable
+        # before either verification path can manufacture a successful result.
+        mounted, dinfo, mount_reason = bridge.is_mounted()
+        if mounted is False:
+            disk_type = dinfo["disk_type"]
+            details = {"disk_type": disk_type}
+            if "volume_node" in dinfo:
+                details["volume_node"] = dinfo["volume_node"]
+
+            if use_json:
+                print(json.dumps(_json_error(
+                    "verify", "NOT_MOUNTED",
+                    f"No usable volume mounted: {mount_reason}",
+                    details=details,
+                )))
+                sys.exit(1)
+            print("Volume: (none)")
+            print(f"  Filesystem responsive: NO -- {mount_reason}")
+            print(f"  id_DiskType: 0x{disk_type:08x}")
+            sys.exit(1)
+
+        responsive_text = "yes"
+        if mounted is None:
+            responsive_text = f"unknown -- {mount_reason}"
+
         if file_path:
             # Verify a specific file
             normalized = "/" + file_path.lstrip("/")
@@ -3589,6 +3651,7 @@ def cmd_verify(args):
                 "exists": True,
                 "size": stat.get("size", 0),
                 "type": "dir" if stat.get("dir_type", 0) > 0 else "file",
+                "filesystem_responsive": mounted,
             }
             if expect_size is not None:
                 result_data["expected_size"] = expect_size
@@ -3601,6 +3664,7 @@ def cmd_verify(args):
                 print(f"  Exists: yes")
                 print(f"  Type: {result_data['type']}")
                 print(f"  Size: {stat.get('size', 0)}")
+                print(f"  Filesystem responsive: {responsive_text}")
                 if expect_size is not None:
                     match = "yes" if result_data["size_matches"] else "NO"
                     print(f"  Expected size: {expect_size} ({match})")
@@ -3624,7 +3688,7 @@ def cmd_verify(args):
                 "total_dirs": total_dirs,
                 "total_files": total_files,
                 "total_size_bytes": total_size,
-                "filesystem_responsive": True,
+                "filesystem_responsive": mounted,
             }
 
             if use_json:
@@ -3634,7 +3698,7 @@ def cmd_verify(args):
                 print(f"  Directories: {total_dirs}")
                 print(f"  Files: {total_files}")
                 print(f"  Total size: {total_size:,} bytes")
-                print(f"  Filesystem responsive: yes")
+                print(f"  Filesystem responsive: {responsive_text}")
     except SystemExit:
         raise
     except Exception as e:

--- a/amifuse/fuse_fs.py
+++ b/amifuse/fuse_fs.py
@@ -1270,7 +1270,19 @@ class HandlerBridge:
 
         Returns a dict containing num_blocks, num_blocks_used,
         bytes_per_block, disk_type, and volume_node.
-        Returns None if the handler doesn't respond.
+        Returns None if the handler doesn't respond or refuses the packet;
+        callers that need to tell those apart want _query_disk_info().
+        """
+        return self._query_disk_info()[0]
+
+    def _query_disk_info(self) -> Tuple[Optional[Dict], Optional[int]]:
+        """Send ACTION_DISK_INFO and return (info, res2).
+
+        A handler can decline this packet two ways, and they mean different
+        things. Silence (no reply at all) says nothing about the volume; an
+        explicit DOSFALSE reply carries a res2 error code that often does.
+        info is None in both cases, and res2 tells them apart: None for
+        silence, the DOS error code for a refusal.
         """
         with self._lock:
             # Allocate InfoDataStruct (9 LONGs = 36 bytes)
@@ -1281,9 +1293,15 @@ class HandlerBridge:
             self.launcher.send_disk_info(self.state, info_mem.addr)
             replies = self._run_until_replies()
 
-            if not replies or replies[-1][2] == 0:
+            if not replies:
                 self.vh.alloc.free_memory(info_mem)
-                return None
+                return None, None
+            if replies[-1][2] == 0:
+                # DOSFALSE: the handler answered, refusing the request. The
+                # InfoData buffer is not filled in, but res2 says why.
+                res2 = replies[-1][3]
+                self.vh.alloc.free_memory(info_mem)
+                return None, res2
 
             # Read InfoDataStruct fields (all LONGs at known offsets):
             # id_NumBlocks: 12, id_NumBlocksUsed: 16,
@@ -1301,7 +1319,7 @@ class HandlerBridge:
                 "bytes_per_block": bytes_per_block,
                 "disk_type": disk_type,
                 "volume_node": volume_node,
-            }
+            }, None
 
     # AmigaDOS id_DiskType sentinels meaning "no usable volume mounted"
     _UNMOUNTED_DISK_REASONS = {
@@ -1313,6 +1331,19 @@ class HandlerBridge:
     }
     # CrossDOS uses ID_MSDOS_DISK for successfully mounted volumes.
 
+    # res2 codes from a refused ACTION_DISK_INFO that positively identify an
+    # unusable volume. A handler can reject a disk this way instead of filling
+    # in an NDOS id_DiskType the way pfs3aio does. Only diagnostic codes belong
+    # here: any other refusal stays inconclusive rather than risk calling a
+    # healthy image broken.
+    _UNMOUNTED_DISK_ERRORS = {
+        225: "not a DOS disk",  # ERROR_NOT_A_DOS_DISK
+        226: "no disk present",  # ERROR_NO_DISK
+        218: "device not mounted",  # ERROR_DEVICE_NOT_MOUNTED
+    }
+    # ERROR_ACTION_NOT_KNOWN (209) means the handler does not implement this
+    # packet at all, which says nothing about the volume.
+
     def is_mounted(
             self) -> Tuple[Optional[bool], Optional[Dict], Optional[str]]:
         """Return the mount state, ACTION_DISK_INFO result, and reason.
@@ -1320,11 +1351,19 @@ class HandlerBridge:
         The state is None when the handler does not provide enough information
         to decide. Any nonzero type except a known unusable sentinel counts as
         mounted, allowing custom filesystem identifiers. id_VolumeNode can
-        confirm a mount when the type is zero.
+        confirm a mount when the type is zero. A handler that refuses the
+        packet outright is judged by its res2 error code instead, and the
+        returned InfoData is None in that case.
         """
-        info = self.get_disk_info()
+        info, res2 = self._query_disk_info()
         if not info:
-            return None, None, "handler did not report disk info"
+            if res2 is None:
+                return None, None, "handler did not report disk info"
+            reason = self._UNMOUNTED_DISK_ERRORS.get(res2)
+            if reason is not None:
+                return False, None, reason
+            return None, None, (
+                f"handler refused disk info with error {res2}")
 
         disk_type = info.get("disk_type", 0)
         reason = self._UNMOUNTED_DISK_REASONS.get(disk_type)
@@ -3613,10 +3652,14 @@ def cmd_verify(args):
         # before either verification path can manufacture a successful result.
         mounted, dinfo, mount_reason = bridge.is_mounted()
         if mounted is False:
-            disk_type = dinfo["disk_type"]
-            details = {"disk_type": disk_type}
-            if "volume_node" in dinfo:
-                details["volume_node"] = dinfo["volume_node"]
+            # dinfo is None when the handler refused ACTION_DISK_INFO outright.
+            # Report only what it actually told us: there is no id_DiskType to
+            # name in that case.
+            details = {}
+            if dinfo is not None:
+                details["disk_type"] = dinfo["disk_type"]
+                if "volume_node" in dinfo:
+                    details["volume_node"] = dinfo["volume_node"]
 
             if use_json:
                 print(json.dumps(_json_error(
@@ -3627,7 +3670,8 @@ def cmd_verify(args):
                 sys.exit(1)
             print("Volume: (none)")
             print(f"  Filesystem responsive: NO -- {mount_reason}")
-            print(f"  id_DiskType: 0x{disk_type:08x}")
+            if dinfo is not None:
+                print(f"  id_DiskType: 0x{dinfo['disk_type']:08x}")
             sys.exit(1)
 
         responsive_text = "yes"

--- a/amifuse/fuse_fs.py
+++ b/amifuse/fuse_fs.py
@@ -87,6 +87,24 @@ ERROR_DIR_NOT_FOUND = 204
 ERROR_OBJECT_NOT_FOUND = 205
 _NOT_FOUND_ERRORS = frozenset({ERROR_DIR_NOT_FOUND, ERROR_OBJECT_NOT_FOUND})
 
+# AmigaDOS error codes a handler can return when it refuses ACTION_DISK_INFO.
+# ERROR_ACTION_NOT_KNOWN is deliberately absent from the unmounted set in
+# HandlerBridge._UNMOUNTED_DISK_ERRORS: it means the handler does not
+# implement the packet, which says nothing about the volume.
+ERROR_ACTION_NOT_KNOWN = 209
+ERROR_DEVICE_NOT_MOUNTED = 218
+ERROR_NOT_A_DOS_DISK = 225
+ERROR_NO_DISK = 226
+
+# id_DiskType values from dos/dos.h. ID_MSDOS_DISK is not an unusable disk:
+# CrossDOS reports it for a volume it has successfully mounted.
+ID_NO_DISK_PRESENT = 0xFFFFFFFF  # -1
+ID_UNREADABLE_DISK = 0x42414400  # 'BAD\0'
+ID_NOT_REALLY_DOS = 0x4E444F53  # 'NDOS'
+ID_KICKSTART_DISK = 0x4B49434B  # 'KICK'
+ID_MSDOS_DISK = 0x4D534400  # 'MSD\0'
+ID_BUSY = 0x42555359  # 'BUSY'
+
 # Upper bound for the path-keyed metadata caches. They are TTL-based but
 # otherwise unbounded, so a full traversal of a huge image would pin every
 # path in memory for the TTL. Entries are inserted in timestamp order, so
@@ -1323,13 +1341,12 @@ class HandlerBridge:
 
     # AmigaDOS id_DiskType sentinels meaning "no usable volume mounted"
     _UNMOUNTED_DISK_REASONS = {
-        0xFFFFFFFF: "no disk present",  # ID_NO_DISK_PRESENT (-1)
-        0x42414400: "unreadable disk",  # ID_UNREADABLE_DISK 'BAD\0'
-        0x4E444F53: "not a DOS disk",  # ID_NOT_REALLY_DOS 'NDOS'
-        0x42555359: "disk busy or inhibited",  # ID_BUSY 'BUSY'
-        0x4B49434B: "Kickstart disk has no DOS volume",  # ID_KICKSTART_DISK
+        ID_NO_DISK_PRESENT: "no disk present",
+        ID_UNREADABLE_DISK: "unreadable disk",
+        ID_NOT_REALLY_DOS: "not a DOS disk",
+        ID_BUSY: "disk busy or inhibited",
+        ID_KICKSTART_DISK: "Kickstart disk has no DOS volume",
     }
-    # CrossDOS uses ID_MSDOS_DISK for successfully mounted volumes.
 
     # res2 codes from a refused ACTION_DISK_INFO that positively identify an
     # unusable volume. A handler can reject a disk this way instead of filling
@@ -1337,12 +1354,10 @@ class HandlerBridge:
     # here: any other refusal stays inconclusive rather than risk calling a
     # healthy image broken.
     _UNMOUNTED_DISK_ERRORS = {
-        225: "not a DOS disk",  # ERROR_NOT_A_DOS_DISK
-        226: "no disk present",  # ERROR_NO_DISK
-        218: "device not mounted",  # ERROR_DEVICE_NOT_MOUNTED
+        ERROR_NOT_A_DOS_DISK: "not a DOS disk",
+        ERROR_NO_DISK: "no disk present",
+        ERROR_DEVICE_NOT_MOUNTED: "device not mounted",
     }
-    # ERROR_ACTION_NOT_KNOWN (209) means the handler does not implement this
-    # packet at all, which says nothing about the volume.
 
     def is_mounted(
             self) -> Tuple[Optional[bool], Optional[Dict], Optional[str]]:
@@ -3668,7 +3683,12 @@ def cmd_verify(args):
                     details=details,
                 )))
                 sys.exit(1)
-            print("Volume: (none)")
+            # Keep the diagnosis attached to what the user actually asked
+            # about, so --file does not get a bare volume-shaped report.
+            if file_path:
+                print(f"File: {file_path}")
+            else:
+                print("Volume: (none)")
             print(f"  Filesystem responsive: NO -- {mount_reason}")
             if dinfo is not None:
                 print(f"  id_DiskType: 0x{dinfo['disk_type']:08x}")
@@ -3683,10 +3703,20 @@ def cmd_verify(args):
             normalized = "/" + file_path.lstrip("/")
             stat = bridge.stat_path(normalized)
             if stat is None:
+                # A missing file on a volume whose mount could not be
+                # confirmed is a different situation from a missing file on
+                # a healthy volume. Carry the mount state so the error path
+                # stays as informative as the success path below.
+                details = {"filesystem_responsive": mounted}
+                if mounted is None:
+                    details["mount_state_reason"] = mount_reason
                 if use_json:
                     print(json.dumps(_json_error("verify", "FILE_NOT_FOUND",
-                        f"File not found: {file_path}")))
+                        f"File not found: {file_path}", details=details)))
                     sys.exit(1)
+                print(f"File: {file_path}")
+                print(f"  Exists: no")
+                print(f"  Filesystem responsive: {responsive_text}")
                 raise SystemExit(f"Error: file not found: {file_path}")
 
             result_data = {

--- a/amifuse/fuse_fs.py
+++ b/amifuse/fuse_fs.py
@@ -16,7 +16,7 @@ import threading
 import time
 
 from pathlib import Path
-from typing import Dict, List, Optional, Set, Tuple
+from typing import Dict, List, NamedTuple, Optional, Set, Tuple
 
 from .platform import kill_mount_owner_processes
 
@@ -104,6 +104,23 @@ ID_NOT_REALLY_DOS = 0x4E444F53  # 'NDOS'
 ID_KICKSTART_DISK = 0x4B49434B  # 'KICK'
 ID_MSDOS_DISK = 0x4D534400  # 'MSD\0'
 ID_BUSY = 0x42555359  # 'BUSY'
+
+
+class MountState(NamedTuple):
+    """What HandlerBridge.is_mounted() concluded, and what it saw.
+
+    Attribute access rather than unpacking: this result has grown a field
+    twice now, and each time every call site and test mock had to change.
+
+    mounted is None when the handler gave too little to decide. info is the
+    ACTION_DISK_INFO payload, absent when the handler refused the packet
+    rather than answering it -- in which case dos_error carries the res2
+    code that produced the verdict.
+    """
+    mounted: Optional[bool]
+    info: Optional[Dict]
+    reason: Optional[str]
+    dos_error: Optional[int] = None
 
 # Upper bound for the path-keyed metadata caches. They are TTL-based but
 # otherwise unbounded, so a full traversal of a huge image would pin every
@@ -1359,9 +1376,8 @@ class HandlerBridge:
         ERROR_DEVICE_NOT_MOUNTED: "device not mounted",
     }
 
-    def is_mounted(
-            self) -> Tuple[Optional[bool], Optional[Dict], Optional[str]]:
-        """Return the mount state, ACTION_DISK_INFO result, and reason.
+    def is_mounted(self) -> MountState:
+        """Decide whether a usable volume is mounted.
 
         The state is None when the handler does not provide enough information
         to decide. Any nonzero type except a known unusable sentinel counts as
@@ -1373,22 +1389,25 @@ class HandlerBridge:
         info, res2 = self._query_disk_info()
         if not info:
             if res2 is None:
-                return None, None, "handler did not report disk info"
+                return MountState(
+                    None, None, "handler did not report disk info")
             reason = self._UNMOUNTED_DISK_ERRORS.get(res2)
             if reason is not None:
-                return False, None, reason
-            return None, None, (
-                f"handler refused disk info with error {res2}")
+                return MountState(False, None, reason, res2)
+            return MountState(
+                None, None,
+                f"handler refused disk info with error {res2}", res2)
 
         disk_type = info.get("disk_type", 0)
         reason = self._UNMOUNTED_DISK_REASONS.get(disk_type)
         if reason is not None:
-            return False, info, reason
+            return MountState(False, info, reason)
         if disk_type != 0:
-            return True, info, None
+            return MountState(True, info, None)
         if info.get("volume_node", 0) != 0:
-            return True, info, None
-        return None, info, "handler reported no disk type or volume node"
+            return MountState(True, info, None)
+        return MountState(
+            None, info, "handler reported no disk type or volume node")
 
     def volume_name(self) -> str:
         """Best-effort name: RDB drive name, else first dir entry, else fallback."""
@@ -3376,18 +3395,41 @@ def _json_result(command: str, **kwargs) -> dict:
     return result
 
 
-def _mount_error_details(dinfo: Optional[Dict]) -> Dict:
+def _mount_error_details(state: "MountState") -> Dict:
     """Machine-readable details for a NOT_MOUNTED error envelope.
 
-    dinfo is None when the handler refused ACTION_DISK_INFO outright, in
-    which case there is no id_DiskType it actually reported and the details
-    stay empty rather than naming a value the handler never sent.
+    The two ways a volume can be rejected leave different evidence, and each
+    reports what it actually has. An InfoData reply carries the disk type the
+    handler named; a refusal carries only the res2 code that produced the
+    verdict. Reporting the res2 keeps the refusal branch machine-readable
+    instead of leaving prose in `message` as a consumer's only handle -- both
+    branches can yield the same reason string, so the distinction would
+    otherwise be invisible.
+
+    Every key is read defensively: this feeds an error path, and a KeyError
+    here would be swallowed by the caller's blanket `except Exception` and
+    reported as HANDLER_ERROR, hiding the diagnosis it was trying to give.
     """
     details = {}
-    if dinfo is not None:
-        details["disk_type"] = dinfo["disk_type"]
-        if "volume_node" in dinfo:
-            details["volume_node"] = dinfo["volume_node"]
+    if state.info is not None:
+        for key in ("disk_type", "volume_node"):
+            if key in state.info:
+                details[key] = state.info[key]
+    if state.dos_error is not None:
+        details["dos_error"] = state.dos_error
+    return details
+
+
+def _mount_state_details(state: "MountState") -> Dict:
+    """Mount context for an error envelope raised on a mounted-enough volume.
+
+    A path that is missing on a volume whose mount could not be confirmed is
+    a different situation from one missing on a healthy volume, and the two
+    otherwise emit byte-identical envelopes.
+    """
+    details = {"filesystem_responsive": state.mounted}
+    if state.mounted is None:
+        details["mount_state_reason"] = state.reason
     return details
 
 
@@ -3612,13 +3654,14 @@ def cmd_ls(args):
         # skipped at the root (path != "/"), and -R bypasses it entirely --
         # so without this guard the default `amifuse ls image.hdf` reports an
         # unmountable image as an empty volume and exits 0.
-        mounted, dinfo, mount_reason = bridge.is_mounted()
+        state = bridge.is_mounted()
+        mounted, mount_reason = state.mounted, state.reason
         if mounted is False:
             if use_json:
                 print(json.dumps(_json_error(
                     "ls", "NOT_MOUNTED",
                     f"No usable volume mounted: {mount_reason}",
-                    details=_mount_error_details(dinfo),
+                    details=_mount_error_details(state),
                 )))
                 sys.exit(1)
             raise SystemExit(
@@ -3632,10 +3675,18 @@ def cmd_ls(args):
                 # Path might not exist -- try stat to distinguish
                 stat = bridge.stat_path(path)
                 if stat is None:
+                    # On an unmountable volume no path resolves, so this
+                    # branch is reachable for exactly the condition the check
+                    # above exists for. Carry the mount state, or a missing
+                    # directory on a healthy volume looks identical.
+                    details = _mount_state_details(state)
                     if use_json:
                         print(json.dumps(_json_error("ls", "FILE_NOT_FOUND",
-                            f"Path not found: {path}")))
+                            f"Path not found: {path}", details=details)))
                         sys.exit(1)
+                    if mounted is None:
+                        print(f"Warning: mount state unknown -- {mount_reason}",
+                              file=sys.stderr)
                     raise SystemExit(f"Error: path not found: {path}")
             entries = []
             for ent in raw:
@@ -3704,14 +3755,14 @@ def cmd_verify(args):
     try:
         # Reject a disk that the handler conclusively identified as unusable
         # before either verification path can manufacture a successful result.
-        mounted, dinfo, mount_reason = bridge.is_mounted()
+        state = bridge.is_mounted()
+        mounted, mount_reason = state.mounted, state.reason
         if mounted is False:
-            details = _mount_error_details(dinfo)
             if use_json:
                 print(json.dumps(_json_error(
                     "verify", "NOT_MOUNTED",
                     f"No usable volume mounted: {mount_reason}",
-                    details=details,
+                    details=_mount_error_details(state),
                 )))
                 sys.exit(1)
             # Keep the diagnosis attached to what the user actually asked
@@ -3721,8 +3772,14 @@ def cmd_verify(args):
             else:
                 print("Volume: (none)")
             print(f"  Filesystem responsive: NO -- {mount_reason}")
-            if dinfo is not None:
-                print(f"  id_DiskType: 0x{dinfo['disk_type']:08x}")
+            if state.info is not None and "disk_type" in state.info:
+                print(f"  id_DiskType: 0x{state.info['disk_type']:08x}")
+            # The report belongs on stdout, but every other error path in
+            # this file puts its reason on stderr. Echo it so that
+            # `verify image.hdf 2>&1 >/dev/null` is not silent for exactly
+            # the condition this check exists to surface.
+            print(f"Error: no usable volume mounted: {mount_reason}",
+                  file=sys.stderr)
             sys.exit(1)
 
         responsive_text = "yes"
@@ -3738,9 +3795,7 @@ def cmd_verify(args):
                 # confirmed is a different situation from a missing file on
                 # a healthy volume. Carry the mount state so the error path
                 # stays as informative as the success path below.
-                details = {"filesystem_responsive": mounted}
-                if mounted is None:
-                    details["mount_state_reason"] = mount_reason
+                details = _mount_state_details(state)
                 if use_json:
                     print(json.dumps(_json_error("verify", "FILE_NOT_FOUND",
                         f"File not found: {file_path}", details=details)))

--- a/tests/unit/test_fuse_fs.py
+++ b/tests/unit/test_fuse_fs.py
@@ -1783,6 +1783,99 @@ class TestCmdLs:
 
 
 # ---------------------------------------------------------------------------
+# TestHandlerBridgeMountState -- mounted-volume checks
+# ---------------------------------------------------------------------------
+
+
+class TestHandlerBridgeMountState:
+    """Tests for HandlerBridge.is_mounted()."""
+
+    @staticmethod
+    def _mount_state(fuse_fs_mod, info):
+        bridge = object.__new__(fuse_fs_mod.HandlerBridge)
+        bridge.get_disk_info = MagicMock(return_value=info)
+        return bridge.is_mounted()
+
+    def test_missing_disk_info_is_inconclusive(self, fuse_mock):
+        import amifuse.fuse_fs as fuse_fs_mod
+
+        mounted, info, reason = self._mount_state(fuse_fs_mod, None)
+
+        assert mounted is None
+        assert info is None
+        assert reason == "handler did not report disk info"
+
+    @pytest.mark.parametrize(("disk_type", "expected_reason"), [
+        (0xFFFFFFFF, "no disk present"),
+        (0x42414400, "unreadable disk"),
+        (0x4E444F53, "not a DOS disk"),
+        (0x42555359, "disk busy or inhibited"),
+        (0x4B49434B, "Kickstart disk has no DOS volume"),
+    ])
+    def test_unusable_disk_type_is_not_mounted(
+            self, fuse_mock, disk_type, expected_reason):
+        import amifuse.fuse_fs as fuse_fs_mod
+
+        disk_info = {"disk_type": disk_type, "volume_node": 1}
+        mounted, info, reason = self._mount_state(fuse_fs_mod, disk_info)
+
+        assert mounted is False
+        assert info is disk_info
+        assert reason == expected_reason
+
+    def test_disk_type_is_authoritative_without_volume_node(self, fuse_mock):
+        import amifuse.fuse_fs as fuse_fs_mod
+
+        disk_info = {"disk_type": 0x50465303, "volume_node": 0}
+        mounted, info, reason = self._mount_state(fuse_fs_mod, disk_info)
+
+        assert mounted is True
+        assert info is disk_info
+        assert reason is None
+
+    def test_msdos_disk_type_can_be_mounted(self, fuse_mock):
+        import amifuse.fuse_fs as fuse_fs_mod
+
+        disk_info = {"disk_type": 0x4D534400, "volume_node": 0}
+        mounted, info, reason = self._mount_state(fuse_fs_mod, disk_info)
+
+        assert mounted is True
+        assert info is disk_info
+        assert reason is None
+
+    def test_unknown_disk_type_and_volume_node_is_inconclusive(
+            self, fuse_mock):
+        import amifuse.fuse_fs as fuse_fs_mod
+
+        disk_info = {"disk_type": 0, "volume_node": 0}
+        mounted, info, reason = self._mount_state(fuse_fs_mod, disk_info)
+
+        assert mounted is None
+        assert info is disk_info
+        assert reason == "handler reported no disk type or volume node"
+
+    def test_volume_node_confirms_unknown_disk_type(self, fuse_mock):
+        import amifuse.fuse_fs as fuse_fs_mod
+
+        disk_info = {"disk_type": 0, "volume_node": 1}
+        mounted, info, reason = self._mount_state(fuse_fs_mod, disk_info)
+
+        assert mounted is True
+        assert info is disk_info
+        assert reason is None
+
+    def test_valid_volume_is_mounted(self, fuse_mock):
+        import amifuse.fuse_fs as fuse_fs_mod
+
+        disk_info = {"disk_type": 0x50465303, "volume_node": 1}
+        mounted, info, reason = self._mount_state(fuse_fs_mod, disk_info)
+
+        assert mounted is True
+        assert info is disk_info
+        assert reason is None
+
+
+# ---------------------------------------------------------------------------
 # TestCmdVerify -- verify command tests
 # ---------------------------------------------------------------------------
 
@@ -1796,6 +1889,9 @@ class TestCmdVerify:
         import amifuse.fuse_fs as fuse_fs_mod
 
         mock_bridge = MagicMock()
+        mock_bridge.is_mounted.return_value = (
+            True, {"disk_type": 0x50465303, "volume_node": 1}, None,
+        )
         monkeypatch.setattr(
             fuse_fs_mod, "_create_bridge_from_args",
             lambda args, cmd, read_only=True: (mock_bridge, None),
@@ -1827,6 +1923,7 @@ class TestCmdVerify:
         assert data["exists"] is True
         assert data["size"] == 1234
         assert data["type"] == "file"
+        assert data["filesystem_responsive"] is True
 
     def test_verify_file_size_match(self, mock_bridge_for_verify, capsys):
         mock_bridge, fuse_fs_mod = mock_bridge_for_verify
@@ -1936,6 +2033,176 @@ class TestCmdVerify:
         assert data["total_files"] == 3
         assert data["total_size_bytes"] == 350
         assert data["filesystem_responsive"] is True
+
+    def test_verify_unmounted_volume_json(self, mock_bridge_for_verify, capsys):
+        mock_bridge, fuse_fs_mod = mock_bridge_for_verify
+        mock_bridge.is_mounted.return_value = (
+            False, {"disk_type": 0x4E444F53, "volume_node": 0},
+            "not a DOS disk",
+        )
+
+        args = argparse.Namespace(
+            image=Path("/fake/test.hdf"),
+            json=True,
+            file=None,
+            expect_size=None,
+            partition=None,
+            driver=None,
+            block_size=None,
+            debug=False,
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            fuse_fs_mod.cmd_verify(args)
+        output = capsys.readouterr().out
+        data = json.loads(output)
+
+        assert exc_info.value.code == 1
+        assert data["error"]["code"] == "NOT_MOUNTED"
+        assert "not a DOS disk" in data["error"]["message"]
+        assert data["error"]["details"] == {
+            "disk_type": 0x4E444F53,
+            "volume_node": 0,
+        }
+        mock_bridge.stat_path.assert_not_called()
+        mock_bridge.list_dir_path.assert_not_called()
+        mock_bridge.volume_name.assert_not_called()
+
+    def test_verify_unmounted_volume_human(self, mock_bridge_for_verify, capsys):
+        mock_bridge, fuse_fs_mod = mock_bridge_for_verify
+        mock_bridge.is_mounted.return_value = (
+            False, {"disk_type": 0x42414400, "volume_node": 0},
+            "unreadable disk",
+        )
+
+        args = argparse.Namespace(
+            image=Path("/fake/test.hdf"),
+            json=False,
+            file=None,
+            expect_size=None,
+            partition=None,
+            driver=None,
+            block_size=None,
+            debug=False,
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            fuse_fs_mod.cmd_verify(args)
+        output = capsys.readouterr().out
+
+        assert exc_info.value.code == 1
+        assert "Volume: (none)" in output
+        assert "Filesystem responsive: NO" in output
+        assert "unreadable disk" in output
+        assert "id_DiskType: 0x42414400" in output
+        mock_bridge.stat_path.assert_not_called()
+        mock_bridge.list_dir_path.assert_not_called()
+        mock_bridge.volume_name.assert_not_called()
+
+    def test_verify_unmounted_file_json(self, mock_bridge_for_verify, capsys):
+        mock_bridge, fuse_fs_mod = mock_bridge_for_verify
+        mock_bridge.is_mounted.return_value = (
+            False, {"disk_type": 0x4E444F53, "volume_node": 0},
+            "not a DOS disk",
+        )
+
+        args = argparse.Namespace(
+            image=Path("/fake/test.hdf"),
+            json=True,
+            file="/",
+            expect_size=None,
+            partition=None,
+            driver=None,
+            block_size=None,
+            debug=False,
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            fuse_fs_mod.cmd_verify(args)
+        output = capsys.readouterr().out
+        data = json.loads(output)
+
+        assert exc_info.value.code == 1
+        assert data["error"]["code"] == "NOT_MOUNTED"
+        mock_bridge.stat_path.assert_not_called()
+
+    def test_verify_unknown_mount_status_is_reported_for_file_json(
+            self, mock_bridge_for_verify, capsys):
+        mock_bridge, fuse_fs_mod = mock_bridge_for_verify
+        mock_bridge.is_mounted.return_value = (
+            None, None, "handler did not report disk info",
+        )
+        mock_bridge.stat_path.return_value = {
+            "dir_type": 2, "size": 0, "name": "",
+            "protection": 0,
+        }
+
+        args = argparse.Namespace(
+            image=Path("/fake/test.hdf"),
+            json=True,
+            file="/",
+            expect_size=None,
+            partition=None,
+            driver=None,
+            block_size=None,
+            debug=False,
+        )
+        fuse_fs_mod.cmd_verify(args)
+        output = capsys.readouterr().out
+        data = json.loads(output)
+
+        assert data["status"] == "ok"
+        assert data["filesystem_responsive"] is None
+        mock_bridge.stat_path.assert_called_once_with("/")
+
+    def test_verify_unknown_mount_status_is_reported_for_volume_json(
+            self, mock_bridge_for_verify, capsys):
+        mock_bridge, fuse_fs_mod = mock_bridge_for_verify
+        mock_bridge.is_mounted.return_value = (
+            None, None, "handler did not report disk info",
+        )
+        mock_bridge.list_dir_path.return_value = []
+        mock_bridge.volume_name.return_value = "Unknown"
+
+        args = argparse.Namespace(
+            image=Path("/fake/test.hdf"),
+            json=True,
+            file=None,
+            expect_size=None,
+            partition=None,
+            driver=None,
+            block_size=None,
+            debug=False,
+        )
+        fuse_fs_mod.cmd_verify(args)
+        output = capsys.readouterr().out
+        data = json.loads(output)
+
+        assert data["status"] == "ok"
+        assert data["filesystem_responsive"] is None
+
+    def test_verify_unknown_mount_status_is_reported_for_file_human(
+            self, mock_bridge_for_verify, capsys):
+        mock_bridge, fuse_fs_mod = mock_bridge_for_verify
+        mock_bridge.is_mounted.return_value = (
+            None, None, "handler did not report disk info",
+        )
+        mock_bridge.stat_path.return_value = {
+            "dir_type": 2, "size": 0, "name": "", "protection": 0,
+        }
+
+        args = argparse.Namespace(
+            image=Path("/fake/test.hdf"),
+            json=False,
+            file="/",
+            expect_size=None,
+            partition=None,
+            driver=None,
+            block_size=None,
+            debug=False,
+        )
+        fuse_fs_mod.cmd_verify(args)
+        output = capsys.readouterr().out
+
+        assert "Filesystem responsive: unknown" in output
+        assert "handler did not report disk info" in output
 
     def test_verify_expect_size_without_file_json(self, fuse_mock, capsys):
         import amifuse.fuse_fs as fuse_fs_mod

--- a/tests/unit/test_fuse_fs.py
+++ b/tests/unit/test_fuse_fs.py
@@ -43,8 +43,10 @@ def _make_mock_bridge():
 
     The default is a healthy, mounted PFS volume; tests that care override it.
     """
+    import amifuse.fuse_fs as fuse_fs_mod
+
     bridge = MagicMock()
-    bridge.is_mounted.return_value = (
+    bridge.is_mounted.return_value = fuse_fs_mod.MountState(
         True, {"disk_type": 0x50465303, "volume_node": 1}, None,
     )
     return bridge
@@ -1667,7 +1669,7 @@ class TestCmdLs:
     def test_ls_unmounted_root_json(self, mock_bridge_for_ls, capsys):
         """The default `amifuse ls image.hdf` must not report an empty volume."""
         mock_bridge, fuse_fs_mod = mock_bridge_for_ls
-        mock_bridge.is_mounted.return_value = (
+        mock_bridge.is_mounted.return_value = fuse_fs_mod.MountState(
             False, {"disk_type": 0x4E444F53, "volume_node": 0},
             "not a DOS disk",
         )
@@ -1687,7 +1689,7 @@ class TestCmdLs:
     def test_ls_unmounted_recursive_json(self, mock_bridge_for_ls, capsys):
         """-R bypassed the stat fallback entirely, so it needs the guard too."""
         mock_bridge, fuse_fs_mod = mock_bridge_for_ls
-        mock_bridge.is_mounted.return_value = (
+        mock_bridge.is_mounted.return_value = fuse_fs_mod.MountState(
             False, {"disk_type": 0x4E444F53, "volume_node": 0},
             "not a DOS disk",
         )
@@ -1701,7 +1703,7 @@ class TestCmdLs:
 
     def test_ls_unmounted_human_exits_nonzero(self, mock_bridge_for_ls, capsys):
         mock_bridge, fuse_fs_mod = mock_bridge_for_ls
-        mock_bridge.is_mounted.return_value = (
+        mock_bridge.is_mounted.return_value = fuse_fs_mod.MountState(
             False, None, "no disk present",
         )
 
@@ -1712,21 +1714,59 @@ class TestCmdLs:
         assert "no usable volume mounted" in str(exc_info.value.code)
         assert "no disk present" in str(exc_info.value.code)
 
-    def test_ls_refused_disk_info_omits_disk_type(self, mock_bridge_for_ls, capsys):
+    def test_ls_refused_disk_info_reports_dos_error(self, mock_bridge_for_ls, capsys):
+        """A refusal has no id_DiskType, so res2 is the machine-readable handle."""
         mock_bridge, fuse_fs_mod = mock_bridge_for_ls
-        mock_bridge.is_mounted.return_value = (False, None, "not a DOS disk")
+        mock_bridge.is_mounted.return_value = fuse_fs_mod.MountState(
+            False, None, "not a DOS disk", 225)
 
         with pytest.raises(SystemExit):
             fuse_fs_mod.cmd_ls(self._ls_args())
         data = json.loads(capsys.readouterr().out)
 
         assert data["error"]["code"] == "NOT_MOUNTED"
-        assert "details" not in data["error"]
+        assert data["error"]["details"] == {"dos_error": 225}
+        # The two provenances yield the same reason string, so details is
+        # what tells a consumer which one it got
+        assert "disk_type" not in data["error"]["details"]
+
+    def test_ls_path_not_found_carries_unknown_mount_state(
+            self, mock_bridge_for_ls, capsys):
+        """A missing path on an unconfirmed volume must not look healthy."""
+        mock_bridge, fuse_fs_mod = mock_bridge_for_ls
+        mock_bridge.is_mounted.return_value = fuse_fs_mod.MountState(
+            None, None, "handler did not report disk info")
+        mock_bridge.list_dir_path.return_value = []
+        mock_bridge.stat_path.return_value = None
+
+        with pytest.raises(SystemExit) as exc_info:
+            fuse_fs_mod.cmd_ls(self._ls_args(path="S"))
+        data = json.loads(capsys.readouterr().out)
+
+        assert exc_info.value.code == 1
+        assert data["error"]["code"] == "FILE_NOT_FOUND"
+        assert data["error"]["details"]["filesystem_responsive"] is None
+        assert data["error"]["details"]["mount_state_reason"] == (
+            "handler did not report disk info")
+
+    def test_ls_path_not_found_on_healthy_volume_is_distinguishable(
+            self, mock_bridge_for_ls, capsys):
+        mock_bridge, fuse_fs_mod = mock_bridge_for_ls
+        mock_bridge.list_dir_path.return_value = []
+        mock_bridge.stat_path.return_value = None
+
+        with pytest.raises(SystemExit):
+            fuse_fs_mod.cmd_ls(self._ls_args(path="S"))
+        data = json.loads(capsys.readouterr().out)
+
+        assert data["error"]["code"] == "FILE_NOT_FOUND"
+        assert data["error"]["details"]["filesystem_responsive"] is True
+        assert "mount_state_reason" not in data["error"]["details"]
 
     def test_ls_unknown_mount_state_json(self, mock_bridge_for_ls, capsys):
         """An inconclusive mount is reported, but still lists and exits 0."""
         mock_bridge, fuse_fs_mod = mock_bridge_for_ls
-        mock_bridge.is_mounted.return_value = (
+        mock_bridge.is_mounted.return_value = fuse_fs_mod.MountState(
             None, None, "handler did not report disk info",
         )
         mock_bridge.list_dir_path.return_value = []
@@ -1741,7 +1781,7 @@ class TestCmdLs:
     def test_ls_unknown_mount_state_warns_on_empty_human(
             self, mock_bridge_for_ls, capsys):
         mock_bridge, fuse_fs_mod = mock_bridge_for_ls
-        mock_bridge.is_mounted.return_value = (
+        mock_bridge.is_mounted.return_value = fuse_fs_mod.MountState(
             None, None, "handler did not report disk info",
         )
         mock_bridge.list_dir_path.return_value = []
@@ -2069,11 +2109,11 @@ class TestQueryDiskInfo:
         import amifuse.fuse_fs as fuse_fs_mod
 
         mem_bridge = self._query(fuse_fs_mod, monkeypatch, [(0, 0x9999, 0, 225)])[1]
-        mounted, info, reason = mem_bridge.is_mounted()
+        state = mem_bridge.is_mounted()
 
-        assert mounted is False
-        assert info is None
-        assert reason == "not a DOS disk"
+        assert state.mounted is False
+        assert state.info is None
+        assert state.reason == "not a DOS disk"
 
     def test_end_to_end_ndos_disk_type_is_not_mounted(self, fuse_mock, monkeypatch):
         """An NDOS id_DiskType read from offset 24 drives the same verdict."""
@@ -2081,11 +2121,11 @@ class TestQueryDiskInfo:
 
         fields = dict(self.PLANTED, id_DiskType=0x4E444F53)
         mem_bridge = self._query(fuse_fs_mod, monkeypatch, [(0, 0x9999, 1, 0)], fields)[1]
-        mounted, info, reason = mem_bridge.is_mounted()
+        state = mem_bridge.is_mounted()
 
-        assert mounted is False
-        assert info["disk_type"] == 0x4E444F53
-        assert reason == "not a DOS disk"
+        assert state.mounted is False
+        assert state.info["disk_type"] == 0x4E444F53
+        assert state.reason == "not a DOS disk"
 
 
 # ---------------------------------------------------------------------------
@@ -2105,11 +2145,11 @@ class TestHandlerBridgeMountState:
     def test_missing_disk_info_is_inconclusive(self, fuse_mock):
         import amifuse.fuse_fs as fuse_fs_mod
 
-        mounted, info, reason = self._mount_state(fuse_fs_mod, None)
+        state = self._mount_state(fuse_fs_mod, None)
 
-        assert mounted is None
-        assert info is None
-        assert reason == "handler did not report disk info"
+        assert state.mounted is None
+        assert state.info is None
+        assert state.reason == "handler did not report disk info"
 
     @pytest.mark.parametrize(("disk_type", "expected_reason"), [
         (0xFFFFFFFF, "no disk present"),
@@ -2123,62 +2163,62 @@ class TestHandlerBridgeMountState:
         import amifuse.fuse_fs as fuse_fs_mod
 
         disk_info = {"disk_type": disk_type, "volume_node": 1}
-        mounted, info, reason = self._mount_state(fuse_fs_mod, disk_info)
+        state = self._mount_state(fuse_fs_mod, disk_info)
 
-        assert mounted is False
-        assert info is disk_info
-        assert reason == expected_reason
+        assert state.mounted is False
+        assert state.info is disk_info
+        assert state.reason == expected_reason
 
     def test_disk_type_is_authoritative_without_volume_node(self, fuse_mock):
         import amifuse.fuse_fs as fuse_fs_mod
 
         disk_info = {"disk_type": 0x50465303, "volume_node": 0}
-        mounted, info, reason = self._mount_state(fuse_fs_mod, disk_info)
+        state = self._mount_state(fuse_fs_mod, disk_info)
 
-        assert mounted is True
-        assert info is disk_info
-        assert reason is None
+        assert state.mounted is True
+        assert state.info is disk_info
+        assert state.reason is None
 
     def test_msdos_disk_type_can_be_mounted(self, fuse_mock):
         import amifuse.fuse_fs as fuse_fs_mod
 
         disk_info = {"disk_type": 0x4D534400, "volume_node": 0}
-        mounted, info, reason = self._mount_state(fuse_fs_mod, disk_info)
+        state = self._mount_state(fuse_fs_mod, disk_info)
 
-        assert mounted is True
-        assert info is disk_info
-        assert reason is None
+        assert state.mounted is True
+        assert state.info is disk_info
+        assert state.reason is None
 
     def test_unknown_disk_type_and_volume_node_is_inconclusive(
             self, fuse_mock):
         import amifuse.fuse_fs as fuse_fs_mod
 
         disk_info = {"disk_type": 0, "volume_node": 0}
-        mounted, info, reason = self._mount_state(fuse_fs_mod, disk_info)
+        state = self._mount_state(fuse_fs_mod, disk_info)
 
-        assert mounted is None
-        assert info is disk_info
-        assert reason == "handler reported no disk type or volume node"
+        assert state.mounted is None
+        assert state.info is disk_info
+        assert state.reason == "handler reported no disk type or volume node"
 
     def test_volume_node_confirms_unknown_disk_type(self, fuse_mock):
         import amifuse.fuse_fs as fuse_fs_mod
 
         disk_info = {"disk_type": 0, "volume_node": 1}
-        mounted, info, reason = self._mount_state(fuse_fs_mod, disk_info)
+        state = self._mount_state(fuse_fs_mod, disk_info)
 
-        assert mounted is True
-        assert info is disk_info
-        assert reason is None
+        assert state.mounted is True
+        assert state.info is disk_info
+        assert state.reason is None
 
     def test_valid_volume_is_mounted(self, fuse_mock):
         import amifuse.fuse_fs as fuse_fs_mod
 
         disk_info = {"disk_type": 0x50465303, "volume_node": 1}
-        mounted, info, reason = self._mount_state(fuse_fs_mod, disk_info)
+        state = self._mount_state(fuse_fs_mod, disk_info)
 
-        assert mounted is True
-        assert info is disk_info
-        assert reason is None
+        assert state.mounted is True
+        assert state.info is disk_info
+        assert state.reason is None
 
     @pytest.mark.parametrize(("res2", "expected_reason"), [
         (225, "not a DOS disk"),  # ERROR_NOT_A_DOS_DISK
@@ -2190,41 +2230,41 @@ class TestHandlerBridgeMountState:
         """A DOSFALSE reply naming an unusable volume is a negative answer."""
         import amifuse.fuse_fs as fuse_fs_mod
 
-        mounted, info, reason = self._mount_state(fuse_fs_mod, None, res2)
+        state = self._mount_state(fuse_fs_mod, None, res2)
 
-        assert mounted is False
-        assert info is None
-        assert reason == expected_reason
+        assert state.mounted is False
+        assert state.info is None
+        assert state.reason == expected_reason
 
     def test_unimplemented_packet_is_inconclusive(self, fuse_mock):
         """ERROR_ACTION_NOT_KNOWN says nothing about the volume."""
         import amifuse.fuse_fs as fuse_fs_mod
 
-        mounted, info, reason = self._mount_state(fuse_fs_mod, None, 209)
+        state = self._mount_state(fuse_fs_mod, None, 209)
 
-        assert mounted is None
-        assert info is None
-        assert "209" in reason
+        assert state.mounted is None
+        assert state.info is None
+        assert "209" in state.reason
 
     def test_refusal_with_unknown_error_is_inconclusive(self, fuse_mock):
         """An undiagnostic refusal must not condemn a possibly healthy image."""
         import amifuse.fuse_fs as fuse_fs_mod
 
-        mounted, info, reason = self._mount_state(fuse_fs_mod, None, 202)
+        state = self._mount_state(fuse_fs_mod, None, 202)
 
-        assert mounted is None
-        assert info is None
-        assert "202" in reason
+        assert state.mounted is None
+        assert state.info is None
+        assert "202" in state.reason
 
     def test_silence_is_distinct_from_refusal(self, fuse_mock):
         """No reply at all keeps the old inconclusive wording."""
         import amifuse.fuse_fs as fuse_fs_mod
 
-        mounted, info, reason = self._mount_state(fuse_fs_mod, None, None)
+        state = self._mount_state(fuse_fs_mod, None, None)
 
-        assert mounted is None
-        assert info is None
-        assert reason == "handler did not report disk info"
+        assert state.mounted is None
+        assert state.info is None
+        assert state.reason == "handler did not report disk info"
 
     def test_get_disk_info_returns_only_the_dict(self, fuse_mock):
         """The public accessor keeps its Optional[Dict] contract."""
@@ -2399,7 +2439,7 @@ class TestCmdVerify:
 
     def test_verify_unmounted_volume_json(self, mock_bridge_for_verify, capsys):
         mock_bridge, fuse_fs_mod = mock_bridge_for_verify
-        mock_bridge.is_mounted.return_value = (
+        mock_bridge.is_mounted.return_value = fuse_fs_mod.MountState(
             False, {"disk_type": 0x4E444F53, "volume_node": 0},
             "not a DOS disk",
         )
@@ -2432,7 +2472,7 @@ class TestCmdVerify:
 
     def test_verify_unmounted_volume_human(self, mock_bridge_for_verify, capsys):
         mock_bridge, fuse_fs_mod = mock_bridge_for_verify
-        mock_bridge.is_mounted.return_value = (
+        mock_bridge.is_mounted.return_value = fuse_fs_mod.MountState(
             False, {"disk_type": 0x42414400, "volume_node": 0},
             "unreadable disk",
         )
@@ -2461,9 +2501,10 @@ class TestCmdVerify:
         mock_bridge.volume_name.assert_not_called()
 
     def test_verify_refused_disk_info_json(self, mock_bridge_for_verify, capsys):
-        """A refusal has no InfoData, so no id_DiskType may be reported."""
+        """A refusal has no InfoData, so res2 stands in for id_DiskType."""
         mock_bridge, fuse_fs_mod = mock_bridge_for_verify
-        mock_bridge.is_mounted.return_value = (False, None, "not a DOS disk")
+        mock_bridge.is_mounted.return_value = fuse_fs_mod.MountState(
+            False, None, "not a DOS disk", 225)
 
         args = argparse.Namespace(
             image=Path("/fake/test.hdf"),
@@ -2483,14 +2524,15 @@ class TestCmdVerify:
         assert exc_info.value.code == 1
         assert data["error"]["code"] == "NOT_MOUNTED"
         assert "not a DOS disk" in data["error"]["message"]
-        # No InfoData was returned, so there is nothing to report in details
-        assert "details" not in data["error"]
+        # No InfoData, so no id_DiskType -- but res2 keeps the branch
+        # machine-readable rather than leaving only prose in the message
+        assert data["error"]["details"] == {"dos_error": 225}
         mock_bridge.stat_path.assert_not_called()
         mock_bridge.list_dir_path.assert_not_called()
 
     def test_verify_refused_disk_info_human(self, mock_bridge_for_verify, capsys):
         mock_bridge, fuse_fs_mod = mock_bridge_for_verify
-        mock_bridge.is_mounted.return_value = (False, None, "no disk present")
+        mock_bridge.is_mounted.return_value = fuse_fs_mod.MountState(False, None, "no disk present")
 
         args = argparse.Namespace(
             image=Path("/fake/test.hdf"),
@@ -2514,7 +2556,7 @@ class TestCmdVerify:
 
     def test_verify_unmounted_file_json(self, mock_bridge_for_verify, capsys):
         mock_bridge, fuse_fs_mod = mock_bridge_for_verify
-        mock_bridge.is_mounted.return_value = (
+        mock_bridge.is_mounted.return_value = fuse_fs_mod.MountState(
             False, {"disk_type": 0x4E444F53, "volume_node": 0},
             "not a DOS disk",
         )
@@ -2542,7 +2584,7 @@ class TestCmdVerify:
             self, mock_bridge_for_verify, capsys):
         """The diagnosis must stay attached to the file the user asked about."""
         mock_bridge, fuse_fs_mod = mock_bridge_for_verify
-        mock_bridge.is_mounted.return_value = (
+        mock_bridge.is_mounted.return_value = fuse_fs_mod.MountState(
             False, {"disk_type": 0x4E444F53, "volume_node": 0},
             "not a DOS disk",
         )
@@ -2570,7 +2612,7 @@ class TestCmdVerify:
             self, mock_bridge_for_verify, capsys):
         """FILE_NOT_FOUND must not look identical on a healthy volume."""
         mock_bridge, fuse_fs_mod = mock_bridge_for_verify
-        mock_bridge.is_mounted.return_value = (
+        mock_bridge.is_mounted.return_value = fuse_fs_mod.MountState(
             None, None, "handler did not report disk info",
         )
         mock_bridge.stat_path.return_value = None
@@ -2622,7 +2664,7 @@ class TestCmdVerify:
     def test_verify_unknown_mount_status_is_reported_for_file_json(
             self, mock_bridge_for_verify, capsys):
         mock_bridge, fuse_fs_mod = mock_bridge_for_verify
-        mock_bridge.is_mounted.return_value = (
+        mock_bridge.is_mounted.return_value = fuse_fs_mod.MountState(
             None, None, "handler did not report disk info",
         )
         mock_bridge.stat_path.return_value = {
@@ -2651,7 +2693,7 @@ class TestCmdVerify:
     def test_verify_unknown_mount_status_is_reported_for_volume_json(
             self, mock_bridge_for_verify, capsys):
         mock_bridge, fuse_fs_mod = mock_bridge_for_verify
-        mock_bridge.is_mounted.return_value = (
+        mock_bridge.is_mounted.return_value = fuse_fs_mod.MountState(
             None, None, "handler did not report disk info",
         )
         mock_bridge.list_dir_path.return_value = []
@@ -2677,7 +2719,7 @@ class TestCmdVerify:
     def test_verify_unknown_mount_status_is_reported_for_file_human(
             self, mock_bridge_for_verify, capsys):
         mock_bridge, fuse_fs_mod = mock_bridge_for_verify
-        mock_bridge.is_mounted.return_value = (
+        mock_bridge.is_mounted.return_value = fuse_fs_mod.MountState(
             None, None, "handler did not report disk info",
         )
         mock_bridge.stat_path.return_value = {

--- a/tests/unit/test_fuse_fs.py
+++ b/tests/unit/test_fuse_fs.py
@@ -1791,9 +1791,9 @@ class TestHandlerBridgeMountState:
     """Tests for HandlerBridge.is_mounted()."""
 
     @staticmethod
-    def _mount_state(fuse_fs_mod, info):
+    def _mount_state(fuse_fs_mod, info, res2=None):
         bridge = object.__new__(fuse_fs_mod.HandlerBridge)
-        bridge.get_disk_info = MagicMock(return_value=info)
+        bridge._query_disk_info = MagicMock(return_value=(info, res2))
         return bridge.is_mounted()
 
     def test_missing_disk_info_is_inconclusive(self, fuse_mock):
@@ -1873,6 +1873,66 @@ class TestHandlerBridgeMountState:
         assert mounted is True
         assert info is disk_info
         assert reason is None
+
+    @pytest.mark.parametrize(("res2", "expected_reason"), [
+        (225, "not a DOS disk"),  # ERROR_NOT_A_DOS_DISK
+        (226, "no disk present"),  # ERROR_NO_DISK
+        (218, "device not mounted"),  # ERROR_DEVICE_NOT_MOUNTED
+    ])
+    def test_refusal_with_diagnostic_error_is_not_mounted(
+            self, fuse_mock, res2, expected_reason):
+        """A DOSFALSE reply naming an unusable volume is a negative answer."""
+        import amifuse.fuse_fs as fuse_fs_mod
+
+        mounted, info, reason = self._mount_state(fuse_fs_mod, None, res2)
+
+        assert mounted is False
+        assert info is None
+        assert reason == expected_reason
+
+    def test_unimplemented_packet_is_inconclusive(self, fuse_mock):
+        """ERROR_ACTION_NOT_KNOWN says nothing about the volume."""
+        import amifuse.fuse_fs as fuse_fs_mod
+
+        mounted, info, reason = self._mount_state(fuse_fs_mod, None, 209)
+
+        assert mounted is None
+        assert info is None
+        assert "209" in reason
+
+    def test_refusal_with_unknown_error_is_inconclusive(self, fuse_mock):
+        """An undiagnostic refusal must not condemn a possibly healthy image."""
+        import amifuse.fuse_fs as fuse_fs_mod
+
+        mounted, info, reason = self._mount_state(fuse_fs_mod, None, 202)
+
+        assert mounted is None
+        assert info is None
+        assert "202" in reason
+
+    def test_silence_is_distinct_from_refusal(self, fuse_mock):
+        """No reply at all keeps the old inconclusive wording."""
+        import amifuse.fuse_fs as fuse_fs_mod
+
+        mounted, info, reason = self._mount_state(fuse_fs_mod, None, None)
+
+        assert mounted is None
+        assert info is None
+        assert reason == "handler did not report disk info"
+
+    def test_get_disk_info_returns_only_the_dict(self, fuse_mock):
+        """The public accessor keeps its Optional[Dict] contract."""
+        import amifuse.fuse_fs as fuse_fs_mod
+
+        bridge = object.__new__(fuse_fs_mod.HandlerBridge)
+        disk_info = {"disk_type": 0x444F5301, "volume_node": 1}
+        bridge._query_disk_info = MagicMock(return_value=(disk_info, None))
+
+        assert bridge.get_disk_info() is disk_info
+
+        bridge._query_disk_info = MagicMock(return_value=(None, 225))
+
+        assert bridge.get_disk_info() is None
 
 
 # ---------------------------------------------------------------------------
@@ -2096,6 +2156,58 @@ class TestCmdVerify:
         mock_bridge.stat_path.assert_not_called()
         mock_bridge.list_dir_path.assert_not_called()
         mock_bridge.volume_name.assert_not_called()
+
+    def test_verify_refused_disk_info_json(self, mock_bridge_for_verify, capsys):
+        """A refusal has no InfoData, so no id_DiskType may be reported."""
+        mock_bridge, fuse_fs_mod = mock_bridge_for_verify
+        mock_bridge.is_mounted.return_value = (False, None, "not a DOS disk")
+
+        args = argparse.Namespace(
+            image=Path("/fake/test.hdf"),
+            json=True,
+            file=None,
+            expect_size=None,
+            partition=None,
+            driver=None,
+            block_size=None,
+            debug=False,
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            fuse_fs_mod.cmd_verify(args)
+        output = capsys.readouterr().out
+        data = json.loads(output)
+
+        assert exc_info.value.code == 1
+        assert data["error"]["code"] == "NOT_MOUNTED"
+        assert "not a DOS disk" in data["error"]["message"]
+        # No InfoData was returned, so there is nothing to report in details
+        assert "details" not in data["error"]
+        mock_bridge.stat_path.assert_not_called()
+        mock_bridge.list_dir_path.assert_not_called()
+
+    def test_verify_refused_disk_info_human(self, mock_bridge_for_verify, capsys):
+        mock_bridge, fuse_fs_mod = mock_bridge_for_verify
+        mock_bridge.is_mounted.return_value = (False, None, "no disk present")
+
+        args = argparse.Namespace(
+            image=Path("/fake/test.hdf"),
+            json=False,
+            file=None,
+            expect_size=None,
+            partition=None,
+            driver=None,
+            block_size=None,
+            debug=False,
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            fuse_fs_mod.cmd_verify(args)
+        output = capsys.readouterr().out
+
+        assert exc_info.value.code == 1
+        assert "Volume: (none)" in output
+        assert "Filesystem responsive: NO" in output
+        assert "no disk present" in output
+        assert "id_DiskType" not in output
 
     def test_verify_unmounted_file_json(self, mock_bridge_for_verify, capsys):
         mock_bridge, fuse_fs_mod = mock_bridge_for_verify

--- a/tests/unit/test_fuse_fs.py
+++ b/tests/unit/test_fuse_fs.py
@@ -30,6 +30,26 @@ except ImportError:  # pragma: no cover - amitools submodule not checked out
     _RealInfoData = None
 
 
+def _make_mock_bridge():
+    """Build the bridge mock the cmd_* fixtures hand to their subcommand.
+
+    A bare MagicMock is a trap for any bridge method whose result the caller
+    unpacks. `mounted, dinfo, reason = bridge.is_mounted()` gets a MagicMock,
+    which iterates as empty and raises ValueError; the subcommand's blanket
+    `except Exception` turns that into a HANDLER_ERROR envelope and exits 1,
+    so the test dies with SystemExit nowhere near the real cause. Stubbing it
+    here means wiring is_mounted() into another subcommand cannot silently
+    break that subcommand's whole test class.
+
+    The default is a healthy, mounted PFS volume; tests that care override it.
+    """
+    bridge = MagicMock()
+    bridge.is_mounted.return_value = (
+        True, {"disk_type": 0x50465303, "volume_node": 1}, None,
+    )
+    return bridge
+
+
 # ---------------------------------------------------------------------------
 # A. TestMountFuseOptions -- subtype guard tests
 # ---------------------------------------------------------------------------
@@ -1622,10 +1642,7 @@ class TestCmdLs:
         """Set up mocked bridge for ls tests."""
         import amifuse.fuse_fs as fuse_fs_mod
 
-        mock_bridge = MagicMock()
-        mock_bridge.is_mounted.return_value = (
-            True, {"disk_type": 0x50465303, "volume_node": 1}, None,
-        )
+        mock_bridge = _make_mock_bridge()
         monkeypatch.setattr(
             fuse_fs_mod, "_create_bridge_from_args",
             lambda args, cmd, read_only=True: (mock_bridge, None),
@@ -2237,10 +2254,7 @@ class TestCmdVerify:
         """Set up mocked bridge for verify tests."""
         import amifuse.fuse_fs as fuse_fs_mod
 
-        mock_bridge = MagicMock()
-        mock_bridge.is_mounted.return_value = (
-            True, {"disk_type": 0x50465303, "volume_node": 1}, None,
-        )
+        mock_bridge = _make_mock_bridge()
         monkeypatch.setattr(
             fuse_fs_mod, "_create_bridge_from_args",
             lambda args, cmd, read_only=True: (mock_bridge, None),
@@ -2811,7 +2825,7 @@ class TestCmdHash:
         """Set up mocked bridge for hash tests."""
         import amifuse.fuse_fs as fuse_fs_mod
 
-        mock_bridge = MagicMock()
+        mock_bridge = _make_mock_bridge()
         monkeypatch.setattr(
             fuse_fs_mod, "_create_bridge_from_args",
             lambda args, cmd, read_only=True: (mock_bridge, None),
@@ -3474,7 +3488,7 @@ class TestCmdRead:
         """Set up mocked bridge for read tests."""
         import amifuse.fuse_fs as fuse_fs_mod
 
-        mock_bridge = MagicMock()
+        mock_bridge = _make_mock_bridge()
         monkeypatch.setattr(
             fuse_fs_mod, "_create_bridge_from_args",
             lambda args, cmd, read_only=True: (mock_bridge, None),
@@ -3890,7 +3904,7 @@ class TestCmdWrite:
         """Set up mocked bridge for write tests."""
         import amifuse.fuse_fs as fuse_fs_mod
 
-        mock_bridge = MagicMock()
+        mock_bridge = _make_mock_bridge()
         monkeypatch.setattr(
             fuse_fs_mod, "_create_bridge_from_args",
             lambda args, cmd, read_only=True: (mock_bridge, None),
@@ -3986,7 +4000,7 @@ class TestCmdWrite:
         import amifuse.fuse_fs as fuse_fs_mod
 
         captured = {}
-        mock_bridge = MagicMock()
+        mock_bridge = _make_mock_bridge()
         mock_bridge.open_file.return_value = (0x1000, 0x2000)
         mock_bridge.write_handle.return_value = 5
         mock_bridge.close_file.return_value = None
@@ -4225,7 +4239,7 @@ class TestCmdWrite:
                                              tmp_path):
         import amifuse.fuse_fs as fuse_fs_mod
 
-        mock_bridge = MagicMock()
+        mock_bridge = _make_mock_bridge()
         mock_bridge.open_file.return_value = (0x1000, 0x2000)
         mock_bridge.write_handle.return_value = 5
         mock_bridge.close_file.return_value = None
@@ -4315,7 +4329,7 @@ class TestCmdWrite:
         import amifuse.fuse_fs as fuse_fs_mod
 
         written_data = bytearray()
-        mock_bridge = MagicMock()
+        mock_bridge = _make_mock_bridge()
         mock_bridge.open_file.return_value = (0x1000, 0x2000)
         mock_bridge.close_file.return_value = None
         mock_bridge.flush_volume.return_value = None

--- a/tests/unit/test_fuse_fs.py
+++ b/tests/unit/test_fuse_fs.py
@@ -18,6 +18,17 @@ from unittest.mock import MagicMock
 
 import pytest
 
+# The fuse_mock fixture stubs amitools.vamos with dummies, so the real
+# MockMemory and InfoDataStruct have to be captured at import time, before
+# any fixture patches sys.modules. TestQueryDiskInfo needs the genuine
+# struct to pin the InfoData field offsets.
+try:
+    from amitools.vamos.machine.mock.mem import MockMemory as _RealMockMemory
+    from amitools.vamos.libstructs.dos import InfoDataStruct as _RealInfoData
+except ImportError:  # pragma: no cover - amitools submodule not checked out
+    _RealMockMemory = None
+    _RealInfoData = None
+
 
 # ---------------------------------------------------------------------------
 # A. TestMountFuseOptions -- subtype guard tests
@@ -1783,6 +1794,164 @@ class TestCmdLs:
 
 
 # ---------------------------------------------------------------------------
+# TestQueryDiskInfo -- ACTION_DISK_INFO memory reads
+# ---------------------------------------------------------------------------
+
+
+class TestQueryDiskInfo:
+    """Drive _query_disk_info() through real InfoData memory.
+
+    The is_mounted() tests below stub _query_disk_info, so they exercise the
+    decision table but never the part that can silently be wrong: which
+    InfoData offset each field is read from, and which slot of the reply
+    tuple carries res1 and res2. Offset and BPTR/APTR confusion in direct
+    memory reads is exactly what the repo's gotchas call out as hardest to
+    debug after the fact, so these tests plant known values through the real
+    InfoDataStruct field names and assert they come back out.
+    """
+
+    INFO_ADDR = 0x1000
+
+    # Fields the handler is expected to fill in, plus decoys in the
+    # neighbouring slots. The decoys are the point: reading id_DiskState (8)
+    # or id_InUse (32) instead of id_DiskType (24) or id_VolumeNode (28)
+    # must not go unnoticed.
+    PLANTED = {
+        "id_NumSoftErrors": 7,
+        "id_UnitNumber": 3,
+        "id_DiskState": 81,  # ID_VALIDATING -- decoy for disk_type
+        "id_NumBlocks": 12288,
+        "id_NumBlocksUsed": 4096,
+        "id_BytesPerBlock": 512,
+        "id_DiskType": 0x444F5303,  # 'DOS\3'
+        "id_VolumeNode": 0xABCD00,
+        "id_InUse": 1,  # decoy for volume_node
+    }
+
+    def _query(self, fuse_fs_mod, monkeypatch, replies, fields=None):
+        """Run _query_disk_info() against a bridge backed by MockMemory."""
+        import threading
+
+        if _RealMockMemory is None:
+            pytest.skip("amitools submodule not available")
+        MockMemory = _RealMockMemory
+        InfoDataStruct = _RealInfoData
+        # fuse_mock bound a dummy InfoDataStruct into the module; the real
+        # one is the whole point of these tests.
+        monkeypatch.setattr(fuse_fs_mod, "InfoDataStruct", InfoDataStruct)
+
+        mem = MockMemory(size_kib=64)
+        bridge = object.__new__(fuse_fs_mod.HandlerBridge)
+        bridge._lock = threading.RLock()
+        bridge.mem = mem
+        bridge.state = MagicMock()
+        bridge.launcher = MagicMock()
+        bridge.vh = MagicMock()
+        info_mem = SimpleNamespace(addr=self.INFO_ADDR)
+        bridge.vh.alloc.alloc_memory.return_value = info_mem
+
+        def fake_run_until_replies():
+            # The real handler fills InfoData in place before replying, so
+            # plant the fields here -- the buffer is zeroed before the send.
+            if fields:
+                info = InfoDataStruct(mem, self.INFO_ADDR)
+                for name, value in fields.items():
+                    # Write through the field's own address rather than .val:
+                    # id_VolumeNode is a BPTR whose typed setter rejects a
+                    # raw int. The address still comes from the real struct,
+                    # so a production offset mistake still fails the test.
+                    mem.w32(getattr(info, name).addr, value)
+            return replies
+
+        bridge._run_until_replies = fake_run_until_replies
+        result = bridge._query_disk_info()
+        return result, bridge, info_mem
+
+    def test_success_reads_every_field_from_its_own_offset(self, fuse_mock, monkeypatch):
+        import amifuse.fuse_fs as fuse_fs_mod
+
+        # (msg, pkt_addr, res1, res2) -- res1 nonzero means DOSTRUE
+        replies = [(0, 0x9999, 1, 0)]
+        (info, res2), bridge, info_mem = self._query(
+            fuse_fs_mod, monkeypatch, replies, self.PLANTED)
+
+        assert res2 is None
+        assert info == {
+            "num_blocks": 12288,
+            "num_blocks_used": 4096,
+            "bytes_per_block": 512,
+            "disk_type": 0x444F5303,
+            "volume_node": 0xABCD00,
+        }
+        # The decoy values must not have leaked into any returned field
+        assert 81 not in info.values()
+        assert 7 not in info.values()
+        bridge.vh.alloc.free_memory.assert_called_once_with(info_mem)
+
+    def test_dosfalse_reply_yields_res2_not_the_packet_address(self, fuse_mock, monkeypatch):
+        """res2 is slot 3 of the reply; slot 1 is the packet address."""
+        import amifuse.fuse_fs as fuse_fs_mod
+
+        replies = [(0, 0x9999, 0, 225)]
+        (info, res2), bridge, info_mem = self._query(
+            fuse_fs_mod, monkeypatch, replies, self.PLANTED)
+
+        # res1 == 0 means the buffer is not trustworthy even though this
+        # test planted values in it
+        assert info is None
+        assert res2 == 225
+        assert res2 != 0x9999
+        bridge.vh.alloc.free_memory.assert_called_once_with(info_mem)
+
+    def test_no_reply_is_silence_not_refusal(self, fuse_mock, monkeypatch):
+        import amifuse.fuse_fs as fuse_fs_mod
+
+        (info, res2), bridge, info_mem = self._query(fuse_fs_mod, monkeypatch, [])
+
+        assert info is None
+        assert res2 is None
+        bridge.vh.alloc.free_memory.assert_called_once_with(info_mem)
+
+    def test_zeroed_buffer_when_handler_fills_nothing(self, fuse_mock, monkeypatch):
+        """A handler that replies DOSTRUE but fills nothing reads back zeros."""
+        import amifuse.fuse_fs as fuse_fs_mod
+
+        (info, res2), _, _ = self._query(fuse_fs_mod, monkeypatch, [(0, 0x9999, 1, 0)])
+
+        assert res2 is None
+        assert info == {
+            "num_blocks": 0,
+            "num_blocks_used": 0,
+            "bytes_per_block": 0,
+            "disk_type": 0,
+            "volume_node": 0,
+        }
+
+    def test_end_to_end_refusal_is_not_mounted(self, fuse_mock, monkeypatch):
+        """The offsets and the decision table agree on a real refusal."""
+        import amifuse.fuse_fs as fuse_fs_mod
+
+        mem_bridge = self._query(fuse_fs_mod, monkeypatch, [(0, 0x9999, 0, 225)])[1]
+        mounted, info, reason = mem_bridge.is_mounted()
+
+        assert mounted is False
+        assert info is None
+        assert reason == "not a DOS disk"
+
+    def test_end_to_end_ndos_disk_type_is_not_mounted(self, fuse_mock, monkeypatch):
+        """An NDOS id_DiskType read from offset 24 drives the same verdict."""
+        import amifuse.fuse_fs as fuse_fs_mod
+
+        fields = dict(self.PLANTED, id_DiskType=0x4E444F53)
+        mem_bridge = self._query(fuse_fs_mod, monkeypatch, [(0, 0x9999, 1, 0)], fields)[1]
+        mounted, info, reason = mem_bridge.is_mounted()
+
+        assert mounted is False
+        assert info["disk_type"] == 0x4E444F53
+        assert reason == "not a DOS disk"
+
+
+# ---------------------------------------------------------------------------
 # TestHandlerBridgeMountState -- mounted-volume checks
 # ---------------------------------------------------------------------------
 
@@ -2234,6 +2403,87 @@ class TestCmdVerify:
         assert exc_info.value.code == 1
         assert data["error"]["code"] == "NOT_MOUNTED"
         mock_bridge.stat_path.assert_not_called()
+
+    def test_verify_unmounted_file_human_names_the_file(
+            self, mock_bridge_for_verify, capsys):
+        """The diagnosis must stay attached to the file the user asked about."""
+        mock_bridge, fuse_fs_mod = mock_bridge_for_verify
+        mock_bridge.is_mounted.return_value = (
+            False, {"disk_type": 0x4E444F53, "volume_node": 0},
+            "not a DOS disk",
+        )
+
+        args = argparse.Namespace(
+            image=Path("/fake/test.hdf"),
+            json=False,
+            file="S/Startup-Sequence",
+            expect_size=None,
+            partition=None,
+            driver=None,
+            block_size=None,
+            debug=False,
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            fuse_fs_mod.cmd_verify(args)
+        output = capsys.readouterr().out
+
+        assert exc_info.value.code == 1
+        assert "File: S/Startup-Sequence" in output
+        assert "Volume: (none)" not in output
+        assert "Filesystem responsive: NO -- not a DOS disk" in output
+
+    def test_verify_file_not_found_carries_unknown_mount_state(
+            self, mock_bridge_for_verify, capsys):
+        """FILE_NOT_FOUND must not look identical on a healthy volume."""
+        mock_bridge, fuse_fs_mod = mock_bridge_for_verify
+        mock_bridge.is_mounted.return_value = (
+            None, None, "handler did not report disk info",
+        )
+        mock_bridge.stat_path.return_value = None
+
+        args = argparse.Namespace(
+            image=Path("/fake/test.hdf"),
+            json=True,
+            file="S/Startup-Sequence",
+            expect_size=None,
+            partition=None,
+            driver=None,
+            block_size=None,
+            debug=False,
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            fuse_fs_mod.cmd_verify(args)
+        data = json.loads(capsys.readouterr().out)
+
+        assert exc_info.value.code == 1
+        assert data["error"]["code"] == "FILE_NOT_FOUND"
+        assert data["error"]["details"]["filesystem_responsive"] is None
+        assert data["error"]["details"]["mount_state_reason"] == (
+            "handler did not report disk info")
+
+    def test_verify_file_not_found_on_healthy_volume_is_distinguishable(
+            self, mock_bridge_for_verify, capsys):
+        """The confirmed-mounted case reports true, not null."""
+        mock_bridge, fuse_fs_mod = mock_bridge_for_verify
+        mock_bridge.stat_path.return_value = None
+
+        args = argparse.Namespace(
+            image=Path("/fake/test.hdf"),
+            json=True,
+            file="S/Startup-Sequence",
+            expect_size=None,
+            partition=None,
+            driver=None,
+            block_size=None,
+            debug=False,
+        )
+        with pytest.raises(SystemExit):
+            fuse_fs_mod.cmd_verify(args)
+        data = json.loads(capsys.readouterr().out)
+
+        assert data["error"]["code"] == "FILE_NOT_FOUND"
+        assert data["error"]["details"]["filesystem_responsive"] is True
+        assert "mount_state_reason" not in data["error"]["details"]
 
     def test_verify_unknown_mount_status_is_reported_for_file_json(
             self, mock_bridge_for_verify, capsys):

--- a/tests/unit/test_fuse_fs.py
+++ b/tests/unit/test_fuse_fs.py
@@ -1623,11 +1623,131 @@ class TestCmdLs:
         import amifuse.fuse_fs as fuse_fs_mod
 
         mock_bridge = MagicMock()
+        mock_bridge.is_mounted.return_value = (
+            True, {"disk_type": 0x50465303, "volume_node": 1}, None,
+        )
         monkeypatch.setattr(
             fuse_fs_mod, "_create_bridge_from_args",
             lambda args, cmd, read_only=True: (mock_bridge, None),
         )
         return mock_bridge, fuse_fs_mod
+
+    @staticmethod
+    def _ls_args(**overrides):
+        base = dict(
+            image=Path("/fake/test.hdf"),
+            json=True,
+            path="/",
+            recursive=False,
+            partition=None,
+            driver=None,
+            block_size=None,
+            debug=False,
+        )
+        base.update(overrides)
+        return argparse.Namespace(**base)
+
+    def test_ls_unmounted_root_json(self, mock_bridge_for_ls, capsys):
+        """The default `amifuse ls image.hdf` must not report an empty volume."""
+        mock_bridge, fuse_fs_mod = mock_bridge_for_ls
+        mock_bridge.is_mounted.return_value = (
+            False, {"disk_type": 0x4E444F53, "volume_node": 0},
+            "not a DOS disk",
+        )
+        mock_bridge.list_dir_path.return_value = []
+
+        with pytest.raises(SystemExit) as exc_info:
+            fuse_fs_mod.cmd_ls(self._ls_args())
+        data = json.loads(capsys.readouterr().out)
+
+        assert exc_info.value.code == 1
+        assert data["status"] == "error"
+        assert data["error"]["code"] == "NOT_MOUNTED"
+        assert "not a DOS disk" in data["error"]["message"]
+        assert data["error"]["details"]["disk_type"] == 0x4E444F53
+        mock_bridge.list_dir_path.assert_not_called()
+
+    def test_ls_unmounted_recursive_json(self, mock_bridge_for_ls, capsys):
+        """-R bypassed the stat fallback entirely, so it needs the guard too."""
+        mock_bridge, fuse_fs_mod = mock_bridge_for_ls
+        mock_bridge.is_mounted.return_value = (
+            False, {"disk_type": 0x4E444F53, "volume_node": 0},
+            "not a DOS disk",
+        )
+
+        with pytest.raises(SystemExit) as exc_info:
+            fuse_fs_mod.cmd_ls(self._ls_args(recursive=True))
+        data = json.loads(capsys.readouterr().out)
+
+        assert exc_info.value.code == 1
+        assert data["error"]["code"] == "NOT_MOUNTED"
+
+    def test_ls_unmounted_human_exits_nonzero(self, mock_bridge_for_ls, capsys):
+        mock_bridge, fuse_fs_mod = mock_bridge_for_ls
+        mock_bridge.is_mounted.return_value = (
+            False, None, "no disk present",
+        )
+
+        with pytest.raises(SystemExit) as exc_info:
+            fuse_fs_mod.cmd_ls(self._ls_args(json=False))
+
+        # SystemExit carries the message; a bare listing printed nothing before
+        assert "no usable volume mounted" in str(exc_info.value.code)
+        assert "no disk present" in str(exc_info.value.code)
+
+    def test_ls_refused_disk_info_omits_disk_type(self, mock_bridge_for_ls, capsys):
+        mock_bridge, fuse_fs_mod = mock_bridge_for_ls
+        mock_bridge.is_mounted.return_value = (False, None, "not a DOS disk")
+
+        with pytest.raises(SystemExit):
+            fuse_fs_mod.cmd_ls(self._ls_args())
+        data = json.loads(capsys.readouterr().out)
+
+        assert data["error"]["code"] == "NOT_MOUNTED"
+        assert "details" not in data["error"]
+
+    def test_ls_unknown_mount_state_json(self, mock_bridge_for_ls, capsys):
+        """An inconclusive mount is reported, but still lists and exits 0."""
+        mock_bridge, fuse_fs_mod = mock_bridge_for_ls
+        mock_bridge.is_mounted.return_value = (
+            None, None, "handler did not report disk info",
+        )
+        mock_bridge.list_dir_path.return_value = []
+
+        fuse_fs_mod.cmd_ls(self._ls_args())
+        data = json.loads(capsys.readouterr().out)
+
+        assert data["status"] == "ok"
+        assert data["entries"] == []
+        assert data["filesystem_responsive"] is None
+
+    def test_ls_unknown_mount_state_warns_on_empty_human(
+            self, mock_bridge_for_ls, capsys):
+        mock_bridge, fuse_fs_mod = mock_bridge_for_ls
+        mock_bridge.is_mounted.return_value = (
+            None, None, "handler did not report disk info",
+        )
+        mock_bridge.list_dir_path.return_value = []
+
+        fuse_fs_mod.cmd_ls(self._ls_args(json=False))
+        captured = capsys.readouterr()
+
+        assert captured.out == ""
+        assert "mount state unknown" in captured.err
+        assert "handler did not report disk info" in captured.err
+
+    def test_ls_healthy_volume_reports_responsive(self, mock_bridge_for_ls, capsys):
+        mock_bridge, fuse_fs_mod = mock_bridge_for_ls
+        mock_bridge.list_dir_path.return_value = [
+            {"name": "file1.txt", "dir_type": 0, "size": 100, "protection": 0},
+        ]
+
+        fuse_fs_mod.cmd_ls(self._ls_args())
+        data = json.loads(capsys.readouterr().out)
+
+        assert data["status"] == "ok"
+        assert data["filesystem_responsive"] is True
+        assert len(data["entries"]) == 1
 
     def test_ls_json_output_structure(self, mock_bridge_for_ls, capsys):
         mock_bridge, fuse_fs_mod = mock_bridge_for_ls


### PR DESCRIPTION
`cmd_verify` reported "Filesystem responsive: yes" for any image whose
handler process started, even when the handler had rejected the disk
(NDOS / unreadable / foreign or corrupt rootblock). A recursive listing of
an unmounted volume is simply empty, and `volume_name()` falls back to the
RDB drive name, so nothing in the old path noticed the missing mount --
`amifuse verify` on a zeroed rootblock still printed a healthy report.

Query ACTION_DISK_INFO before either verification path runs, and decide
from what the handler actually reports.

## Three states, not two

A missing answer is not a negative answer, so the check distinguishes them:

- **Mounted** -- `id_DiskType` is non-zero and is not a known unusable
  sentinel. `id_VolumeNode` confirms a mount when the type is zero.
- **Not mounted** -- `id_DiskType` is `ID_NO_DISK_PRESENT`,
  `ID_UNREADABLE_DISK`, `ID_NOT_REALLY_DOS`, `ID_BUSY` or
  `ID_KICKSTART_DISK`; or the handler refused the packet with a res2 code
  that names an unusable volume (`ERROR_NOT_A_DOS_DISK`, `ERROR_NO_DISK`,
  `ERROR_DEVICE_NOT_MOUNTED`).
- **Unknown** -- the handler did not answer, answered with neither a disk
  type nor a volume node, or refused with an undiagnostic code. This still
  exits 0, but says so rather than claiming the volume is fine.

Three choices here are deliberate. `id_DiskType` is authoritative on its
own rather than ANDed with `id_VolumeNode`, since AmiFUSE runs handlers
against a synthetic DeviceNode and whether a handler populates the volume
node is handler-specific. `ID_MSDOS_DISK` counts as mounted, because
CrossDOS reports it for a volume it has successfully mounted. And only res2
codes that positively identify an unusable volume flip the state to
negative -- `ERROR_ACTION_NOT_KNOWN` and any unrecognised refusal stay
inconclusive, so a handler whose behaviour has not been verified cannot
condemn a healthy image.

## `ls` behaviour change

`amifuse ls` on a rejected disk also reported success. The `stat_path`
fallback that would have caught it is guarded by `path != "/"`, and
`--path` defaults to `/`, so the default invocation skipped it;
`--recursive` bypassed it entirely. Both returned an empty listing and
exit 0, indistinguishable from a genuinely empty volume.

`ls` now applies the same check, above the recursive split so it covers
both paths. **This is a user-visible contract change**: `ls` can now exit 1
and emit a `NOT_MOUNTED` error where it previously exited 0.

## JSON contract

- New error code `NOT_MOUNTED` for both `verify` and `ls`.
- Success envelopes carry `filesystem_responsive` (`true`, or `null` when
  the mount state could not be determined).
- `FILE_NOT_FOUND` envelopes carry `filesystem_responsive` and, when
  unknown, `mount_state_reason` -- on an unmountable volume no path
  resolves, so these were otherwise byte-identical to a genuinely missing
  file on a healthy volume.
- `NOT_MOUNTED` details carry `disk_type` and `volume_node`, or `dos_error`
  when the handler refused the packet and there is no InfoData to report.

## API

`get_disk_info()` keeps its contract: `Optional[Dict]` with `num_blocks`,
`num_blocks_used`, `bytes_per_block`, `disk_type` and `volume_node`. The
new `_query_disk_info()` returns `(info, res2)` so callers can tell silence
apart from an explicit DOSFALSE refusal, which `get_disk_info()` alone
collapses into `None`. `is_mounted()` returns a `MountState` NamedTuple.

## Testing

Verified against real handler binaries and known-good images, covering
every handler the project ships: PFS3, SFS, FFS, OFS, CDFileSystem and
BFFS. Each reports a valid dostype on the very first packet after startup,
unchanged after a root listing, so placing the check before any volume
access does not misjudge a handler that mounts lazily. `verify`, `ls` and
`ls --recursive` all exit 0 on every known-good image. A zeroed rootblock
and an out-of-range reserved_blksize are both reported as not mounted
(`id_DiskType=0x4e444f53` NDOS) with exit 1.

Unit tests drive `_query_disk_info` through `MockMemory`, planting values
via the real `InfoDataStruct` field names with decoys in the neighbouring
slots, so a wrong InfoData offset or a res1/res2 mix-up fails the suite
rather than passing silently.
